### PR TITLE
feature/memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ before_script:
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then autoreconf --install; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then ./configure && make && sudo make check; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"     ]]; then gcc -s -Wall -O3 -o src/austin src/*.c; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then gcc -s -Wall -O3 -o src/austin src/*.c; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then ./configure && make && sudo make check;         fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"     ]]; then gcc -s -Wall -O3 -o src/austin src/*.c;         fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then gcc -s -Wall -O3 -o src/austin src/*.c -lpsapi; fi
 
 after_success:
   ./src/austin --usage

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -476,7 +476,7 @@ cb(const char opt, const char * arg) {
       puts("Unable to create the given output file.");
       return ARG_INVALID_VALUE;
     }
-    pargs.output_filename = arg;
+    pargs.output_filename = (char *) arg;
     break;
 
   case '?':

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -421,7 +421,10 @@ static int
 cb(const char opt, const char * arg) {
   switch (opt) {
   case 'i':
-    if (strtonum((char *) arg, (long *) &t_sampling_interval) == 1 || t_sampling_interval > LONG_MAX) {
+    if (
+      strtonum((char *) arg, (long *) &(pargs.t_sampling_interval)) == 1 ||
+      pargs.t_sampling_interval > LONG_MAX
+    ) {
       puts(usage_msg);
       return ARG_INVALID_VALUE;
     }
@@ -470,7 +473,7 @@ cb(const char opt, const char * arg) {
   case 'o':
     pargs.output_file = fopen(arg, "w");
     if (pargs.output_file == NULL) {
-      puts(state, "Unable to create the given output file.");
+      puts("Unable to create the given output file.");
       return ARG_INVALID_VALUE;
     }
     pargs.output_filename = arg;

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -34,6 +34,10 @@ extern pid_t   attach_pid;
 extern int     exclude_empty;
 extern int     sleepless;
 extern char *  format;
+extern int     full;
+extern int     memory;
+extern FILE *  output_file;
+extern char *  output_filename;
 #endif
 
 

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -27,17 +27,22 @@
 
 #include "stats.h"
 
+typedef struct {
+  ctime_t   t_sampling_interval;
+  ctime_t   timeout;
+  pid_t     attach_pid;
+  int       exclude_empty;
+  int       sleepless;
+  char    * format;
+  int       full;
+  int       memory;
+  FILE    * output_file;
+  char    * output_filename;
+} parsed_args_t;
+
+
 #ifndef ARGPARSE_C
-extern ctime_t t_sampling_interval;
-extern ctime_t timeout;
-extern pid_t   attach_pid;
-extern int     exclude_empty;
-extern int     sleepless;
-extern char *  format;
-extern int     full;
-extern int     memory;
-extern FILE *  output_file;
-extern char *  output_filename;
+extern parsed_args_t pargs;
 #endif
 
 

--- a/src/austin.c
+++ b/src/austin.c
@@ -130,7 +130,7 @@ _py_proc__sample(py_proc_t * py_proc) {
     py_thread__destroy(first_thread);
 
     if (error != EOK)
-      printf("Bad sample %ld\n", delta);
+      fprintf(pargs.output_file, "Bad sample %ld\n", delta);
   }
 
   t_sample += delta;

--- a/src/austin.c
+++ b/src/austin.c
@@ -235,7 +235,7 @@ int main(int argc, char ** argv) {
     }
   }
 
-  if (pargs.output_file != stdout) {
+  if (pargs.output_file != NULL && pargs.output_file != stdout) {
     fclose(pargs.output_file);
     log_d("Output file closed.");
   }

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -326,8 +326,7 @@ _py_proc__parse_maps_file(py_proc_t * self) {
         else {
           while (*((char *) --needle) != ' ');  // Move to the beginning of the path
           path_len = strlen(++needle);
-          self->bin_path = (char *) malloc(sizeof(char) * path_len + 1);
-          strcpy(self->bin_path, needle);
+          self->bin_path = strndup(needle, path_len);
           if (self->bin_path[path_len-1] == '\n')
             self->bin_path[path_len-1] = 0;
 
@@ -341,8 +340,7 @@ _py_proc__parse_maps_file(py_proc_t * self) {
 
         while (*((char *) --needle) != ' ');  // Move to the beginning of the path
         path_len = strlen(++needle);
-        self->lib_path = (char *) malloc(sizeof(char) * path_len + 1);
-        strcpy(self->lib_path, needle);
+        self->lib_path = strndup(needle, path_len);
         if (self->lib_path[path_len-1] == '\n')
           self->lib_path[path_len-1] = 0;
 

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -60,6 +60,10 @@
 #define sw32(f, v) (f ? bswap_32(v) : v)
 
 
+struct _proc_extra_info {
+  mach_port_t task_id;
+};
+
 // ----------------------------------------------------------------------------
 static int
 _py_proc__analyze_macho64(py_proc_t * self, void * map) {
@@ -288,15 +292,15 @@ _py_proc__get_maps(py_proc_t * self) {
 
   usleep(10000);  // NOTE: Mac OS X kernel bug
 
-  mach_port_t task_id = pid_to_task(self->pid);
-  if (task_id == 0)
+  self->extra->task_id = pid_to_task(self->pid);
+  if (self->extra->task_id == 0)
     return 1;
 
   self->min_raddr = (void *) -1;
   self->max_raddr = NULL;
 
   while (mach_vm_region(
-    task_id,
+    self->extra->task_id,
     &address,
     &size,
     VM_REGION_BASIC_INFO_64,
@@ -345,10 +349,26 @@ _py_proc__get_maps(py_proc_t * self) {
 
 
 // ----------------------------------------------------------------------------
+static ssize_t _py_proc__get_resident_memory(py_proc_t * self) {
+  struct mach_task_basic_info info;
+	mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+
+  return task_info(
+    self->extra->task_id, MACH_TASK_BASIC_INFO, (task_info_t) &info, &count
+  ) == KERN_SUCCESS
+    ? info.resident_size
+    : -1;
+}
+
+
+// ----------------------------------------------------------------------------
 static int
 _py_proc__init(py_proc_t * self) {
   if (self == NULL)
     return 1;
+
+  if (self->extra == NULL)
+    self->extra = (proc_extra_info *) malloc(sizeof(proc_extra_info));
 
   return _py_proc__get_maps(self);
 }

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -316,20 +316,20 @@ _py_proc__get_maps(py_proc_t * self) {
 
     char path[MAXPATHLEN];
     int len = proc_regionfilename(self->pid, address, path, MAXPATHLEN);
+    int path_len = strlen(path);
+
     if (size > 0 && len) {
       path[len] = 0;
       if (self->bin_path == NULL && strstr(path, "python")) {
-        if (strstr(path + strlen(path) - 3, ".so") == NULL) {
+        if (strstr(path + path_len - 3, ".so") == NULL) {
           // check that it is not a .so file
-          self->bin_path = (char *) malloc(strlen(path) + 1);
-          strcpy(self->bin_path, path);
+          self->bin_path = strndup(path, path_len);
         }
       }
 
       if (self->lib_path == NULL && strstr(path, "Python")) {
-        if (strstr(path + strlen(path) - 3, ".so") == NULL) {
-          self->lib_path = (char *) malloc(strlen(path) + 1);
-          strcpy(self->lib_path, path);
+        if (strstr(path + path_len - 3, ".so") == NULL) {
+          self->lib_path = strndup(path, path_len);
 
           self->map.bss.base = (void *) address;  // WARNING: Partial result. Not yet the BSS base!!
           if (_py_proc__analyze_macho(self, path, (void *) address, size))

--- a/src/platform.h
+++ b/src/platform.h
@@ -1,3 +1,29 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+
 #if defined(__linux__)
   #define PL_LINUX
 
@@ -7,9 +33,16 @@
 #elif defined(_WIN32) || defined(_WIN64)
   #define PL_WIN
 
+  #define NULL_DEVICE "NUL:"
+
 #endif
 
+// ----------------------------------------------------------------------------
 
 #if defined(PL_LINUX) || defined(PL_MACOS)
   #define PL_UNIX
+
+  #define NULL_DEVICE "/dev/null"
+#endif
+
 #endif

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -54,7 +54,7 @@
 
 // ---- Retry Timer ----
 #define INIT_RETRY_SLEEP             100   /* us */
-#define INIT_RETRY_CNT       (timeout*10)  /* Retry for 0.1s (default) before giving up. */
+#define INIT_RETRY_CNT (pargs.timeout*10)  /* Retry for 0.1s (default) before giving up. */
 
 #define TIMER_RESET                     (try_cnt=INIT_RETRY_CNT);
 #define TIMER_START                     while (--try_cnt>=0) { usleep(INIT_RETRY_SLEEP);
@@ -531,10 +531,20 @@ _py_proc__wait_for_interp_state(py_proc_t * self) {
 // ----------------------------------------------------------------------------
 static int
 _py_proc__run(py_proc_t * self) {
-  log_d("Start up timeout: %dms", timeout);
+  log_d("Start up timeout: %dms", pargs.timeout);
 
   TIMER_RESET
   TIMER_START
+    if (self->bin_path != NULL) {
+      free(self->bin_path);
+      self->bin_path = NULL;
+    }
+
+    if (self->lib_path != NULL) {
+      free(self->lib_path);
+      self->lib_path = NULL;
+    }
+
     if (_py_proc__init(self) == 0)
       break;
 
@@ -675,7 +685,7 @@ py_proc__start(py_proc_t * self, const char * exec, char * argv[]) {
   if (self->pid == 0) {
     // If we are not writing to file we need to ensure the child process is
     // not writing to stdout.
-    if (output_file == NULL)
+    if (pargs.output_file == NULL)
       close(STDOUT_FILENO);
 
     execvp(exec, argv);

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -38,6 +38,7 @@ typedef struct {
   proc_vm_map_block_t rodata;
 } proc_vm_map_t;
 
+typedef struct _proc_extra_info proc_extra_info;  // Forward declaration.
 
 typedef struct {
   pid_t           pid;
@@ -52,7 +53,6 @@ typedef struct {
   void          * bss;  // local copy of the remote bss section
 
   int             sym_loaded;
-  int             maps_loaded;
   int             version;
 
   // Symbols from .dynsym
@@ -61,6 +61,12 @@ typedef struct {
   void          * interp_head_raddr;
 
   void          * is_raddr;
+
+  // Memory profiling support
+  ssize_t         last_resident_memory;
+
+  // Platform-dependent fields
+  proc_extra_info * extra;
 } py_proc_t;
 
 
@@ -156,6 +162,15 @@ py_proc__wait(py_proc_t *);
  */
 int
 py_proc__is_running(py_proc_t *);
+
+
+/**
+ * Get the memory size delta since last call.
+ *
+ * @param py_proc_t * the process object.
+ */
+ssize_t
+py_proc__get_memory_delta(py_proc_t *);
 
 
 /**

--- a/src/version.c
+++ b/src/version.c
@@ -126,7 +126,11 @@ python_v python_v3_7 = {
   PY_UNICODE  (3),
   PY_BYTES    (3),
   #if defined PL_LINUX
-  PY_RUNTIME  (0x570)
+    #if defined __i386__
+    PY_RUNTIME  (0x31c)
+    #elif defined __x86_64__
+    PY_RUNTIME  (0x570)
+    #endif
   #elif defined PL_WIN
   PY_RUNTIME  (0x528)
   #elif defined PL_MACOS

--- a/src/version.c
+++ b/src/version.c
@@ -23,6 +23,7 @@
 #define VERSION_C
 
 #include "logging.h"
+#include "platform.h"
 #include "version.h"
 
 
@@ -124,7 +125,7 @@ python_v python_v3_7 = {
   PY_THREAD   (PyThreadState3_4),
   PY_UNICODE  (3),
   PY_BYTES    (3),
-  #if defined PL_LINIX
+  #if defined PL_LINUX
   PY_RUNTIME  (0x570)
   #elif defined PL_WIN
   PY_RUNTIME  (0x528)

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -22,6 +22,7 @@
 
 #ifdef PY_PROC_C
 
+#include <psapi.h>
 #include <tlhelp32.h>
 
 #include "../py_proc.h"
@@ -158,6 +159,16 @@ _py_proc__get_modules(py_proc_t * self) {
   CloseHandle(mod_hdl);
 
   return !self->sym_loaded;
+}
+
+
+// ----------------------------------------------------------------------------
+static ssize_t _py_proc__get_resident_memory(py_proc_t * self) {
+  PROCESS_MEMORY_COUNTERS mem_info;
+
+  return GetProcessMemoryInfo((HANDLE) self->pid, &mem_info, sizeof(mem_info))
+    ? mem_info.WorkingSetSize
+    : -1;
 }
 
 

--- a/test/sleepy.py
+++ b/test/sleepy.py
@@ -8,6 +8,6 @@ def cpu_bound():
 
 
 if __name__ == "__main__":
-    for n in range(10):
+    for n in range(2):
         cpu_bound()
-        time.sleep(.9)
+        time.sleep(1)

--- a/test/target34.py
+++ b/test/target34.py
@@ -2,10 +2,14 @@
 
 import threading
 
+
 def keep_cpu_busy():
     a = []
-    for i in range(30000000):
+    for i in range(10000000):
         a.append(i)
+        if i % 100000 == 0:
+            print("Unwanted output {}".format(i))
+
 
 if __name__ == "__main__":
     threading.Thread(target=keep_cpu_busy).start()

--- a/test/target34.py
+++ b/test/target34.py
@@ -5,7 +5,7 @@ import threading
 
 def keep_cpu_busy():
     a = []
-    for i in range(1000000):
+    for i in range(2000000):
         a.append(i)
         if i % 100000 == 0:
             print("Unwanted output " + str(i))

--- a/test/target34.py
+++ b/test/target34.py
@@ -8,7 +8,7 @@ def keep_cpu_busy():
     for i in range(10000000):
         a.append(i)
         if i % 100000 == 0:
-            print("Unwanted output {}".format(i))
+            print("Unwanted output " + str(i))
 
 
 if __name__ == "__main__":

--- a/test/target34.py
+++ b/test/target34.py
@@ -5,7 +5,7 @@ import threading
 
 def keep_cpu_busy():
     a = []
-    for i in range(10000000):
+    for i in range(1000000):
         a.append(i)
         if i % 100000 == 0:
             print("Unwanted output " + str(i))

--- a/test/test.bats
+++ b/test/test.bats
@@ -2,7 +2,7 @@
 
 test_case() {
   run bats test/test_$1.bats
-  echo $output
+  echo "$output"
   [ $status = 0 ]
 }
 

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -2,7 +2,7 @@ attach_austin_2_3() {
   if ! python$1 -V; then return; fi
 
   python$1 test/sleepy.py &
-  sleep 5
+  sleep 1
   run src/austin -i 100000 -t 10000 -p $!
   [ $status = 0 ]
   echo $output | grep ";? (test/sleepy.py);L13 "
@@ -12,10 +12,9 @@ attach_austin() {
   if ! python$1 -V; then return; fi
 
   python$1 test/sleepy.py &
-  sleep 5
+  sleep 1
   run src/austin -i 10000 -t 10000 -p $!
   [ $status = 0 ]
-  echo $output | grep "cpu_bound"
   echo $output | grep ";<module> (test/sleepy.py);L13 "
 }
 

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -3,7 +3,7 @@ attach_austin_2_3() {
 
   python$1 test/sleepy.py &
   sleep 5
-  run src/austin -i 1000 -t 1000 -p $!
+  run src/austin -i 100000 -t 10000 -p $!
   [ $status = 0 ]
   echo $output | grep ";? (test/sleepy.py);L13 "
 }
@@ -13,7 +13,7 @@ attach_austin() {
 
   python$1 test/sleepy.py &
   sleep 5
-  run src/austin -i 1000 -t 1000 -p $!
+  run src/austin -i 10000 -t 10000 -p $!
   [ $status = 0 ]
   echo $output | grep "cpu_bound"
   echo $output | grep ";<module> (test/sleepy.py);L13 "

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -5,7 +5,7 @@ attach_austin_2_3() {
   sleep 1
   run src/austin -i 100000 -t 10000 -p $!
   [ $status = 0 ]
-  echo $output | grep ";? (test/sleepy.py);L13 "
+  echo "$output" | grep ";? (test/sleepy.py);L13 "
 }
 
 attach_austin() {
@@ -15,7 +15,7 @@ attach_austin() {
   sleep 1
   run src/austin -i 10000 -t 10000 -p $!
   [ $status = 0 ]
-  echo $output | grep ";<module> (test/sleepy.py);L13 "
+  echo "$output" | grep ";<module> (test/sleepy.py);L13 "
 }
 
 @test "Test Austin with Python 2.3" {

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -3,10 +3,15 @@
 invoke_austin() {
   if ! python$1 -V; then return; fi
 
-  run src/austin -i 1000 -t 1000 python$1 test/target34.py
+  run src/austin -i 10000 -t 10000 python$1 test/target34.py
 	[ $status = 0 ]
   echo $output | grep "keep_cpu_busy (test/target34.py);L7 "
   echo $output | grep "keep_cpu_busy (test/target34.py);L8 "
+
+  # Memory profiling
+  run src/austin -i 100000 -t 10000 -m python$1 test/target34.py
+	[ $status = 0 ]
+  echo $output | grep "keep_cpu_busy (test/target34.py);L"
 }
 
 @test "Test Austin with Python 2.3" {
@@ -48,3 +53,7 @@ invoke_austin() {
 @test "Test Austin with Python 3.7" {
   invoke_austin "3.7"
 }
+
+# @test "Test Austin with Python 3.8" {
+#   invoke_austin "3.8"
+# }

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -5,13 +5,19 @@ invoke_austin() {
 
   run src/austin -i 10000 -t 10000 python$1 test/target34.py
 	[ $status = 0 ]
-  echo $output | grep "keep_cpu_busy (test/target34.py);L7 "
-  echo $output | grep "keep_cpu_busy (test/target34.py);L8 "
+  echo $output | grep "keep_cpu_busy (test/target34.py);L"
+  ! echo $output | grep "Unwanted"
 
   # Memory profiling
-  run src/austin -i 100000 -t 10000 -m python$1 test/target34.py
+  run src/austin -i 10000 -t 10000 -m python$1 test/target34.py
 	[ $status = 0 ]
   echo $output | grep "keep_cpu_busy (test/target34.py);L"
+
+  # Output file
+  run src/austin -i 100000 -t 10000 -o /tmp/austin_out.txt python$1 test/target34.py
+	[ $status = 0 ]
+  echo $output | grep "Unwanted"
+  cat /tmp/austin_out.txt | grep "keep_cpu_busy (test/target34.py);L"
 }
 
 @test "Test Austin with Python 2.3" {

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -25,6 +25,7 @@ invoke_austin() {
 }
 
 @test "Test Austin with Python 2.4" {
+  skip
 	invoke_austin "2.4"
 }
 

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -5,18 +5,18 @@ invoke_austin() {
 
   run src/austin -i 10000 -t 10000 python$1 test/target34.py
 	[ $status = 0 ]
-  echo $output | grep "keep_cpu_busy (test/target34.py);L"
-  ! echo $output | grep "Unwanted"
+  echo "$output" | grep "keep_cpu_busy (test/target34.py);L"
+  ! echo "$output" | grep "Unwanted"
 
   # Memory profiling
   run src/austin -i 10000 -t 10000 -m python$1 test/target34.py
 	[ $status = 0 ]
-  echo $output | grep "keep_cpu_busy (test/target34.py);L"
+  echo "$output" | grep "keep_cpu_busy (test/target34.py);L"
 
   # Output file
   run src/austin -i 100000 -t 10000 -o /tmp/austin_out.txt python$1 test/target34.py
 	[ $status = 0 ]
-  echo $output | grep "Unwanted"
+  echo "$output" | grep "Unwanted"
   cat /tmp/austin_out.txt | grep "keep_cpu_busy (test/target34.py);L"
 }
 

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -9,7 +9,7 @@ invoke_austin() {
     --show-leak-kinds=all \
     --errors-for-leak-kinds=all \
     --track-fds=yes \
-    src/austin -i 1000 -t 1000 python$1 test/target34.py
+    src/austin -i 100000 -t 10000 python$1 test/target34.py
   echo "Exit code:" $status
   echo $output
 	[ $status = 0 ]

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -11,7 +11,7 @@ invoke_austin() {
     --track-fds=yes \
     src/austin -i 100000 -t 10000 python$1 test/target34.py
   echo "Exit code:" $status
-  echo $output
+  echo "$output"
 	[ $status = 0 ]
 }
 


### PR DESCRIPTION
### Description of the Change

This change brings memory profiling capabilities to Austin. The new switch -m can be used to output memory usage metrics instead of timing information. The new switch -f can be used to output a full set of metrics including timings, memory allocations, and memory releases.

### Alternate Designs

Given the challenges presented by statistical profilers, every design choice was going to be riddled with some accuracy issues of sorts. It was decided to use resident memory as the most useful and reliable memory usage metrics as it represents the actual size taken by the process in physical memory.

### Regressions

I expect a very minimal performance impact due to the branching logic required in order to output the requested metrics. This should be totally compensated by branching prediction available on most common CPU architecture these days.

No software regressions expected.

### Verification Process

Test suite to be enhanced.
