### PR TITLE
Python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
     - sourceline: 'ppa:duggan/bats'
     packages:
     - bats
+    - python2.6
+    - python2.7
     - python3.3
     - python3.4
     - python3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,14 @@ addons:
     - sourceline: 'ppa:duggan/bats'
     packages:
     - bats
+    - valgrind
+
+    - python2.3
+    - python2.4
+    - python2.5
     - python2.6
     - python2.7
+    
     - python3.3
     - python3.4
     - python3.5

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Austin has been tested on the following systems
 
 ## Linux
 
+- Python 2.3 (2.3.7) on Ubuntu 18.04.1 x86-64
+- Python 2.4 (2.4.6) on Ubuntu 18.04.1 x86-64
+- Python 2.5 (2.5.6) on Ubuntu 18.04.1 x86-64
 - Python 2.6 (2.6.9) on Ubuntu 18.04.1 x86-64
 - Python 2.7 (2.7.15rc1) on Ubuntu 18.04.1 x86-64
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![austin](art/austin.png)
 
-[![Build Status](https://travis-ci.org/P403n1x87/austin.svg?branch=master)](https://travis-ci.org/P403n1x87/austin) ![Version](https://img.shields.io/badge/version-0.3.1--alpha-blue.svg)
+[![Build Status](https://travis-ci.org/P403n1x87/austin.svg?branch=master)](https://travis-ci.org/P403n1x87/austin) ![Version](https://img.shields.io/badge/version-0.4.0--alpha-blue.svg) [![License](https://img.shields.io/badge/license-GPLv3-ff69b4.svg)](https://github.com/P403n1x87/austin/blob/master/LICENSE.md)
 
 Meet Austin, a Python frame stack sampler for CPython.
 
@@ -103,6 +103,9 @@ average.
 Austin has been tested on the following systems
 
 ## Linux
+
+- Python 2.6 (2.6.9) on Ubuntu 18.04.1 x86-64
+- Python 2.7 (2.7.15rc1) on Ubuntu 18.04.1 x86-64
 
 - Python 3.3 (3.3.7) on Ubuntu 18.04.1 x86-64
 - Python 3.4 (3.4.9+) on Ubuntu 18.04.1 x86-64

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([austin], [0.3.1-alpha], [https://github.com/p403n1x87/austin/issues])
+AC_INIT([austin], [0.4.0-alpha], [https://github.com/p403n1x87/austin/issues])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE

--- a/src/austin.h
+++ b/src/austin.h
@@ -25,7 +25,7 @@
 
 
 #define PROGRAM_NAME                    "austin"
-#define VERSION                         "0.3.1-alpha"
+#define VERSION                         "0.4.0-alpha"
 
 
 #endif

--- a/src/error.c
+++ b/src/error.c
@@ -41,14 +41,14 @@ const char * _error_msg_tab[MAXERROR] = {
   NULL,
 
   // py_code_t
-  "Failed to retrieve PyUnicodeObject",
+  "Failed to retrieve PyCodeObject",
   "Encountered unsupported string format",
   "Not a compact unicode object",
   "Failed to retrieve PyBytesObject",
   "Unable to get filename from code object",
   "Unable to get function name from code object",
   "Unable to get line number from code object",
-  NULL,
+  "Failed to retrieve PyUnicodeObject",
 
   // py_frame_t
   "Failed to create frame object",

--- a/src/error.h
+++ b/src/error.h
@@ -38,6 +38,7 @@
 #define ECODENOFNAME          ((1 << 3) + 4)
 #define ECODENONAME           ((1 << 3) + 5)
 #define ECODENOLINENO         ((1 << 3) + 6)
+#define ECODEUNICODE          ((1 << 3) + 7)
 
 // py_frame_t
 #define EFRAME                ((2 << 3) + 0)

--- a/src/py_code.c
+++ b/src/py_code.c
@@ -158,7 +158,7 @@ _get_bytes_from_raddr(pid_t pid, void * raddr, char ** array) {
   }
 
   check_not_null(*array);
-  return len - 1;  // The last char is guaranteed to be the null terminator
+  return (error & ECODEBYTES) ? -1 : len - 1;  // The last char is guaranteed to be the null terminator
 }
 
 

--- a/src/py_frame.c
+++ b/src/py_frame.c
@@ -68,7 +68,7 @@ py_frame_new_from_raddr(raddr_t * raddr) {
   }
 
   if (py_frame == NULL && py_code != NULL)
-    free(py_code);
+    py_code__destroy(py_code);
 
   check_not_null(py_frame);
   return py_frame;

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -45,7 +45,7 @@
 // ---- PRIVATE ---------------------------------------------------------------
 
 #define INIT_RETRY_SLEEP             100  /* usecs */
-#define INIT_RETRY_CNT               100  /* Retry for 10 ms before giving up. */
+#define INIT_RETRY_CNT              1000  /* Retry for 100 ms before giving up. */
 
 #define BIN_MAP                  (1 << 0)
 #define DYNSYM_MAP               (1 << 1)
@@ -110,7 +110,7 @@ _py_proc__parse_maps_file(py_proc_t * self) {
         int len = strlen(++needle);
         if (self->bin_path != NULL)
           free(self->bin_path);
-        self->bin_path = (char *) malloc(sizeof(char) * len);
+        self->bin_path = (char *) malloc(sizeof(char) * len + 1);
         if (self->bin_path == NULL)
           error = EPROCVM;
         else {
@@ -453,7 +453,7 @@ _py_proc__wait_for_interp_state(py_proc_t * self) {
   log_d("Unable to de-reference global symbols. Scanning the bss section...");
 
   // Educated guess failed. Try brute force now.
-  try_cnt = INIT_RETRY_CNT;
+  try_cnt = INIT_RETRY_CNT >> 4;
   while (--try_cnt) {
     // Copy .bss section from remote location
     self->bss = malloc(self->map.bss.size);

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -491,7 +491,7 @@ _py_proc__wait_for_interp_state(py_proc_t * self) {
   log_d("Unable to de-reference global symbols. Scanning the bss section...");
 
   // Educated guess failed. Try brute force now.
-  try_cnt = INIT_RETRY_CNT >> 4;
+  try_cnt = INIT_RETRY_CNT;
   while (--try_cnt) {
     usleep(INIT_RETRY_SLEEP);
 

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -61,18 +61,15 @@ py_thread_new_from_raddr(raddr_t * raddr) {
         while (py_frame != NULL && limit--) {
           if (py_frame->invalid) {
             error = ETHREADNOFRAME;
-            free(last_frame);
+            py_frame__destroy(last_frame);
             last_frame = NULL;
             break;
           }
-          else {
-            first_frame = py_frame;
-            py_frame = py_frame__prev(py_frame);
-          }
-        }
 
-        if (last_frame == NULL)
-          error = ETHREADNOFRAME;
+          first_frame = py_frame;
+
+          py_frame = py_frame__prev(py_frame);
+        }
       }
     }
   }
@@ -100,6 +97,9 @@ py_thread_new_from_raddr(raddr_t * raddr) {
       py_thread->invalid = 0;
     }
   }
+
+  if (py_thread == NULL && last_frame != NULL)
+    py_frame__destroy(last_frame);
 
   check_not_null(py_thread);
   return py_thread;

--- a/src/python.h
+++ b/src/python.h
@@ -70,6 +70,24 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     int co_argcount;		/* #arguments, except *args */
+    int co_nlocals;		/* #local variables */
+    int co_stacksize;		/* #entries needed for evaluation stack */
+    int co_flags;		/* CO_..., see below */
+    PyObject *co_code;		/* instruction opcodes */
+    PyObject *co_consts;	/* list (constants used) */
+    PyObject *co_names;		/* list of strings (names used) */
+    PyObject *co_varnames;	/* tuple of strings (local variable names) */
+    PyObject *co_freevars;	/* tuple of strings (free variable names) */
+    PyObject *co_cellvars;      /* tuple of strings (cell variable names) */
+    PyObject *co_filename;	/* string (where it was loaded from) */
+    PyObject *co_name;		/* string (name, for reference) */
+    int co_firstlineno;		/* first source line number */
+    PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) */
+} PyCodeObject2;
+
+typedef struct {
+    PyObject_HEAD
+    int co_argcount;		/* #arguments, except *args */
     int co_kwonlyargcount;	/* #keyword only arguments */
     int co_nlocals;		/* #local variables */
     int co_stacksize;		/* #entries needed for evaluation stack */
@@ -108,6 +126,7 @@ typedef struct {
 } PyCodeObject3_6;
 
 typedef union {
+  PyCodeObject2   v2;
   PyCodeObject3_3 v3_3;
   PyCodeObject3_6 v3_6;
 } PyCodeObject;
@@ -248,6 +267,20 @@ typedef uint32_t Py_UCS4;
 typedef uint16_t Py_UCS2;
 typedef uint8_t Py_UCS1;
 
+#define PY_UNICODE_TYPE Py_UCS4
+
+typedef PY_UNICODE_TYPE Py_UNICODE;
+
+
+typedef struct {
+    PyObject_HEAD
+    Py_ssize_t length;          /* Length of raw Unicode data in buffer */
+    Py_UNICODE *str;            /* Raw Unicode buffer */
+    long hash;                  /* Hash value; -1 if not set */
+    PyObject *defenc;           /* (Default) Encoded version as Python string */
+} PyUnicodeObject2;
+
+
 typedef Py_ssize_t Py_hash_t;
 
 typedef struct {
@@ -283,8 +316,13 @@ typedef struct {
         Py_UCS2 *ucs2;
         Py_UCS4 *ucs4;
     } data;                     /* Canonical, smallest-form Unicode buffer */
-} PyUnicodeObject;
+} PyUnicodeObject3;
 
+
+typedef union {
+  PyUnicodeObject2 v2;
+  PyUnicodeObject3 v3;
+} PyUnicodeObject;
 
 // ---- bytesobject.h ---------------------------------------------------------
 
@@ -293,6 +331,16 @@ typedef struct {
     Py_hash_t ob_shash;
     char ob_sval[1];
 } PyBytesObject;
+
+
+// ---- stringobject.h --------------------------------------------------------
+
+typedef struct {
+    PyObject_VAR_HEAD
+    long ob_shash;
+    int ob_sstate;
+    char ob_sval[1];
+} PyStringObject; /* From Python 2.7 */
 
 
 // ----------------------------------------------------------------------------

--- a/src/version.c
+++ b/src/version.c
@@ -29,6 +29,37 @@
 #define UNSUPPORTED_VERSION log_w("Unsupported Python 3 version detected. Austin might not work as expected.")
 
 
+// ---- Python 2 --------------------------------------------------------------
+
+python_v python_v2 = {
+  // py_code
+  {
+    sizeof(PyCodeObject2),
+
+    offsetof(PyCodeObject2, co_filename),
+    offsetof(PyCodeObject2, co_name),
+    offsetof(PyCodeObject2, co_lnotab),
+    offsetof(PyCodeObject2, co_firstlineno)
+  },
+
+  // py_thread
+  {
+    sizeof(PyThreadState3_3),
+
+    offsetof(PyThreadState3_3, next), /* Hack. Python 3.3 doesn't have this field */
+    offsetof(PyThreadState3_3, next),
+    offsetof(PyThreadState3_3, interp),
+    offsetof(PyThreadState3_3, frame),
+    offsetof(PyThreadState3_3, thread_id)
+  },
+
+  // py_unicode
+  {
+    2
+  }
+};
+
+
 // ---- Python 3.3 ------------------------------------------------------------
 
 python_v python_v3_3 = {
@@ -51,6 +82,11 @@ python_v python_v3_3 = {
     offsetof(PyThreadState3_3, interp),
     offsetof(PyThreadState3_3, frame),
     offsetof(PyThreadState3_3, thread_id)
+  },
+
+  // py_unicode
+  {
+    3
   }
 };
 
@@ -77,6 +113,11 @@ python_v python_v3_4 = {
     offsetof(PyThreadState3_4, interp),
     offsetof(PyThreadState3_4, frame),
     offsetof(PyThreadState3_4, thread_id)
+  },
+
+  // py_unicode
+  {
+    3
   }
 };
 
@@ -102,6 +143,11 @@ python_v python_v3_6 = {
     offsetof(PyThreadState3_4, interp),
     offsetof(PyThreadState3_4, frame),
     offsetof(PyThreadState3_4, thread_id)
+  },
+
+  // py_unicode
+  {
+    3
   }
 };
 
@@ -116,7 +162,19 @@ set_version(int version) {
 
   // ---- Python 2 ------------------------------------------------------------
   case 2:
-    log_e("Python 2 is not supported yet.");
+    py_v = &python_v2;
+    switch (minor) {
+
+      // 2.6, 2.7
+      case 6:
+      case 7:
+        py_v = &python_v2;
+        break;
+
+      default:
+        UNSUPPORTED_VERSION;
+        py_v = &python_v2;
+    }
     break;
 
   // ---- Python 3 ------------------------------------------------------------

--- a/src/version.c
+++ b/src/version.c
@@ -29,9 +29,45 @@
 #define UNSUPPORTED_VERSION log_w("Unsupported Python 3 version detected. Austin might not work as expected.")
 
 
-// ---- Python 2 --------------------------------------------------------------
+// ---- Python 2.4 ------------------------------------------------------------
 
-python_v python_v2 = {
+python_v python_v2_4 = {
+  // py_code
+  {
+    sizeof(PyCodeObject2),
+
+    offsetof(PyCodeObject2, co_filename),
+    offsetof(PyCodeObject2, co_name),
+    offsetof(PyCodeObject2, co_lnotab),
+    offsetof(PyCodeObject2, co_firstlineno)
+  },
+
+  // py_thread
+  {
+    sizeof(PyThreadState3_3),
+
+    offsetof(PyThreadState3_3, next), /* Hack. Python 3.3 doesn't have this field */
+    offsetof(PyThreadState3_3, next),
+    offsetof(PyThreadState3_3, interp),
+    offsetof(PyThreadState3_3, frame),
+    offsetof(PyThreadState3_3, thread_id)
+  },
+
+  // py_unicode
+  {
+    2
+  },
+
+  // py_bytes
+  {
+    2, 4
+  }
+};
+
+
+// ---- Python 2.5 ------------------------------------------------------------
+
+python_v python_v2_5 = {
   // py_code
   {
     sizeof(PyCodeObject2),
@@ -162,18 +198,28 @@ set_version(int version) {
 
   // ---- Python 2 ------------------------------------------------------------
   case 2:
-    py_v = &python_v2;
     switch (minor) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+      UNSUPPORTED_VERSION;
 
-      // 2.6, 2.7
-      case 6:
-      case 7:
-        py_v = &python_v2;
-        break;
+    // 2.4
+    case 4:
+      py_v = &python_v2_4;
+      break;
 
-      default:
-        UNSUPPORTED_VERSION;
-        py_v = &python_v2;
+    // 2.5, 2.6, 2.7
+    case 5:
+    case 6:
+    case 7:
+      py_v = &python_v2_5;
+      break;
+
+    default:
+      UNSUPPORTED_VERSION;
+      py_v = &python_v2_5;
     }
     break;
 

--- a/src/version.c
+++ b/src/version.c
@@ -31,7 +31,7 @@
 
 // ---- Python 2.4 ------------------------------------------------------------
 
-python_v python_v2_4 = {
+python_v python_v2_3 = {
   // py_code
   {
     sizeof(PyCodeObject2),
@@ -202,12 +202,12 @@ set_version(int version) {
     case 0:
     case 1:
     case 2:
-    case 3:
       UNSUPPORTED_VERSION;
 
-    // 2.4
+    // 2.3, 2.4
+    case 3:
     case 4:
-      py_v = &python_v2_4;
+      py_v = &python_v2_3;
       break;
 
     // 2.5, 2.6, 2.7

--- a/src/version.h
+++ b/src/version.h
@@ -64,8 +64,14 @@ typedef struct {
 
 
 typedef struct {
-  py_code_v   py_code;
-  py_thread_v py_thread;
+  int version;
+} py_unicode_v;
+
+
+typedef struct {
+  py_code_v    py_code;
+  py_thread_v  py_thread;
+  py_unicode_v py_unicode;
 } python_v;
 
 

--- a/src/version.h
+++ b/src/version.h
@@ -69,9 +69,16 @@ typedef struct {
 
 
 typedef struct {
+  int version;
+  int minor;
+} py_bytes_v;
+
+
+typedef struct {
   py_code_v    py_code;
   py_thread_v  py_thread;
   py_unicode_v py_unicode;
+  py_bytes_v   py_bytes;
 } python_v;
 
 

--- a/test/test.bats
+++ b/test/test.bats
@@ -13,3 +13,7 @@ test_case() {
 @test "Test Austin: attach" {
   test_case attach
 }
+
+@test "Test Austin: valgrind" {
+  test_case valgrind
+}

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -1,4 +1,4 @@
-attach_austin_2_4() {
+attach_austin_2_3() {
   python$1 test/sleepy.py &
   sleep 5
   run src/austin -i 10000 -p $!
@@ -23,8 +23,12 @@ attach_austin() {
   echo $output | grep ";<module> (test/sleepy.py);L13 "
 }
 
+@test "Test Austin with Python 2.3" {
+	attach_austin_2_3 "2.3"
+}
+
 @test "Test Austin with Python 2.4" {
-	attach_austin_2_4 "2.4"
+	attach_austin_2_3 "2.4"
 }
 
 @test "Test Austin with Python 2.5" {

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -1,3 +1,11 @@
+attach_austin_2() {
+  python$1 test/sleepy.py &
+  sleep 5
+  run src/austin -i 10000 -p $!
+  [ $status = 0 ]
+  echo $output | grep ";<module> (test/sleepy.py);L11 "
+}
+
 attach_austin() {
   python$1 test/sleepy.py &
   sleep 5
@@ -5,6 +13,14 @@ attach_austin() {
   [ $status = 0 ]
   echo $output | grep "cpu_bound"
   echo $output | grep ";<module> (test/sleepy.py);L13 "
+}
+
+@test "Test Austin with Python 2.6" {
+	attach_austin_2 "2.6"
+}
+
+@test "Test Austin with Python 2.7" {
+	attach_austin_2 "2.7"
 }
 
 @test "Test Austin with Python 3.3" {

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -1,4 +1,12 @@
-attach_austin_2() {
+attach_austin_2_4() {
+  python$1 test/sleepy.py &
+  sleep 5
+  run src/austin -i 10000 -p $!
+  [ $status = 0 ]
+  echo $output | grep ";? (test/sleepy.py);L13 "
+}
+
+attach_austin_2_5() {
   python$1 test/sleepy.py &
   sleep 5
   run src/austin -i 10000 -p $!
@@ -15,12 +23,20 @@ attach_austin() {
   echo $output | grep ";<module> (test/sleepy.py);L13 "
 }
 
+@test "Test Austin with Python 2.4" {
+	attach_austin_2_4 "2.4"
+}
+
+@test "Test Austin with Python 2.5" {
+	attach_austin_2_5 "2.5"
+}
+
 @test "Test Austin with Python 2.6" {
-	attach_austin_2 "2.6"
+	attach_austin_2_5 "2.6"
 }
 
 @test "Test Austin with Python 2.7" {
-	attach_austin_2 "2.7"
+	attach_austin_2_5 "2.7"
 }
 
 @test "Test Austin with Python 3.3" {

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -6,6 +6,14 @@ invoke_austin() {
   echo $output | grep "keep_cpu_busy"
 }
 
+@test "Test Austin with Python 2.6" {
+	invoke_austin "2.6"
+}
+
+@test "Test Austin with Python 2.7" {
+	invoke_austin "2.7"
+}
+
 @test "Test Austin with Python 3.3" {
 	invoke_austin "3.3"
 }

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -6,6 +6,11 @@ invoke_austin() {
   echo $output | grep "keep_cpu_busy"
 }
 
+@test "Test Austin with Python 2.3" {
+  skip # Austin fails to find a PyInterpreterState instance when run via bats
+	invoke_austin "2.3"
+}
+
 @test "Test Austin with Python 2.4" {
 	invoke_austin "2.4"
 }

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -1,9 +1,15 @@
 #!/usr/bin/env bats
 
 invoke_austin() {
-  run src/austin -i 1000 python$1 test/target34.py
+  run valgrind \
+    --error-exitcode=42 \
+    --leak-check=full \
+    --show-leak-kinds=all \
+    --errors-for-leak-kinds=all \
+    --track-fds=yes \
+    src/austin -i 1000 python$1 test/target34.py
+  echo "Exit code:" $status
 	[ $status = 0 ]
-  echo $output | grep "keep_cpu_busy"
 }
 
 @test "Test Austin with Python 2.4" {

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -9,10 +9,12 @@ invoke_austin() {
     --track-fds=yes \
     src/austin -i 1000 python$1 test/target34.py
   echo "Exit code:" $status
+  echo $output
 	[ $status = 0 ]
 }
 
 @test "Test Austin with Python 2.3" {
+  skip
 	invoke_austin "2.3"
 }
 

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -12,6 +12,10 @@ invoke_austin() {
 	[ $status = 0 ]
 }
 
+@test "Test Austin with Python 2.3" {
+	invoke_austin "2.3"
+}
+
 @test "Test Austin with Python 2.4" {
 	invoke_austin "2.4"
 }


### PR DESCRIPTION
### Description of the Change

Introduced support for Python 2 (versions 2.3-2.7).

### Alternate Designs

The change builds on top of the version support introduced for the support of multiple versions of Python 3.

### Regressions

There are no known regressions that could be caused by this change.

### Verification Process

The introduction of Python 2 support unearthed a couple of bugs that could have potentially caused some (mild) memory leaks. The test suite has been enriched with a valgrind task to check that every version of Python doesn't lead to any memory leaks or memory problems of other nature.