### PR TITLE
Support multiple Python 3 versions on amd64 Linux

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2018-09-30 v0.3.0-alpha
 
-  Austin now supports Python 3.4, 3.5 on x86_64 Linux.
+  Austin now supports Python 3.4, 3.5 and 3.7 on x86_64 Linux.
 
 
 2018-09-26 v0.2.0-alpha

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2018-09-30 v0.3.0-alpha
 
-  Austin now supports Python 3.4, 3.5 and 3.7 on x86_64 Linux.
+  Austin now supports Python 3.3, 3.4, 3.5 and 3.7 on x86_64 Linux.
 
 
 2018-09-26 v0.2.0-alpha

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-09-30 v0.3.0-alpha
+
+  Austin now supports Python 3.4, 3.5 on x86_64 Linux.
+
+
 2018-09-26 v0.2.0-alpha
 
   Austin can now be attached to a running Python 3 process.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Linux-based operating systems that has not been compiled wit the
 `--enable-shared` flag. There is a plan to first support more Python versions,
 then the 32-bit architecture and finally more operating systems.
 
+> **NOTE** The TUI is still work in progress. Its main purpose is to provide
+> an example of how to use the output produce by Austin rather than an
+> additional application to maintain.
+
 
 # Installation
 
@@ -93,12 +97,14 @@ Austin has been tested on the following systems
 - Python 3.4 (3.4.9+) on Ubuntu 18.04.1 x86-64
 - Python 3.5 (3.5.2) on Ubuntu 16.04.5 x86-64
 - Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04.1 x86-64
+- Python 3.7 (3.7.0) on Ubuntu 18.04.1 x86-64
 
 ## Windows
 
 - Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04 x86-64 via WSL
 
-> **NOTE** Austin *might* work with other versions of Python 3.
+> **NOTE** Austin *might* work with other versions of Python 3 on both Linux
+> and Windows
 
 # How does it work?
 
@@ -144,6 +150,11 @@ before, bearing in mind that, in principle, the `tstate_head` of
 
 At this point we are ready to navigate all the threads and traverse their frame
 stacks at regular interval of times to sample them.
+
+Starting with Python 3.7, the symbol `_PyRuntime` is exposed in the `.dynsym`
+section. This is a pointer to an internal structure of type `_PyRuntimeState`.
+The sub-field `interpreters.head` points to the head `PyInterpreterState`
+instance that can then be de-referenced directly.
 
 ## Concurrency
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/P403n1x87/austin.svg?branch=master)](https://travis-ci.org/P403n1x87/austin)
-
 ![austin](art/austin.png)
+
+[![Build Status](https://travis-ci.org/P403n1x87/austin.svg?branch=master)](https://travis-ci.org/P403n1x87/austin) ![Version](https://img.shields.io/badge/version-0.3.0--alpha-blue.svg)
 
 Meet Austin, a Python frame stack sampler for CPython.
 
@@ -77,15 +77,25 @@ some further processing.
 Each line has the structure
 
 ~~~
-Thread [tid];[func] ([mod]);#[line no];[func] ...;#[line no] [usec]
+Thread [tid];[func] ([mod]);#[line no];[func] ...;L[line no] [usec]
 ~~~
 
 The reason why the line number is not included in the `([mod])` part, as done
 by py-spy, is that, this way, the flame graph will show the total time spent at
-each function, plus the finer detail of the time spent on each line.
+each function, plus the finer detail of the time spent on each line. A drawback
+of this format is that frame stacks double in height. If you prefer something
+more conventional, you can use the `-a` option to switch to the alternative
+format
+
+~~~
+Thread [tid];[func] ([mod]:[line no]);#[line no];[func] ... ([mod]:[line no]) [usec]
+~~~
 
 Austin uses syslog for log messages so make sure you watch `/var/log/syslog` for
-the `austin` tag to get some execution details and statistics.
+the `austin` tag to get execution details and statistics. _Bad_ frames are
+output together with the other frames. In general, entries for bad frames will
+not be visible in a flame graph as all tests show error rates below 1% on
+average.
 
 
 # Compatibility
@@ -94,6 +104,7 @@ Austin has been tested on the following systems
 
 ## Linux
 
+- Python 3.3 (3.3.7) on Ubuntu 18.04.1 x86-64
 - Python 3.4 (3.4.9+) on Ubuntu 18.04.1 x86-64
 - Python 3.5 (3.5.2) on Ubuntu 16.04.5 x86-64
 - Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04.1 x86-64
@@ -109,15 +120,15 @@ Austin has been tested on the following systems
 # How does it work?
 
 To understand how Python works internally in terms of keeping track of all the
-function calls, you can have a look at the related project
-[py-spy](https://github.com/benfred/py-spy) and references therein (in
-particular the [pyflame](https://github.com/uber/pyflame) project).
+function calls, you can have a look at similar projects like
+[py-spy](https://github.com/benfred/py-spy) and follow the references therein
+(in particular the [pyflame](https://github.com/uber/pyflame) project).
 
 The approach taken by Austin is similar to py-spy in the sense that it too
 peeks at the process memory while it is running, instead of pausing it with
 `ptrace`.
 
-Austin will fork itself and execute the program given at the command line. It
+Austin forks itself and executes the program specified at the command line. It
 waits until python has mapped its memory and uses the information contained in
 `/proc/[pid]/maps` to retrieve the location of the binary. It then looks at its
 header in memory to find the location and size of the section header table and
@@ -208,7 +219,7 @@ where the sample `test.py` script has the following content
 ~~~ python
 import psutil
 
-for i in range(1_000):
+for i in range(1000):
   list(psutil.process_iter())
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -90,12 +90,15 @@ Austin has been tested on the following systems
 
 ## Linux
 
-- Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04 x86-64
+- Python 3.4 (3.4.9+) on Ubuntu 18.04.1 x86-64
+- Python 3.5 (3.5.2) on Ubuntu 16.04.5 x86-64
+- Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04.1 x86-64
 
 ## Windows
 
 - Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04 x86-64 via WSL
 
+> **NOTE** Austin *might* work with other versions of Python 3.
 
 # How does it work?
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([austin], [0.2.0-alpha], [https://github.com/p403n1x87/austin/issues])
+AC_INIT([austin], [0.3.0-alpha], [https://github.com/p403n1x87/austin/issues])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,7 @@ austin_SOURCES = \
   error.c        \
   logging.c      \
   mem.c          \
+  version.c      \
   stats.c        \
   py_code.c      \
   py_frame.c     \

--- a/src/austin.c
+++ b/src/austin.c
@@ -31,6 +31,7 @@
 #include "error.h"
 #include "logging.h"
 #include "mem.h"
+#include "python.h"
 #include "stats.h"
 
 #include "py_frame.h"
@@ -40,7 +41,7 @@
 
 #define DEFAULT_SAMPLING_INTERVAL    100
 
-const char SAMPLE_FORMAT_NORMAL[]      = ";%s (%s);line %d";
+const char SAMPLE_FORMAT_NORMAL[]      = ";%s (%s);L%d";
 const char SAMPLE_FORMAT_ALTERNATIVE[] = ";%s (%s:%d)";
 
 static ctime_t t_sample;  // Checkmark for sampling duration calculation

--- a/src/austin.h
+++ b/src/austin.h
@@ -25,7 +25,7 @@
 
 
 #define PROGRAM_NAME                    "austin"
-#define VERSION                         "0.2.0-alpha"
+#define VERSION                         "0.3.0-alpha"
 
 
 #endif

--- a/src/mem.h
+++ b/src/mem.h
@@ -38,6 +38,15 @@
 
 
 /**
+ * Copy a data structure from the given remote address structure.
+ * @param  raddr the remote address
+ * @param  dt    the data structure as a local variable
+ * @return       the number of bytes read.
+ */
+#define copy_from_raddr_v(raddr, dt, n) copy_memory(raddr->pid, raddr->addr, n, &dt) != n
+
+
+/**
  * Same as copy_from_raddr, but with explicit arguments instead of a pointer to
  * a remote address structure
  * @param  pid  the process ID

--- a/src/py_frame.c
+++ b/src/py_frame.c
@@ -23,7 +23,7 @@
 #include "error.h"
 #include "logging.h"
 #include "py_frame.h"
-#include "python36.h"
+#include "python.h"
 
 
 // ---- PUBLIC ----------------------------------------------------------------

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -36,6 +36,7 @@
 #include "error.h"
 #include "logging.h"
 #include "mem.h"
+#include "version.h"
 
 #include "py_proc.h"
 #include "py_thread.h"
@@ -50,6 +51,7 @@
 #define DYNSYM_MAP               (1 << 1)
 #define RODATA_MAP               (1 << 2)
 #define HEAP_MAP                 (1 << 3)
+#define BSS_MAP                  (1 << 4)
 
 
 #define _py_proc__get_elf_type(self, offset, dt) (py_proc__memcpy(self, self->map.elf.base + offset, sizeof(dt), &dt))
@@ -78,8 +80,9 @@ _py_proc__parse_maps_file(py_proc_t * self) {
   FILE    * fp        = NULL;
   char    * line      = NULL;
   size_t    len       = 0;
+  int       maps_flag = 0;
 
-  if (self->bin_path != NULL)
+  if (self->maps_loaded)
     return 0;
 
   sprintf(file_name, "/proc/%d/maps", self->pid);
@@ -93,47 +96,60 @@ _py_proc__parse_maps_file(py_proc_t * self) {
     error = EPROCVM;
 
   else {
-    int maps_flag = 0;
     ssize_t a, b;  // VM map bounds
     char * needle;
-    while (maps_flag != (BIN_MAP | HEAP_MAP) && getline(&line, &len, fp) != -1) {
-      if ((maps_flag & BIN_MAP) == 0) {
-        needle = strstr(line, "python");
-        if (needle != NULL) {
-          // Store binary file name
-          // TODO: Extend to deal with libpython.so
-          while (*((char *) --needle) != ' ');
-          int len = strlen(++needle);
-          if (self->bin_path != NULL)
-            free(self->bin_path);
-          self->bin_path = (char *) malloc(sizeof(char) * len);
-          if (self->bin_path == NULL)
-            error = EPROCVM;
-          else {
-            strcpy(self->bin_path, needle);
-            if (self->bin_path[len-1] == '\n')
-              self->bin_path[len-1] = 0;
+    while (maps_flag != (HEAP_MAP | BSS_MAP) && getline(&line, &len, fp) != -1) {
+      if (self->bin_path == NULL) {
+        // Store binary file name
+        // TODO: Extend to deal with libpython.so
+        if ((needle = strstr(line, "python")) == NULL)
+          break;
 
-            get_bounds(line, a, b);
-            self->map.elf.base = (void *) a;
-            self->map.elf.size = b - a;
+        while (*((char *) --needle) != ' ');
+        int len = strlen(++needle);
+        if (self->bin_path != NULL)
+          free(self->bin_path);
+        self->bin_path = (char *) malloc(sizeof(char) * len);
+        if (self->bin_path == NULL)
+          error = EPROCVM;
+        else {
+          strcpy(self->bin_path, needle);
+          if (self->bin_path[len-1] == '\n')
+            self->bin_path[len-1] = 0;
 
-            #ifdef DEBUG
-            log_d("Python binary path: %s\n", self->bin_path);
-            #endif // DEBUG
+          get_bounds(line, a, b);
+          self->map.elf.base = (void *) a;
+          self->map.elf.size = b - a;
 
-            maps_flag |= BIN_MAP;
-          }
+          #ifdef DEBUG
+          log_d("Python binary path: %s\n", self->bin_path);
+          #endif // DEBUG
         }
       }
-      if ((maps_flag & HEAP_MAP) == 0) {
-        needle = strstr(line, "[heap]\n");
-        if (needle != NULL) {
-          get_bounds(line, a, b);
-          self->map.heap.base = (void *) a;
-          self->map.heap.size = b - a;
+      else {
+        if ((needle = strstr(line, "[heap]\n")) != NULL) {
+          if ((maps_flag & HEAP_MAP) == 0) {
+            get_bounds(line, a, b);
+            self->map.heap.base = (void *) a;
+            self->map.heap.size = b - a;
 
-          maps_flag |= HEAP_MAP;
+            maps_flag |= HEAP_MAP;
+
+            #ifdef DEBUG
+            log_d("HEAP bounds: %s", line);
+            #endif
+          }
+        }
+        else if ((maps_flag & BSS_MAP) == 0 && (line[strlen(line)-2] == ' ')) {
+          get_bounds(line, a, b);
+          self->map.bss.base = (void *) a;
+          self->map.bss.size = b - a;
+
+          maps_flag |= BSS_MAP;
+
+          #ifdef DEBUG
+          log_d("BSS bounds: %s", line);
+          #endif
         }
       }
     }
@@ -146,7 +162,9 @@ _py_proc__parse_maps_file(py_proc_t * self) {
 
   if (error & EPROC) log_error();
 
-  return self->bin_path == NULL ? 1 : 0;
+  self->maps_loaded = maps_flag == (HEAP_MAP | BSS_MAP) ? 1 : 0;
+
+  return 1 - self->maps_loaded;
 }
 
 
@@ -158,23 +176,43 @@ _py_proc__get_version(py_proc_t * self, void * map) {
 
   int major = 0, minor = 0, patch = 0;
 
+  FILE *fp;
+  char version[64];
+  char cmd[128];
+
+  sprintf(cmd, "%s --version", self->bin_path);
+
+  fp = popen(cmd, "r");
+  if (fp == NULL) {
+    log_e("Failed to start Python to determine its version.");
+    return 0;
+  }
+
+  while (fgets(version, sizeof(version) - 1, fp) != NULL) {
+    if (sscanf(version, "Python %d.%d.%d", &major, &minor, &patch) == 3)
+      break;
+  }
+
+  /* close */
+  pclose(fp);
+
+  log_i("Python version: %d.%d.%d", major, minor, patch);
+
   // Scan the rodata section for something that looks like the Python version.
   // There are good chances this is at the very beginning of the section so
   // it shouldn't take too long to find a match. This is more reliable than
   // waiting until the version appears in the bss section at run-time.
   // NOTE: This method is not guaranteed to find a valid Python version.
   //       If this causes problems then another method is required.
-  char * p_ver = (char *) map + (Elf64_Addr) self->map.rodata.base;
-  for (register int i = 0; i < self->map.rodata.size; i++) {
-    if (p_ver[i] == '.' && p_ver[i+1] != '.' && p_ver[i+2] == '.' && p_ver[i-2] == 0) {
-      if (sscanf(p_ver + i - 1, "%d.%d.%d", &major, &minor, &patch) == 3 && (major == 2 || major == 3)) {
-        #ifdef DEBUG
-        log_d("Python version: %s", p_ver + i - 1, p_ver);
-        #endif
-        break;
-      }
-    }
-  }
+  // char * p_ver = (char *) map + (Elf64_Addr) self->map.rodata.base;
+  // for (register int i = 0; i < self->map.rodata.size; i++) {
+  //   if (p_ver[i] == '.' && p_ver[i+1] != '.' && p_ver[i+2] == '.' && p_ver[i-2] == 0) {
+  //     if (sscanf(p_ver + i - 1, "%d.%d.%d", &major, &minor, &patch) == 3 && (major == 2 || major == 3)) {
+  //       log_i("Python version: %s", p_ver + i - 1, p_ver);
+  //       // break;
+  //     }
+  //   }
+  // }
 
   return (major << 16) | (minor << 8) | patch;
 }
@@ -186,14 +224,14 @@ _py_proc__analyze_bin(py_proc_t * self) {
   if (self == NULL)
     return 1;
 
-  if (self->sym_loaded)
-    return 0;
-
-  if (self->bin_path == NULL)
+  if (self->maps_loaded == 0)
     _py_proc__parse_maps_file(self);
 
-  if (self->bin_path == NULL)
+  if (self->maps_loaded == 0)
     return 1;
+
+  if (self->sym_loaded)
+    return 0;
 
   Elf64_Ehdr ehdr;
 
@@ -238,8 +276,7 @@ _py_proc__analyze_bin(py_proc_t * self) {
   if (map_flag == (DYNSYM_MAP | RODATA_MAP)) {
     self->version = _py_proc__get_version(self, elf_map);
     if (self->version) {
-      if ((self->version & 0x00FFFF00) != ((3 << 16) | (6 << 8))) // Version 3.6
-        log_w("Unsupported Python version detected. Austin might not work as expected.");
+      set_version(self->version);
 
       Elf64_Shdr * p_dynsym = self->map.dynsym.base;
       if (p_dynsym->sh_offset == 0)
@@ -292,11 +329,23 @@ _py_proc__check_interp_state(py_proc_t * self, void * raddr) {
   if (py_proc__get_type(self, raddr, is) != 0)
     return -1; // This signals that we are out of bounds.
 
+  #ifdef DEBUG
+  log_d("PyInterpreterState loaded @ %p", raddr);
+  #endif
+
   if (py_proc__get_type(self, is.tstate_head, tstate_head) != 0)
     return 1;
 
+  #ifdef DEBUG
+  log_d("PyThreadState head loaded @ %p", is.tstate_head);
+  #endif
+
   if (tstate_head.interp != raddr || tstate_head.frame == 0)
     return 1;
+
+  #ifdef DEBUG
+  log_d("Found possible interpreter state @ %p (offset %p).", raddr, raddr - self->map.heap.base);
+  #endif
 
   error = EOK;
   raddr_t thread_raddr = { .pid = self->pid, .addr = is.tstate_head };
@@ -304,6 +353,10 @@ _py_proc__check_interp_state(py_proc_t * self, void * raddr) {
   if (thread == NULL)
     return 1;
   py_thread__destroy(thread);
+
+  #ifdef DEBUG
+  log_d("Stack trace constructed from possible interpreter state (error %d)", error);
+  #endif
 
   return error == EOK ? 0 : 1;
 }
@@ -374,6 +427,8 @@ _py_proc__wait_for_interp_state(py_proc_t * self) {
     }
   }
 
+  log_d("Unable to dereference _PyThreadState_Current. Scanning heap...");
+
   // Educated guess failed. Try brute force now.
   void * upper_bound = self->map.heap.base + self->map.heap.size;
 
@@ -407,6 +462,7 @@ py_proc_new() {
     py_proc->bin_path = NULL;
     py_proc->is_raddr = NULL;
 
+    py_proc->maps_loaded       = 0;
     py_proc->sym_loaded        = 0;
     py_proc->tstate_curr_raddr = NULL;
   }

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -24,9 +24,6 @@
 #define PY_PROC_H
 
 
-#include "python36.h"
-
-
 typedef struct {
   void    * base;
   ssize_t   size;
@@ -38,6 +35,7 @@ typedef struct {
   proc_vm_map_block_t dynsym;
   proc_vm_map_block_t rodata;
   proc_vm_map_block_t heap;
+  proc_vm_map_block_t bss;
 } proc_vm_map_t;
 
 
@@ -50,6 +48,7 @@ typedef struct {
 
   // Local copy of the dynsym section
   int             sym_loaded;
+  int             maps_loaded;
   int             version;
   void          * tstate_curr_raddr;
 

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -51,6 +51,7 @@ typedef struct {
   int             maps_loaded;
   int             version;
   void          * tstate_curr_raddr;
+  void          * py_runtime;
 
   void          * is_raddr;
 } py_proc_t;

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -20,10 +20,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "py_thread.h"
-#include "python36.h"
-#include "logging.h"
 #include "error.h"
+#include "logging.h"
+#include "python.h"
+
+#include "py_thread.h"
 
 
 // ---- PRIVATE ---------------------------------------------------------------

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -22,7 +22,7 @@
 
 #include "error.h"
 #include "logging.h"
-#include "python.h"
+#include "version.h"
 
 #include "py_thread.h"
 
@@ -49,8 +49,8 @@ py_thread_new_from_raddr(raddr_t * raddr) {
     error = ETHREAD;
 
   else {
-    if (ts.frame != NULL) {
-      raddr_t frame_raddr = { .pid = raddr->pid, .addr = ts.frame };
+    if (V_FIELD(void*, ts, py_thread, o_frame) != NULL) {
+      raddr_t frame_raddr = { .pid = raddr->pid, .addr = V_FIELD(void*, ts, py_thread, o_frame) };
       py_frame = py_frame_new_from_raddr(&frame_raddr);
       if (py_frame == NULL)
         error = ETHREADNOFRAME;
@@ -87,9 +87,11 @@ py_thread_new_from_raddr(raddr_t * raddr) {
       py_thread->raddr.addr = raddr->addr;
 
       py_thread->next_raddr.pid  = raddr->pid;
-      py_thread->next_raddr.addr = ts.next == raddr->addr ? NULL : ts.next;
+      py_thread->next_raddr.addr = V_FIELD(void*, ts, py_thread, o_next) == raddr->addr \
+        ? NULL \
+        : V_FIELD(void*, ts, py_thread, o_next);
 
-      py_thread->tid  = ts.thread_id;
+      py_thread->tid  = V_FIELD(long, ts, py_thread, o_thread_id);
       py_thread->next = NULL;
 
       py_thread->first_frame = first_frame;

--- a/src/python.h
+++ b/src/python.h
@@ -85,7 +85,7 @@ typedef struct {
     PyObject *co_name;		/* unicode (name, for reference) */
     int co_firstlineno;		/* first source line number */
     PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) */
-} PyCodeObject3_4;
+} PyCodeObject3_3;
 
 typedef struct {
     PyObject_HEAD
@@ -108,7 +108,7 @@ typedef struct {
 } PyCodeObject3_6;
 
 typedef union {
-  PyCodeObject3_4 v3_4;
+  PyCodeObject3_3 v3_3;
   PyCodeObject3_6 v3_6;
 } PyCodeObject;
 
@@ -150,9 +150,44 @@ typedef struct _is {
 typedef int (*Py_tracefunc)(PyObject *, struct _frame *, int, PyObject *);
 
 
-typedef struct _ts {
-    struct _ts *prev;
-    struct _ts *next;
+typedef struct _ts3_3 {
+    struct _ts3_3 *next;
+    PyInterpreterState *interp;
+
+    struct _frame *frame;
+    int recursion_depth;
+    char overflowed;
+    char recursion_critical;
+    int tracing;
+    int use_tracing;
+
+    Py_tracefunc c_profilefunc;
+    Py_tracefunc c_tracefunc;
+    PyObject *c_profileobj;
+    PyObject *c_traceobj;
+
+    PyObject *curexc_type;
+    PyObject *curexc_value;
+    PyObject *curexc_traceback;
+
+    PyObject *exc_type;
+    PyObject *exc_value;
+    PyObject *exc_traceback;
+
+    PyObject *dict;  /* Stores per-thread state */
+
+    int tick_counter;
+
+    int gilstate_counter;
+
+    PyObject *async_exc; /* Asynchronous exception to raise */
+    long thread_id; /* Thread id where this tstate was created */
+} PyThreadState3_3;
+
+
+typedef struct _ts3_4 {
+    struct _ts3_4 *prev;
+    struct _ts3_4 *next;
     PyInterpreterState *interp;
 
     struct _frame *frame;
@@ -181,8 +216,13 @@ typedef struct _ts {
 
     PyObject *async_exc; /* Asynchronous exception to raise */
     long thread_id; /* Thread id where this tstate was created */
-} PyThreadState;
+} PyThreadState3_4;
 
+
+typedef union {
+  PyThreadState3_3 v3_3;
+  PyThreadState3_4 v3_4;
+} PyThreadState;
 
 // ---- internal/pystate.h ----------------------------------------------------
 

--- a/src/python.h
+++ b/src/python.h
@@ -184,6 +184,24 @@ typedef struct _ts {
 } PyThreadState;
 
 
+// ---- internal/pystate.h ----------------------------------------------------
+
+typedef void *PyThread_type_lock;
+
+typedef struct pyruntimestate {
+    int initialized;
+    int core_initialized;
+    PyThreadState *finalizing;
+
+    struct pyinterpreters {
+        PyThread_type_lock mutex;
+        PyInterpreterState *head;
+        PyInterpreterState *main;
+        int64_t next_id;
+    } interpreters;
+} _PyRuntimeState;
+
+
 // ---- unicodeobject.h -------------------------------------------------------
 
 typedef uint32_t Py_UCS4;

--- a/src/python.h
+++ b/src/python.h
@@ -21,20 +21,21 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // COPYRIGHT NOTICE: The content of this file is composed of different parts
-//                   taken from the source code of Python version 3.6.5.
-//                   The authors of those sources hold the copyright for most
-//                   of the content of this header file.
+//                   taken from different versions of the source code of
+//                   Python. The authors of those sources hold the copyright
+//                   for most of the content of this header file.
 
-#ifndef PYTHON36_H
-#define PYTHON36_H
+#ifndef PYTHON_H
+#define PYTHON_H
 
 #include <stdint.h>
 #include <stdlib.h>
 
+
 // ---- object.h --------------------------------------------------------------
 
-#define PyObject_HEAD                   PyObject ob_base;
-#define PyObject_VAR_HEAD      PyVarObject ob_base;
+#define PyObject_HEAD                   PyObject    ob_base;
+#define PyObject_VAR_HEAD               PyVarObject ob_base;
 
 #ifdef Py_TRACE_REFS
 #define _PyObject_HEAD_EXTRA            \
@@ -73,6 +74,26 @@ typedef struct {
     int co_nlocals;		/* #local variables */
     int co_stacksize;		/* #entries needed for evaluation stack */
     int co_flags;		/* CO_..., see below */
+    PyObject *co_code;		/* instruction opcodes */
+    PyObject *co_consts;	/* list (constants used) */
+    PyObject *co_names;		/* list of strings (names used) */
+    PyObject *co_varnames;	/* tuple of strings (local variable names) */
+    PyObject *co_freevars;	/* tuple of strings (free variable names) */
+    PyObject *co_cellvars;      /* tuple of strings (cell variable names) */
+    unsigned char *co_cell2arg; /* Maps cell vars which are arguments. */
+    PyObject *co_filename;	/* unicode (where it was loaded from) */
+    PyObject *co_name;		/* unicode (name, for reference) */
+    int co_firstlineno;		/* first source line number */
+    PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) */
+} PyCodeObject3_4;
+
+typedef struct {
+    PyObject_HEAD
+    int co_argcount;		/* #arguments, except *args */
+    int co_kwonlyargcount;	/* #keyword only arguments */
+    int co_nlocals;		/* #local variables */
+    int co_stacksize;		/* #entries needed for evaluation stack */
+    int co_flags;		/* CO_..., see below */
     int co_firstlineno;   /* first source line number */
     PyObject *co_code;		/* instruction opcodes */
     PyObject *co_consts;	/* list (constants used) */
@@ -80,16 +101,15 @@ typedef struct {
     PyObject *co_varnames;	/* tuple of strings (local variable names) */
     PyObject *co_freevars;	/* tuple of strings (free variable names) */
     PyObject *co_cellvars;      /* tuple of strings (cell variable names) */
-    /* The rest aren't used in either hash or comparisons, except for co_name,
-       used in both. This is done to preserve the name and line number
-       for tracebacks and debuggers; otherwise, constant de-duplication
-       would collapse identical functions/lambdas defined on different lines.
-    */
     unsigned char *co_cell2arg; /* Maps cell vars which are arguments. */
     PyObject *co_filename;	/* unicode (where it was loaded from) */
     PyObject *co_name;		/* unicode (name, for reference) */
-    PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) See
-				   Objects/lnotab_notes.txt for details. */
+    PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) */
+} PyCodeObject3_6;
+
+typedef union {
+  PyCodeObject3_4 v3_4;
+  PyCodeObject3_6 v3_6;
 } PyCodeObject;
 
 
@@ -214,12 +234,6 @@ typedef struct {
     PyObject_VAR_HEAD
     Py_hash_t ob_shash;
     char ob_sval[1];
-
-    /* Invariants:
-     *     ob_sval contains space for 'ob_size+1' elements.
-     *     ob_sval[ob_size] == 0.
-     *     ob_shash is the hash of the string or -1 if not computed yet.
-     */
 } PyBytesObject;
 
 

--- a/src/version.c
+++ b/src/version.c
@@ -26,17 +26,57 @@
 #include "version.h"
 
 
+#define UNSUPPORTED_VERSION log_w("Unsupported Python 3 version detected. Austin might not work as expected.")
+
+
+// ---- Python 3.3 ------------------------------------------------------------
+
+python_v python_v3_3 = {
+  // py_code
+  {
+    sizeof(PyCodeObject3_3),
+
+    offsetof(PyCodeObject3_3, co_filename),
+    offsetof(PyCodeObject3_3, co_name),
+    offsetof(PyCodeObject3_3, co_lnotab),
+    offsetof(PyCodeObject3_3, co_firstlineno)
+  },
+
+  // py_thread
+  {
+    sizeof(PyThreadState3_3),
+
+    offsetof(PyThreadState3_3, next), /* Hack. Python 3.3 doesn't have this field */
+    offsetof(PyThreadState3_3, next),
+    offsetof(PyThreadState3_3, interp),
+    offsetof(PyThreadState3_3, frame),
+    offsetof(PyThreadState3_3, thread_id)
+  }
+};
+
+
 // ---- Python 3.4 ------------------------------------------------------------
 
 python_v python_v3_4 = {
   // py_code
   {
-    sizeof(PyCodeObject3_4),
+    sizeof(PyCodeObject3_3),
 
-    offsetof(PyCodeObject3_4, co_filename),
-    offsetof(PyCodeObject3_4, co_name),
-    offsetof(PyCodeObject3_4, co_lnotab),
-    offsetof(PyCodeObject3_4, co_firstlineno)
+    offsetof(PyCodeObject3_3, co_filename),
+    offsetof(PyCodeObject3_3, co_name),
+    offsetof(PyCodeObject3_3, co_lnotab),
+    offsetof(PyCodeObject3_3, co_firstlineno)
+  },
+
+  // py_thread
+  {
+    sizeof(PyThreadState3_4),
+
+    offsetof(PyThreadState3_4, prev),
+    offsetof(PyThreadState3_4, next),
+    offsetof(PyThreadState3_4, interp),
+    offsetof(PyThreadState3_4, frame),
+    offsetof(PyThreadState3_4, thread_id)
   }
 };
 
@@ -51,6 +91,17 @@ python_v python_v3_6 = {
     offsetof(PyCodeObject3_6, co_name),
     offsetof(PyCodeObject3_6, co_lnotab),
     offsetof(PyCodeObject3_6, co_firstlineno)
+  },
+
+  // py_thread
+  {
+    sizeof(PyThreadState3_4),
+
+    offsetof(PyThreadState3_4, prev),
+    offsetof(PyThreadState3_4, next),
+    offsetof(PyThreadState3_4, interp),
+    offsetof(PyThreadState3_4, frame),
+    offsetof(PyThreadState3_4, thread_id)
   }
 };
 
@@ -76,7 +127,12 @@ set_version(int version) {
     case 0:
     case 1:
     case 2:
+      UNSUPPORTED_VERSION;
+
+    // 3.3
     case 3:
+      py_v = &python_v3_3;
+      break;
 
     // 3.4, 3.5
     case 4:
@@ -91,7 +147,7 @@ set_version(int version) {
       break;
 
     default:
-      log_w("Unsupported Python 3 version detected. Austin might not work as expected.");
+      UNSUPPORTED_VERSION;
       py_v = &python_v3_6;
     }
   }

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,91 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#define VERSION_C
+
+#include "logging.h"
+#include "version.h"
+
+
+// ---- Python 3.4 ------------------------------------------------------------
+
+python_v python_v3_4 = {
+  // py_code
+  {
+    sizeof(PyCodeObject3_4),
+
+    offsetof(PyCodeObject3_4, co_filename),
+    offsetof(PyCodeObject3_4, co_name),
+    offsetof(PyCodeObject3_4, co_lnotab),
+    offsetof(PyCodeObject3_4, co_firstlineno)
+  }
+};
+
+
+// ---- Python 3.6 ------------------------------------------------------------
+
+python_v python_v3_6 = {
+  {
+    sizeof(PyCodeObject3_6),
+
+    offsetof(PyCodeObject3_6, co_filename),
+    offsetof(PyCodeObject3_6, co_name),
+    offsetof(PyCodeObject3_6, co_lnotab),
+    offsetof(PyCodeObject3_6, co_firstlineno)
+  }
+};
+
+
+// ----------------------------------------------------------------------------
+void
+set_version(int version) {
+  int minor = (version >> 8)  & 0xFF;
+  int major = (version >> 16) & 0xFF;
+
+  switch (major) {
+
+  // ---- Python 2 ------------------------------------------------------------
+  case 2:
+    log_e("Python 2 is not supported yet.");
+    break;
+
+  // ---- Python 3 ------------------------------------------------------------
+  case 3:
+    switch (minor) {
+
+    // 3.4, 3.5
+    case 4:
+    case 5:
+      py_v = &python_v3_4;
+      break;
+
+    // 3.6
+    case 6:
+      py_v = &python_v3_6;
+      break;
+
+    default:
+      log_w("Unsupported Python 3 version detected. Austin might not work as expected.");
+      py_v = &python_v3_6;
+    }
+  }
+}

--- a/src/version.c
+++ b/src/version.c
@@ -72,14 +72,21 @@ set_version(int version) {
   case 3:
     switch (minor) {
 
+    // NOTE: These versions haven't been tested.
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+
     // 3.4, 3.5
     case 4:
     case 5:
       py_v = &python_v3_4;
       break;
 
-    // 3.6
+    // 3.6, 3.7
     case 6:
+    case 7:
       py_v = &python_v3_6;
       break;
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,71 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// This unit provides version support for Python. It summarises the ABI
+// changes into structures, and the correct one is chosen at runtime and
+// exposed via the global variable py_v. This variable should be used, when
+// different versions of the same structures are available, to de-reference
+// structure fields at the correct location.
+
+#ifndef VERSION_H
+#define VERSION_H
+
+
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "python.h"
+
+
+#define V_FIELD(ctype, py_obj, py_type, field) (*((ctype*) (((void *) &py_obj) + py_v->py_type.field)))
+
+
+typedef unsigned long offset_t;
+
+
+typedef struct {
+  ssize_t  size;
+
+  offset_t o_filename;
+  offset_t o_name;
+  offset_t o_lnotab;
+  offset_t o_firstlineno;
+} py_code_v;
+
+
+typedef struct {
+  py_code_v py_code;
+} python_v;
+
+
+void
+set_version(int);
+
+
+#ifndef VERSION_C
+extern python_v * py_v;
+#else
+python_v * py_v;
+#endif
+
+
+#endif

--- a/src/version.h
+++ b/src/version.h
@@ -53,7 +53,19 @@ typedef struct {
 
 
 typedef struct {
-  py_code_v py_code;
+  ssize_t  size;
+
+  offset_t o_prev;
+  offset_t o_next;
+  offset_t o_interp;
+  offset_t o_frame;
+  offset_t o_thread_id;
+} py_thread_v;
+
+
+typedef struct {
+  py_code_v   py_code;
+  py_thread_v py_thread;
 } python_v;
 
 


### PR DESCRIPTION
### Description of the Change

Introduced support for multiple versions of Python 3 on amd64 Linux. Given the positive test results with Python 3.6 on Windows 10 via WSL, there are good chances that the same support extends to Windows too.

### Alternate Designs

Regarding the design of the solution, two possibilities have been considered. One was to make every unit of code aware of the Python version detected and then decide on the data structure to use accordingly. The second approach, which is the one adopted for the change, was to centralise all the versioning information in a dedicated unit and have any other unit that is affected by differences among versions refer to a single global variable.

### Regressions

There are no known regressions. The version inference has been changed from the rodata scan to a popen on the executable with the `--version` option. This is fine in general, but will probably not work for embedded Python.

### Verification Process

The change has been repeatedly tested on each version of Python 3 that is targeted by this PR.