### PR TITLE
Fix current thread de-referencing in Python 3.7+

### DIFF
--- a/src/austin.c
+++ b/src/austin.c
@@ -118,6 +118,12 @@ _py_proc__sample(py_proc_t * py_proc) {
     while (py_thread != NULL) {
       if (pargs.memory) {
         mem_delta = 0;
+        if (py_proc->py_runtime_raddr != NULL && current_thread == (void *) -1) {
+          if (py_proc__find_current_thread_offset(py_proc, py_thread->raddr.addr))
+            continue;
+          else
+            current_thread = py_proc__get_current_thread_state_raddr(py_proc);
+        }
         if (py_thread->raddr.addr == current_thread) {
           mem_delta = py_proc__get_memory_delta(py_proc);
           log_t("Thread %lx holds the GIL", py_thread->tid);

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -154,6 +154,19 @@ py_proc__wait(py_proc_t *);
 
 
 /**
+ * Find the offset of the pointer to the current thread structure from the
+ * beginning of the _PyRuntimeState structure (Python 3.7+ only).
+ *
+ * @param py_proc_t * the process object.
+ * @param void      * the remote address of the thread to use for comparison.
+ *
+ * @return 0 on success, 1 otherwise.
+ */
+int
+py_proc__find_current_thread_offset(py_proc_t * self, void * thread_raddr);
+
+
+/**
  * Check if the process is still running
  *
  * @param py_proc_t * the process object.

--- a/src/version.c
+++ b/src/version.c
@@ -125,17 +125,7 @@ python_v python_v3_7 = {
   PY_THREAD   (PyThreadState3_4),
   PY_UNICODE  (3),
   PY_BYTES    (3),
-  #if defined PL_LINUX
-    #if defined __i386__
-    PY_RUNTIME  (0x31c)
-    #elif defined __x86_64__
-    PY_RUNTIME  (0x570)
-    #endif
-  #elif defined PL_WIN
-  PY_RUNTIME  (0x528)
-  #elif defined PL_MACOS
-  PY_RUNTIME  (0x5a0)
-  #endif
+  PY_RUNTIME  (0)
 };
 
 

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -80,6 +80,7 @@ attach_austin() {
 
 
 @test "Test Austin with Python 2.3" {
+  skip "Disabled"
 	attach_austin_2_3 "2.3"
 }
 

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -3,23 +3,33 @@ attach_austin_2_3() {
 
   for i in {1..3}
   do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Standard profiling"
     python$1 test/sleepy.py &
     sleep 1
     run src/austin -i 100000 -t 10000 -p $!
+    echo "       Exit code: $status"
     [ $status = 0 ]
     if ! echo "$output" | grep -q ";? (test/sleepy.py);L13 "
     then
       continue
     fi
-    echo "Python $1: Standard profiling OK"
+    echo "       Output: OK"
 
+    # -------------------------------------------------------------------------
+
+    echo "  :: Memory profiling"
     python$1 test/sleepy.py &
     sleep 1
     run src/austin -mi 100 -t 10000 -p $!
+    echo "       Exit code: $status"
     [ $status = 0 ]
     if echo "$output" | grep -q "cpu_bound"
     then
-      echo "Python $1: Memory profiling OK"
+      echo "       Output: OK"
       return
     fi
   done
@@ -32,29 +42,42 @@ attach_austin() {
 
   for i in {1..3}
   do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Standard profiling"
     python$1 test/sleepy.py &
     sleep 1
     run src/austin -i 10000 -t 10000 -p $!
+    echo "       Exit code: $status"
     [ $status = 0 ]
     if ! echo "$output" | grep -q ";<module> (test/sleepy.py);L13 "
     then
       continue
     fi
-    echo "Python $1: Standard profiling OK"
+    echo "       Output: OK"
+
+    # -------------------------------------------------------------------------
 
     python$1 test/sleepy.py &
     sleep 1
     run src/austin -mi 100 -t 10000 -p $!
+    echo "       Exit code: $status"
     [ $status = 0 ]
     if echo "$output" | grep -q "cpu_bound"
     then
-      echo "Python $1: Memory profiling OK"
+      echo "       Output: OK"
       return
     fi
   done
 
   false
 }
+
+
+# -----------------------------------------------------------------------------
+
 
 @test "Test Austin with Python 2.3" {
 	attach_austin_2_3 "2.3"

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -15,9 +15,9 @@ attach_austin_2_3() {
 
     python$1 test/sleepy.py &
     sleep 1
-    run src/austin -mi 100000 -t 10000 -p $!
+    run src/austin -mi 100 -t 10000 -p $!
     [ $status = 0 ]
-    if echo "$output" | grep -q ";? (test/sleepy.py);L"
+    if echo "$output" | grep -q "cpu_bound"
     then
       echo "Python $1: Memory profiling OK"
       return
@@ -46,7 +46,7 @@ attach_austin() {
     sleep 1
     run src/austin -mi 100 -t 10000 -p $!
     [ $status = 0 ]
-    if echo "$output" | grep -q ";<module> (test/sleepy.py);L"
+    if echo "$output" | grep -q "cpu_bound"
     then
       echo "Python $1: Memory profiling OK"
       return

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -1,5 +1,5 @@
 attach_austin_2_3() {
-  if ! python$1 -V; then return; fi
+  if ! python$1 -V; then skip "Python $1 not found."; fi
 
   for i in {1..3}
   do
@@ -38,7 +38,7 @@ attach_austin_2_3() {
 }
 
 attach_austin() {
-  if ! python$1 -V; then return; fi
+  if ! python$1 -V; then skip "Python $1 not found."; fi
 
   for i in {1..3}
   do

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 invoke_austin() {
-  if ! python$1 -V; then return; fi
+  if ! python$1 -V; then skip "Python $1 not found."; fi
 
   for i in {1..3}
   do
@@ -58,7 +58,7 @@ invoke_austin() {
 }
 
 @test "Test Austin with Python 2.4" {
-  skip
+  skip "Disabled"
 	invoke_austin "2.4"
 }
 

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -5,37 +5,53 @@ invoke_austin() {
 
   for i in {1..3}
   do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Standard profiling"
     run src/austin -i 10000 -t 10000 python$1 test/target34.py
+    echo "       Exit code: $status"
   	[ $status = 0 ]
     echo "$output" | grep -q "keep_cpu_busy (test/target34.py);L"
     if echo "$output" | grep -q "Unwanted"
     then
       continue
     fi
-    echo "Python $1: Standard profiling OK"
+    echo "       Output: OK"
 
-    # Memory profiling
+    # -------------------------------------------------------------------------
+
+    echo "  :: Memory profiling"
     run src/austin -i 10000 -t 10000 -m python$1 test/target34.py
+    echo "       Exit code: $status"
   	[ $status = 0 ]
     if ! echo "$output" | grep -q "keep_cpu_busy (test/target34.py);L"
     then
       continue
     fi
-    echo "Python $1: Memory profiling OK"
+    echo "       Output: OK"
 
-    # Output file
+    # -------------------------------------------------------------------------
+
+    echo "  :: Output file"
     run src/austin -i 100000 -t 10000 -o /tmp/austin_out.txt python$1 test/target34.py
+    echo "       Exit code: $status"
   	[ $status = 0 ]
     echo "$output" | grep -q "Unwanted"
     if cat /tmp/austin_out.txt | grep -q "keep_cpu_busy (test/target34.py);L"
     then
-      echo "Python $1: Output file OK"
+      echo "       Output: OK"
       return
     fi
   done
 
   false
 }
+
+
+# -----------------------------------------------------------------------------
+
 
 @test "Test Austin with Python 2.3" {
 	invoke_austin "2.3"

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 invoke_austin() {
-  if ! python$1 -V; then return; fi
+  if ! python$1 -V; then skip "Python $1 not found."; fi
 
   for i in {1..3}
   do

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -38,6 +38,7 @@ invoke_austin() {
 }
 
 @test "Test Austin with Python 2.4" {
+  skip "Disabled"
 	invoke_austin "2.4"
 }
 

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -5,6 +5,11 @@ invoke_austin() {
 
   for i in {1..3}
   do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Valgrind test"
     run valgrind \
       --error-exitcode=42 \
       --leak-check=full \
@@ -12,7 +17,8 @@ invoke_austin() {
       --errors-for-leak-kinds=all \
       --track-fds=yes \
       src/austin -i 100000 -t 10000 python$1 test/target34.py
-    echo "Exit code:" $status
+    echo "       Exit code: $status"
+    echo "       Valgrind report: <"
     echo "$output"
   	if [ $status = 0 ]
     then
@@ -22,6 +28,10 @@ invoke_austin() {
 
   false
 }
+
+
+# -----------------------------------------------------------------------------
+
 
 @test "Test Austin with Python 2.3" {
 	invoke_austin "2.3"


### PR DESCRIPTION
### Description of the Change

The offset of the _PyRuntime.gilstate.tstate_current field varies across Python patch releases and therefore needs to be determined at runtime. This affects the new memory profiling mode.

### Alternate Designs

Given the granularity on minor releases of the versioning support built into Austin, the offset cannot be hard-coded and therefore needs to be determined at runtime.

### Regressions

The bug affects the new memory profiling mode. When sampling at low frequencies, more samples than initially anticipated could be lost while Austin tries to determine the offset of the _PyRuntime.gilstate.tstate_current field.

### Verification Process

Standard test suite.