### PR TITLE
Feature/elf32

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,17 @@
-2018-09-02 v0.3.1-alpha
+2018-10-10 v0.5.0-beta
+
+  Added support for all the major releases of Python 2 and 3 on 32-bit Linux.
+
+
+2018-10-08 v0.4.0-alpha
+
+  Added support for all the major releases of Python 2 and 3 on 64-bit Linux.
+
+
+2018-10-02 v0.3.1-alpha
 
   Bugfix: Austin can now attach to a running Python process again.
-  
+
 
 2018-09-30 v0.3.0-alpha
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![austin](art/austin.png)
 
-[![Build Status](https://travis-ci.org/P403n1x87/austin.svg?branch=master)](https://travis-ci.org/P403n1x87/austin) ![Version](https://img.shields.io/badge/version-0.4.0--alpha-blue.svg) [![License](https://img.shields.io/badge/license-GPLv3-ff69b4.svg)](https://github.com/P403n1x87/austin/blob/master/LICENSE.md)
+[![Build Status](https://travis-ci.org/P403n1x87/austin.svg?branch=master)](https://travis-ci.org/P403n1x87/austin) ![Version](https://img.shields.io/badge/version-0.5.0--beta-blue.svg) [![License](https://img.shields.io/badge/license-GPLv3-ff69b4.svg)](https://github.com/P403n1x87/austin/blob/master/LICENSE.md)
 
 Meet Austin, a Python frame stack sampler for CPython.
 
@@ -19,14 +19,13 @@ spirit to [py-spy](https://github.com/benfred/py-spy).
 
 ![tui](art/austin-tui_wip.png)
 
-The current version only supports the 64-bit versions of Python on
-Linux-based operating systems that have not been compiled with the
-`--enable-shared` flag. Support for the i386 architecture is next in line, and
-then there might be support for other operating systems too.
+The current version only supports Python on Linux-based operating systems that
+have not been compiled with the `--enable-shared` flag. Support for other
+operating systems is next in line.
 
-> **NOTE** The TUI is still work in progress. Its main purpose is to provide
-> an example of how to use the output produce by Austin rather than an
-> additional application to maintain.
+> **NOTE** The TUI is experimental and still work in progress. Its main purpose
+> is to provide an example of how to use the output produce by Austin rather
+> than an additional application to maintain.
 
 
 # Installation
@@ -100,21 +99,22 @@ average.
 
 # Compatibility
 
-Austin has been tested on the following systems
+Austin has been tested on the following systems (both 32- and 64-bit, unless
+otherwise specified).
 
 ## Linux
 
-- Python 2.3 (2.3.7) on Ubuntu 18.04.1 x86-64
-- Python 2.4 (2.4.6) on Ubuntu 18.04.1 x86-64
-- Python 2.5 (2.5.6) on Ubuntu 18.04.1 x86-64
-- Python 2.6 (2.6.9) on Ubuntu 18.04.1 x86-64
-- Python 2.7 (2.7.15rc1) on Ubuntu 18.04.1 x86-64
+- Python 2.3 (2.3.7) on Ubuntu 18.04.1
+- Python 2.4 (2.4.6) on Ubuntu 18.04.1
+- Python 2.5 (2.5.6) on Ubuntu 18.04.1
+- Python 2.6 (2.6.9) on Ubuntu 18.04.1
+- Python 2.7 (2.7.15rc1) on Ubuntu 18.04.1
 
-- Python 3.3 (3.3.7) on Ubuntu 18.04.1 x86-64
-- Python 3.4 (3.4.9+) on Ubuntu 18.04.1 x86-64
-- Python 3.5 (3.5.2) on Ubuntu 16.04.5 x86-64
-- Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04.1 x86-64
-- Python 3.7 (3.7.0) on Ubuntu 18.04.1 x86-64
+- Python 3.3 (3.3.7) on Ubuntu 18.04.1
+- Python 3.4 (3.4.9+) on Ubuntu 18.04.1
+- Python 3.5 (3.5.2) on Ubuntu 18.04.1
+- Python 3.6 (3.6.5, 3.6.6) on Ubuntu 18.04.1
+- Python 3.7 (3.7.0) on Ubuntu 18.04.1
 
 ## Windows
 
@@ -123,7 +123,7 @@ Austin has been tested on the following systems
 > **NOTE** Austin *might* work with other versions of Python 3 on both Linux
 > and Windows
 
-# How does it work?
+# A Note on How Austin Works
 
 To understand how Python works internally in terms of keeping track of all the
 function calls, you can have a look at similar projects like
@@ -238,7 +238,7 @@ The Python TUI that is currently included in this repository is experimental and
 work in progress. It serves the purpose of providing an example of how to use
 Austin to profile Python applications. Here is a recording of the TUI in action
 with a sample script that spawns a new thread and keeps the CPU busy with a CPU
-bound loop on each thread. You can use PageUp and PageDown to explore the
+bound loop on each thread. You can use PageUp and PageDown to navigate the
 frame stack of each frame as the Python application runs.
 
 ![austin-tui thread navigation](art/austin-tui_threads_nav.gif)

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([austin], [0.4.0-alpha], [https://github.com/p403n1x87/austin/issues])
+AC_INIT([austin], [0.5.0-beta], [https://github.com/p403n1x87/austin/issues])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE

--- a/src/austin.h
+++ b/src/austin.h
@@ -25,7 +25,7 @@
 
 
 #define PROGRAM_NAME                    "austin"
-#define VERSION                         "0.4.0-alpha"
+#define VERSION                         "0.5.0-beta"
 
 
 #endif

--- a/src/linux/py_proc_elf.c
+++ b/src/linux/py_proc_elf.c
@@ -1,0 +1,212 @@
+#include <elf.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#include "../dict.h"
+#include "../py_proc.h"
+
+
+#define BIN_MAP                  (1 << 0)
+#define DYNSYM_MAP               (1 << 1)
+#define RODATA_MAP               (1 << 2)
+#define HEAP_MAP                 (1 << 3)
+#define BSS_MAP                  (1 << 4)
+
+
+#define _py_proc__get_elf_type(self, offset, dt) (py_proc__memcpy(self, self->map.elf.base + offset, sizeof(dt), &dt))
+#define ELF_SH_OFF(ehdr, i)            (ehdr.e_shoff + i * ehdr.e_shentsize)
+
+#define DYNSYM_COUNT                   2
+
+union {
+  Elf32_Ehdr v32;
+  Elf64_Ehdr v64;
+} ehdr_v;
+
+static const char * _dynsym_array[DYNSYM_COUNT] = {
+  "_PyThreadState_Current",
+  "_PyRuntime"
+};
+
+static long _dynsym_hash_array[DYNSYM_COUNT] = {
+  0
+};
+
+
+// ----------------------------------------------------------------------------
+static int
+_py_proc__analyze_elf64(py_proc_t * self) {
+  Elf64_Ehdr ehdr = ehdr_v.v64;
+
+  // Section header must be read from binary as it is not loaded into memory
+  Elf64_Xword   sht_size      = ehdr.e_shnum * ehdr.e_shentsize;
+  Elf64_Off     elf_map_size  = ehdr.e_shoff + sht_size;
+  int           fd            = open(self->bin_path, O_RDONLY);
+  void        * elf_map       = mmap(NULL, elf_map_size, PROT_READ, MAP_SHARED, fd, 0);
+  int           map_flag      = 0;
+  Elf64_Shdr  * p_shdr;
+
+  Elf64_Shdr  * p_shstrtab = elf_map + ELF_SH_OFF(ehdr, ehdr.e_shstrndx);
+  char        * sh_name_base = elf_map + p_shstrtab->sh_offset;
+
+  for (Elf64_Off sh_off = ehdr.e_shoff; \
+    map_flag != (DYNSYM_MAP | RODATA_MAP) && sh_off < elf_map_size; \
+    sh_off += ehdr.e_shentsize \
+  ) {
+    p_shdr = (Elf64_Shdr *) (elf_map + sh_off);
+
+    if (   p_shdr->sh_type == SHT_DYNSYM \
+        && strcmp(sh_name_base + p_shdr->sh_name, ".dynsym") == 0
+    ) {
+      self->map.dynsym.base = p_shdr;  // WARNING: Different semantics!
+      map_flag |= DYNSYM_MAP;
+    }
+    else if (p_shdr->sh_type == SHT_PROGBITS \
+        && strcmp(sh_name_base + p_shdr->sh_name, ".rodata") == 0
+    ) {
+      self->map.rodata.base = (void *) p_shdr->sh_offset;
+      self->map.rodata.size = p_shdr->sh_size;
+      map_flag |= RODATA_MAP;
+    }
+  }
+
+  register int hit_cnt = 0;
+  if (map_flag == (DYNSYM_MAP | RODATA_MAP)) {
+    Elf64_Shdr * p_dynsym = self->map.dynsym.base;
+    if (p_dynsym->sh_offset == 0)
+      return 1;
+
+    Elf64_Shdr * p_strtabsh = (Elf64_Shdr *) (elf_map + ELF_SH_OFF(ehdr, p_dynsym->sh_link));
+
+    // Search for dynamic symbols
+    for (Elf64_Off tab_off = p_dynsym->sh_offset; \
+      hit_cnt < DYNSYM_COUNT && tab_off < p_dynsym->sh_offset + p_dynsym->sh_size; \
+      tab_off += p_dynsym->sh_entsize
+    ) {
+      Elf64_Sym * sym      = (Elf64_Sym *) (elf_map + tab_off);
+      char      * sym_name = elf_map + p_strtabsh->sh_offset + sym->st_name;
+      long        hash     = string_hash(sym_name);
+      for (register int i = 0; i < DYNSYM_COUNT; i++) {
+        if (hash == _dynsym_hash_array[i] && strcmp(sym_name, _dynsym_array[i]) == 0) {
+          *(&(self->tstate_curr_raddr) + i) = (void *) sym->st_value;
+          hit_cnt++;
+          #ifdef DEBUG
+          log_d("Symbol %s found at %p", sym_name, sym->st_value);
+          #endif
+        }
+      }
+    }
+  }
+
+  munmap(elf_map, elf_map_size);
+  close(fd);
+
+  return hit_cnt;
+}
+
+
+// ----------------------------------------------------------------------------
+static int
+_py_proc__analyze_elf32(py_proc_t * self) {
+
+  Elf32_Ehdr ehdr = ehdr_v.v32;
+
+  // Section header must be read from binary as it is not loaded into memory
+  Elf32_Xword   sht_size      = ehdr.e_shnum * ehdr.e_shentsize;
+  Elf32_Off     elf_map_size  = ehdr.e_shoff + sht_size;
+  int           fd            = open(self->bin_path, O_RDONLY);
+  void        * elf_map       = mmap(NULL, elf_map_size, PROT_READ, MAP_SHARED, fd, 0);
+  int           map_flag      = 0;
+  Elf32_Shdr  * p_shdr;
+
+  Elf32_Shdr  * p_shstrtab = elf_map + ELF_SH_OFF(ehdr, ehdr.e_shstrndx);
+  char        * sh_name_base = elf_map + p_shstrtab->sh_offset;
+
+  for (Elf32_Off sh_off = ehdr.e_shoff; \
+    map_flag != (DYNSYM_MAP | RODATA_MAP) && sh_off < elf_map_size; \
+    sh_off += ehdr.e_shentsize \
+  ) {
+    p_shdr = (Elf32_Shdr *) (elf_map + sh_off);
+
+    if (   p_shdr->sh_type == SHT_DYNSYM \
+        && strcmp(sh_name_base + p_shdr->sh_name, ".dynsym") == 0
+    ) {
+      self->map.dynsym.base = p_shdr;  // WARNING: Different semantics!
+      map_flag |= DYNSYM_MAP;
+    }
+    else if (p_shdr->sh_type == SHT_PROGBITS \
+        && strcmp(sh_name_base + p_shdr->sh_name, ".rodata") == 0
+    ) {
+      self->map.rodata.base = (void *) p_shdr->sh_offset;
+      self->map.rodata.size = p_shdr->sh_size;
+      map_flag |= RODATA_MAP;
+    }
+  }
+
+  register int hit_cnt = 0;
+  if (map_flag == (DYNSYM_MAP | RODATA_MAP)) {
+    Elf32_Shdr * p_dynsym = self->map.dynsym.base;
+    if (p_dynsym->sh_offset == 0)
+      return 1;
+
+    Elf32_Shdr * p_strtabsh = (Elf32_Shdr *) (elf_map + ELF_SH_OFF(ehdr, p_dynsym->sh_link));
+
+    // Search for dynamic symbols
+    for (Elf32_Off tab_off = p_dynsym->sh_offset; \
+      hit_cnt < DYNSYM_COUNT && tab_off < p_dynsym->sh_offset + p_dynsym->sh_size; \
+      tab_off += p_dynsym->sh_entsize
+    ) {
+      Elf32_Sym * sym      = (Elf32_Sym *) (elf_map + tab_off);
+      char      * sym_name = elf_map + p_strtabsh->sh_offset + sym->st_name;
+      long        hash     = string_hash(sym_name);
+      for (register int i = 0; i < DYNSYM_COUNT; i++) {
+        if (hash == _dynsym_hash_array[i] && strcmp(sym_name, _dynsym_array[i]) == 0) {
+          *(&(self->tstate_curr_raddr) + i) = (void *) sym->st_value;
+          hit_cnt++;
+          #ifdef DEBUG
+          log_d("Symbol %s found at %p", sym_name, sym->st_value);
+          #endif
+        }
+      }
+    }
+  }
+
+  munmap(elf_map, elf_map_size);
+  close(fd);
+
+  return hit_cnt;
+}
+
+
+// ----------------------------------------------------------------------------
+static int
+_py_proc__analyze_elf(py_proc_t * self) {
+  Elf64_Ehdr ehdr = ehdr_v.v64;
+
+  // Check magic
+  if (_py_proc__get_elf_type(self, 0, ehdr_v) || ehdr.e_shoff == 0 || ehdr.e_shnum < 2 \
+    || ehdr.e_ident[1] != 'E' || ehdr.e_ident[2] != 'L' || ehdr.e_ident[3] != 'F' \
+  ) return 0;
+
+  // NOTE: This runs sub-optimally when searching for a single symbol
+  // Pre-hash symbol names
+  if (_dynsym_hash_array[0] == 0) {
+    for (register int i = 0; i < DYNSYM_COUNT; i++)
+      _dynsym_hash_array[i] = string_hash((char *) _dynsym_array[i]);
+  }
+
+  // Dispatch
+  switch (ehdr.e_ident[EI_CLASS]) {
+  case ELFCLASS32:
+    return _py_proc__analyze_elf32(self);
+
+  case ELFCLASS64:
+    return _py_proc__analyze_elf64(self);
+
+  default:
+    return 0;
+  }
+}

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -49,7 +49,7 @@
 // ---- PRIVATE ---------------------------------------------------------------
 
 #define INIT_RETRY_SLEEP             100  /* usecs */
-#define INIT_RETRY_CNT              1000  /* Retry for 100 ms before giving up. */
+#define INIT_RETRY_CNT              1000  /* Retry for 0.1s before giving up. */
 
 
 // Get the offset of the ith section header

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -89,6 +89,8 @@ py_thread_new_from_raddr(raddr_t * raddr) {
         : V_FIELD(void*, ts, py_thread, o_next);
 
       py_thread->tid  = V_FIELD(long, ts, py_thread, o_thread_id);
+      if (py_thread->tid == 0)
+        py_thread->tid = (int) raddr->addr;
       py_thread->next = NULL;
 
       py_thread->first_frame = first_frame;


### PR DESCRIPTION
### Description of the Change

Introduced support for ELF32.

### Regressions

Tests have shown issues with Python 2.7 (32-bit) whereby a less efficient scan of the heap was required to let Austin work with this release of Python. This could potentially affect slower machines, as Python applications that run under 0.2s might not produce any output through Austin.

### Verification Process

The change has been tested without major issues with a 32-bit Ubuntu 18.04.1 base image on a 64-bit machine as well as on a 32-bit machine.
