### PR TITLE
Add Snap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-# ====  C SOURCES =============================================================
+# -----------------------------------------------------------------------------
+# --  C SOURCES
+# -----------------------------------------------------------------------------
 
 /autom4te.cache/
 /config/
@@ -37,7 +39,9 @@ stamp-h1
 src/austin
 
 
-# ====  PYTHON SOURCES ========================================================
+# -----------------------------------------------------------------------------
+# --  PYTHON SOURCES
+# -----------------------------------------------------------------------------
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -109,3 +113,20 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+
+# -----------------------------------------------------------------------------
+# --  SNAP SOURCES
+# -----------------------------------------------------------------------------
+
+/parts/
+/stage/
+/prime/
+/*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2

--- a/README.md
+++ b/README.md
@@ -77,8 +77,15 @@ operating systems is next in line.
 
 # Installation
 
-Installing Austin amounts to the usual `./configure`, `make` and `make install`
-finger gymnastic. The only dependency is the standard C library.
+Austin can be installed using `autotools` or as a snap from the Snap Store. The
+latter will automatically perform the steps of the `autotools` method with a
+single command
+
+## With `autotools`
+
+Installing Austin using `autotools` amounts to the usual `./configure`, `make`
+and `make install` finger gymnastic. The only dependency is the standard C
+library.
 
 ~~~ bash
 git clone --depth=1 https://github.com/P403n1x87/austin.git
@@ -100,6 +107,18 @@ so you can use just this command if you don't have `autoreconf` installed.
 
 Add `-DDEBUG` if you want a more verbose syslog output on UNIX-like systems,
 or `%TEMP%/austin.log` on Windows.
+
+## From the Snap Store
+
+Austin can be installed from the Snap Store with the following command
+
+~~~ bash
+sudo snap install austin --channel=beta
+~~~
+
+Note that this will fetch the latest sources from the `master` branch on
+GitHub and invoke the `autotools` steps.
+
 
 # Usage
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: austin # you probably want to 'snapcraft register <name>'
+version: 'beta+git' # just for humans, typically '1.2+git' or '1.3.2'
+summary: A Python frame stack sampler for CPython # 79 char long summary
+description: |
+  Austin is a Python frame stack sampler for CPython written in pure C. It
+  samples the stack traces of a Python application so that they can be
+  visualised and analysed. As such, it serves the basis for building powerful
+  profilers for Python.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: classic # use 'strict' once you have the right plugs and slots
+
+architectures: [ all ]
+
+parts:
+  austin:
+    plugin: autotools
+    source: git://github.com/P403n1x87/austin
+    source-depth: 1
+
+apps:
+  austin:
+    command: bin/austin


### PR DESCRIPTION
### Description of the Change

This change add support Snapcraft support so that Austin can be installed from the Snap Store.

### Alternate Designs

N. A.

### Regressions

N. A.

### Verification Process

N. A.