### PR TITLE
Add CLI option to output stacks to a separate file

### DIFF
--- a/src/argparse.c
+++ b/src/argparse.c
@@ -24,6 +24,7 @@
 
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 
 #include "argparse.h"
@@ -45,6 +46,7 @@ pid_t   attach_pid          = 0;
 int     exclude_empty       = 0;
 int     sleepless           = 0;
 char *  format              = (char *) SAMPLE_FORMAT_NORMAL;
+char*   output_filename     = NULL;
 
 static int exec_arg = 0;
 
@@ -114,6 +116,10 @@ static struct argp_option options[] = {
     "pid",          'p', "PID",         0,
     "The the ID of the process to which Austin should attach."
   },
+  {
+    "output",       'o', "OUTPUT",       0,
+    "Output file."
+  },
   #ifndef PL_LINUX
   {
     "help",         '?', NULL
@@ -177,6 +183,12 @@ parse_opt (int key, char *arg, struct argp_state *state)
     if (strtonum(arg, &l_pid) == 1 || l_pid <= 0)
       argp_error(state, "invalid PID.");
     attach_pid = (pid_t) l_pid;
+    break;
+
+  case 'o':
+    if (output_filename == NULL)
+      free(output_filename);
+    output_filename = strdup(arg);
     break;
 
   case ARGP_KEY_ARG:

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -34,6 +34,7 @@ extern pid_t   attach_pid;
 extern int     exclude_empty;
 extern int     sleepless;
 extern char *  format;
+extern char *  output_filename;
 #endif
 
 

--- a/src/error.h
+++ b/src/error.h
@@ -29,6 +29,7 @@
 // generic messages
 #define EOK                   0
 #define EMMAP                 1
+#define EFILE                 2
 
 // py_code_t
 #define ECODE                 ((1 << 3) + 0)


### PR DESCRIPTION
### Requirements for Adding, Changing, Fixing or Removing a Feature

### Description of the Change

Add a CLI option (`-o`) to write stacks to a file instead of standard output. Makes it easier to split austin standard output from the caller's standard output.

### Alternate Designs

Use a wrapper script doing the redirection.

### Regressions

Not enabled by default. I geuss it should be fine.

### Verification Process

``
# Works as before:
austin python3 -m http.server

# Write to a file:
austin -o test.stacks python3 -m http.server
```