### PR TITLE
Add multi-process support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,5 +34,6 @@ austin_SOURCES = \
   stats.c        \
   py_code.c      \
   py_frame.c     \
+	py_proc_list.c \
   py_proc.c      \
   py_thread.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,6 @@ austin_SOURCES = \
   stats.c        \
   py_code.c      \
   py_frame.c     \
-	py_proc_list.c \
+  py_proc_list.c \
   py_proc.c      \
   py_thread.c

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -30,7 +30,7 @@
 
 
 #define DEFAULT_SAMPLING_INTERVAL    100
-#define DEFAULT_INIT_RETRY_CNT      1000
+#define DEFAULT_INIT_RETRY_CNT       100
 
 const char SAMPLE_FORMAT_NORMAL[]      = ";%s (%s);L%d";
 const char SAMPLE_FORMAT_ALTERNATIVE[] = ";%s (%s:%d)";

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -23,7 +23,6 @@
 #define ARGPARSE_C
 
 #include <limits.h>
-#include <sys/types.h>
 
 #include "argparse.h"
 #include "austin.h"

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -23,8 +23,6 @@
 #define ARGPARSE_C
 
 #include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <sys/types.h>
 
 #include "argparse.h"
@@ -51,6 +49,7 @@ parsed_args_t pargs = {
   /* memory              */ 0,
   /* output_file         */ NULL,
   /* output_filename     */ NULL,
+  /* children            */ 0,
 };
 
 static int exec_arg = 0;
@@ -132,6 +131,10 @@ static struct argp_option options[] = {
   {
     "output",       'o', "FILE",        0,
     "Specify an output file for the collected samples."
+  },
+  {
+    "children",     'C', NULL,          0,
+    "Attach to child processes."
   },
   #ifndef PL_LINUX
   {
@@ -218,6 +221,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
       argp_error(state, "Unable to create the given output file.");
     }
     pargs.output_filename = arg;
+    break;
+
+  case 'C':
+    pargs.children = 1;
     break;
 
   case ARGP_KEY_ARG:
@@ -390,6 +397,7 @@ static const char * help_msg = \
 "Austin -- A frame stack sampler for Python.\n"
 "\n"
 "  -a, --alt-format           Alternative collapsed stack sample format.\n"
+"  -C, --children             Attach to child processes.\n"
 "  -e, --exclude-empty        Do not output samples of threads with no frame\n"
 "                             stacks.\n"
 "  -f, --full                 Produce the full set of metrics (time +mem -mem).\n"
@@ -411,8 +419,9 @@ static const char * help_msg = \
 "Report bugs to <https://github.com/P403n1x87/austin/issues>.\n";
 
 static const char * usage_msg = \
-"Usage: austin [-aes?V] [-i n_us] [-p PID] [-t n_ms] [--alt-format]\n"
-"            [--exclude-empty] [--interval=n_us] [--pid=PID] [--sleepless]\n"
+"Usage: austin [-aCefms?V] [-i n_us] [-o FILE] [-p PID] [-t n_ms] [--alt-format]\n"
+"            [--children] [--exclude-empty] [--full] [--interval=n_us]\n"
+"            [--memory] [--output=FILE] [--pid=PID] [--sleepless]\n"
 "            [--timeout=n_ms] [--help] [--usage] [--version] command [ARG...]\n";
 
 
@@ -477,6 +486,10 @@ cb(const char opt, const char * arg) {
       return ARG_INVALID_VALUE;
     }
     pargs.output_filename = (char *) arg;
+    break;
+
+  case 'C':
+    pargs.children = 1;
     break;
 
   case '?':

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -23,6 +23,7 @@
 #ifndef ARGPARSE_H
 #define ARGPARSE_H
 
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "stats.h"
@@ -38,6 +39,7 @@ typedef struct {
   int       memory;
   FILE    * output_file;
   char    * output_filename;
+  int       children;
 } parsed_args_t;
 
 

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #include "stats.h"
 

--- a/src/austin.c
+++ b/src/austin.c
@@ -167,7 +167,7 @@ int main(int argc, char ** argv) {
       goto finally;
     }
   } else {
-    if (py_proc__attach(py_proc, pargs.attach_pid)) {
+    if (py_proc__attach(py_proc, pargs.attach_pid) && !pargs.children) {
       retval = EPROCATTACH;
       goto finally;
     }

--- a/src/austin.c
+++ b/src/austin.c
@@ -109,7 +109,10 @@ do_child_processes(py_proc_t * py_proc) {
   // Austin to them.
   if (!py_proc__is_running(py_proc)) {
     log_d("Parent process is not running. Trying with its children.");
-    pid_t ppid = py_proc->pid;  // Store the PID before being deleted by the update.
+
+    // Store the PID before it gets deleted by the update.
+    pid_t ppid = py_proc->pid;
+
     py_proc_list__update(list);
     py_proc_list__add_proc_children(list, ppid);
   }

--- a/src/austin.c
+++ b/src/austin.c
@@ -37,141 +37,113 @@
 
 #include "py_frame.h"
 #include "py_proc.h"
+#include "py_proc_list.h"
 #include "py_thread.h"
 
 
-static ctime_t t_sample;  // Checkmark for sampling duration calculation
+// ---- TIMING ----------------------------------------------------------------
+
+static ctime_t _sample_timestamp;
 
 
-// ---- HELPERS ---------------------------------------------------------------
-
-// ----------------------------------------------------------------------------
-static int
-_print_collapsed_stack(py_thread_t * thread, ctime_t delta, ssize_t mem_delta) {
-  if (!pargs.full && pargs.memory && mem_delta <= 0)
-    return 1;
-
-  if (thread->invalid) {
-    fprintf(pargs.output_file, "Thread %lx;Bad sample %ld\n", thread->tid, delta);
-    stats_count_error();
-    return 0;
-  }
-
-  py_frame_t * frame = py_thread__first_frame(thread);
-
-  if (frame == NULL && pargs.exclude_empty)
-    // Skip if thread has no frames and we want to exclude empty threads
-    return 1;
-
-  // Group entries by thread.
-  fprintf(pargs.output_file, "Thread %lx", thread->tid);
-
-  // Append frames
-  while(frame != NULL) {
-    py_code_t * code = frame->code;
-    if (pargs.sleepless && strstr(code->scope, "wait") != NULL) {
-      delta = 0;
-      fprintf(pargs.output_file, ";<idle>");
-      break;
-    }
-    fprintf(pargs.output_file, pargs.format, code->scope, code->filename, code->lineno);
-
-    frame = frame->next;
-  }
-
-  // Finish off sample with the metric(s)
-  if (pargs.full) {
-    fprintf(pargs.output_file, " %lu %ld %ld\n",
-      delta, mem_delta >= 0 ? mem_delta : 0, mem_delta < 0 ? mem_delta : 0
-    );
-  }
-  else {
-    if (pargs.memory)
-      fprintf(pargs.output_file, " %ld\n", mem_delta);
-    else
-      fprintf(pargs.output_file, " %lu\n", delta);
-  }
-
-  return 0;
-}
+static void
+timer_start(void) {
+  _sample_timestamp = gettime();
+} /* timer_start */
 
 
-// ----------------------------------------------------------------------------
-static int
-_py_proc__sample(py_proc_t * py_proc) {
-  ctime_t   delta     = gettime() - t_sample;
-  ssize_t   mem_delta = 0;
-  void    * current_thread;
-  int       sample_printed = 0;
-  error = EOK;
+static void
+timer_stop(void) {
+  ctime_t delta = gettime() - _sample_timestamp;
 
-  PyInterpreterState is;
-  if (py_proc__get_type(py_proc, py_proc->is_raddr, is) != 0)
-    return 1;
+  // Record stats
+  stats_check_duration(delta, pargs.t_sampling_interval);
 
-  if (is.tstate_head != NULL) {
-    raddr_t       raddr        = { .pid = py_proc->pid, .addr = is.tstate_head };
-    py_thread_t * py_thread    = py_thread_new_from_raddr(&raddr);
-    py_thread_t * first_thread = py_thread;
-
-    if (pargs.memory) {
-      // Use the current thread to determine which thread is manipulating memory
-      current_thread = py_proc__get_current_thread_state_raddr(py_proc);
-    }
-
-    while (py_thread != NULL) {
-      if (pargs.memory) {
-        mem_delta = 0;
-        if (py_proc->py_runtime_raddr != NULL && current_thread == (void *) -1) {
-          if (py_proc__find_current_thread_offset(py_proc, py_thread->raddr.addr))
-            continue;
-          else
-            current_thread = py_proc__get_current_thread_state_raddr(py_proc);
-        }
-        if (py_thread->raddr.addr == current_thread) {
-          mem_delta = py_proc__get_memory_delta(py_proc);
-          log_t("Thread %lx holds the GIL", py_thread->tid);
-        }
-      }
-      sample_printed = !_print_collapsed_stack(py_thread, delta, mem_delta >> 10);
-      py_thread = py_thread__next(py_thread);
-    }
-
-    py_thread__destroy(first_thread);
-
-    if (error != EOK) {
-      fprintf(pargs.output_file, "Bad sample %ld\n", delta);
-      stats_count_error();
-    }
-  }
-
-  t_sample += delta;
-  return !sample_printed;
-}
+  // Pause if sampling took less than the sampling interval.
+  if (delta < pargs.t_sampling_interval)
+    usleep(pargs.t_sampling_interval - delta);
+} /* timer_stop */
 
 
 // ---- SIGNAL HANDLING -------------------------------------------------------
 
 static int interrupt = 0;
 
+
 static void
 signal_callback_handler(int signum)
 {
   if (signum == SIGINT)
     interrupt++;
-}
+} /* signal_callback_handler */
+
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+void
+do_single_process(py_proc_t * py_proc) {
+  while(py_proc__is_running(py_proc) && !interrupt) {
+    timer_start();
+    {
+      py_proc__sample(py_proc);
+    }
+    timer_stop();
+  }
+
+  if (!interrupt)
+    py_proc__wait(py_proc);
+
+  py_proc__destroy(py_proc);
+} /* do_single_process */
+
+
+// ----------------------------------------------------------------------------
+void
+do_child_processes(py_proc_t * py_proc) {
+  py_proc_list_t * list = py_proc_list_new(py_proc);
+  if (list == NULL)
+    return;
+
+  // If the parent process is not running maybe it wasn't a Python
+  // process. However, its children might be, so we attempt to attach
+  // Austin to them.
+  if (!py_proc__is_running(py_proc)) {
+    log_d("Parent process is not running. Trying with its children.");
+    pid_t ppid = py_proc->pid;  // Store the PID before being deleted by the update.
+    py_proc_list__update(list);
+    py_proc_list__add_proc_children(list, ppid);
+  }
+
+  while (!py_proc_list__is_empty(list) && !interrupt) {
+    timer_start();
+    {
+      py_proc_list__update(list);
+      py_proc_list__sample(list);
+    }
+    timer_stop();
+  }
+
+  if (!interrupt) {
+    py_proc_list__update(list);
+    py_proc_list__wait(list);
+  }
+
+  py_proc_list__destroy(list);
+} /* do_child_processes */
 
 
 // ---- MAIN ------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
 int main(int argc, char ** argv) {
-  int code = 0;
+  int retval = 0;
 
   int exec_arg = parse_args(argc, argv);
 
-  if (exec_arg == 0 && pargs.attach_pid == 0)
-    return -1;
+  if (exec_arg == 0 && pargs.attach_pid == 0) {
+    retval = -1;
+    goto release;
+  }
 
   logger_init();
   log_header();
@@ -179,81 +151,66 @@ int main(int argc, char ** argv) {
 
   if (pargs.attach_pid == 0 && argv[exec_arg] == NULL) {
     log_f("Null command and invalid PID. Austin doesn't know what to do.");
-    code = EPROC;
+    retval = EPROC;
+    goto finally;
   }
 
-  else {
-    error = EOK;
+  py_proc_t * py_proc = py_proc_new();
+  if (py_proc == NULL) {
+    retval = EPROC;
+    goto finally;
+  }
 
-    py_proc_t * py_proc = py_proc_new();
-    if (py_proc == NULL)
-      return EPROC;
-
-    if (pargs.attach_pid == 0) {
-      if (py_proc__start(py_proc, argv[exec_arg], (char **) &argv[exec_arg]) != 0)
-        code = EPROCFORK;
-    } else {
-      if (py_proc__attach(py_proc, pargs.attach_pid) != 0)
-        code = EPROCATTACH;
+  if (pargs.attach_pid == 0) {
+    if (py_proc__start(py_proc, argv[exec_arg], (char **) &argv[exec_arg])) {
+      retval = EPROCFORK;
+      goto finally;
     }
-
-    if (code == EOK) {
-      if (py_proc->is_raddr == NULL)
-        code = EPROC;
-
-      else {
-        // Register signal handler for Ctrl+C
-        signal(SIGINT, signal_callback_handler);
-
-        // Redirect output to STDOUT if not output file was given.
-        if (pargs.output_file == NULL)
-          pargs.output_file = stdout;
-        else
-          log_i("Output file: %s", pargs.output_filename);
-
-        log_i("Sampling interval: %lu usec", pargs.t_sampling_interval);
-
-        if (pargs.full) {
-          if (pargs.memory)
-            log_w("Requested full metrics. The memory switch is redundant.");
-          log_i("Producing full set of metrics (time +mem -mem).");
-          pargs.memory = 1;
-        }
-
-        stats_reset();
-
-        t_sample = gettime();  // Prime sample checkmark
-        while(py_proc__is_running(py_proc) && !interrupt) {
-          if (_py_proc__sample(py_proc))
-            continue;
-
-          stats_count_sample();
-
-          ctime_t delta = gettime() - t_sample;  // Time spent sampling
-          stats_check_duration(delta, pargs.t_sampling_interval);
-
-          if (delta < pargs.t_sampling_interval)
-            usleep(pargs.t_sampling_interval - delta);
-        }
-
-        stats_log_metrics();
-      }
-    }
-
-    if (py_proc != NULL) {
-      if (!interrupt)
-        py_proc__wait(py_proc);
-      py_proc__destroy(py_proc);
+  } else {
+    if (py_proc__attach(py_proc, pargs.attach_pid)) {
+      retval = EPROCATTACH;
+      goto finally;
     }
   }
 
+  // Register signal handler for Ctrl+C
+  signal(SIGINT, signal_callback_handler);
+
+  // Redirect output to STDOUT if not output file was given.
+  if (pargs.output_file == NULL)
+    pargs.output_file = stdout;
+  else
+    log_i("Output file: %s", pargs.output_filename);
+
+  log_i("Sampling interval: %lu usec", pargs.t_sampling_interval);
+
+  if (pargs.full) {
+    if (pargs.memory)
+      log_w("Requested full metrics. The memory switch is redundant.");
+    log_i("Producing full set of metrics (time +mem -mem).");
+    pargs.memory = 1;
+  }
+
+  stats_reset();
+  {
+    if (pargs.children)
+      do_child_processes(py_proc);
+    else
+      do_single_process(py_proc);
+  }
+  stats_log_metrics();
+
+finally:
+  if (retval && error != EOK)
+    log_i("Last error code: %d", error);
+  log_footer();
+  logger_close();
+
+release:
   if (pargs.output_file != NULL && pargs.output_file != stdout) {
     fclose(pargs.output_file);
     log_d("Output file closed.");
   }
 
-  log_footer();
-  logger_close();
-
-  return code;
-}
+  return retval;
+} /* main */

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -76,7 +76,8 @@ _get_base_64(Elf64_Ehdr * ehdr, void * elf_map)
       return phdr->p_vaddr - phdr->p_vaddr % phdr->p_align;
   }
   return UINT64_MAX;
-}
+} /* _get_base_64 */
+
 
 static int
 _py_proc__analyze_elf64(py_proc_t * self) {
@@ -151,7 +152,7 @@ _py_proc__analyze_elf64(py_proc_t * self) {
   close(fd);
 
   return !symbols;
-}
+} /* _py_proc__analyze_elf64 */
 
 
 // ----------------------------------------------------------------------------
@@ -164,7 +165,8 @@ _get_base_32(Elf32_Ehdr * ehdr, void * elf_map)
       return phdr->p_vaddr - phdr->p_vaddr % phdr->p_align;
   }
   return UINT32_MAX;
-}
+} /* _get_base_32 */
+
 
 static int
 _py_proc__analyze_elf32(py_proc_t * self) {
@@ -239,7 +241,7 @@ _py_proc__analyze_elf32(py_proc_t * self) {
   close(fd);
 
   return !symbols;
-}
+} /* _py_proc__analyze_elf32 */
 
 
 // ----------------------------------------------------------------------------
@@ -265,7 +267,7 @@ _py_proc__analyze_elf(py_proc_t * self) {
   default:
     return 1;
   }
-}
+} /* _py_proc__analyze_elf */
 
 
 // ----------------------------------------------------------------------------
@@ -381,11 +383,12 @@ _py_proc__parse_maps_file(py_proc_t * self) {
     (self->bin_path == NULL && self->lib_path == NULL) ||
     maps_flag != (HEAP_MAP | BSS_MAP)
   );
-}
+} /* _py_proc__parse_maps_file */
 
 
 // ----------------------------------------------------------------------------
-static ssize_t _py_proc__get_resident_memory(py_proc_t * self) {
+static ssize_t
+_py_proc__get_resident_memory(py_proc_t * self) {
   FILE * statm = fopen(self->extra->statm_file, "rb");
   if (statm == NULL) {
     error = EPROCVM;
@@ -399,7 +402,7 @@ static ssize_t _py_proc__get_resident_memory(py_proc_t * self) {
   fclose(statm);
 
   return resident * self->extra->page_size;
-}
+} /* _py_proc__get_resident_memory */
 
 
 // ----------------------------------------------------------------------------
@@ -411,7 +414,6 @@ _py_proc__init(py_proc_t * self) {
     _py_proc__analyze_elf(self)
   ) return 1;
 
-  self->extra = (proc_extra_info *) malloc(sizeof(proc_extra_info));
   self->extra->page_size = getpagesize();
   log_d("Page size: %ld", self->extra->page_size);
 
@@ -420,7 +422,7 @@ _py_proc__init(py_proc_t * self) {
   self->last_resident_memory = _py_proc__get_resident_memory(self);
 
   return 0;
-}
+} /* _py_proc__init */
 
 
 #endif

--- a/src/logging.h
+++ b/src/logging.h
@@ -23,6 +23,11 @@
 #ifndef LOGGING_H
 #define LOGGING_H
 
+#ifdef TRACE
+#define DEBUG
+#endif
+
+
 #define log_header() log_i("============================  AUSTIN  ╦̵̵̿╤─ ҉ ~ •  ============================")
 #define log_footer() log_i("============================================================================")
 
@@ -43,7 +48,7 @@ log_w(const char *, ...);
 void
 log_i(const char *, ...);
 
-#if defined(DEBUG) || defined(TRACE)
+#ifdef DEBUG
 void
 log_d(const char *, ...);
 #else

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -64,6 +64,7 @@ struct _proc_extra_info {
   mach_port_t task_id;
 };
 
+
 // ----------------------------------------------------------------------------
 static int
 _py_proc__analyze_macho64(py_proc_t * self, void * map) {
@@ -273,7 +274,7 @@ static mach_port_t
 pid_to_task(pid_t pid) {
   mach_port_t task;
   if (task_for_pid(mach_task_self(), pid, &task) != KERN_SUCCESS) {
-    log_f("Insufficient permissions to call task_for_pid.");
+    log_e("Insufficient permissions to call task_for_pid.");
     error = EPROCPERM;
     return 0;
   }

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -367,9 +367,6 @@ _py_proc__init(py_proc_t * self) {
   if (self == NULL)
     return 1;
 
-  if (self->extra == NULL)
-    self->extra = (proc_extra_info *) malloc(sizeof(proc_extra_info));
-
   return _py_proc__get_maps(self);
 }
 

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -825,7 +825,10 @@ py_proc__is_running(py_proc_t * self) {
   DWORD ec;
   return GetExitCodeProcess(self->extra->h_proc, &ec) ? ec : -1;
 
-  #else                                                               /* UNIX */
+  #elif defined PL_MACOS                                             /* MACOS */
+  return pid_to_task(self->pid) != 0;
+
+  #else                                                              /* LINUX */
   kill(self->pid, 0);
   return errno == ESRCH ? 0 : 1;
   #endif

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -802,6 +802,9 @@ py_proc__find_current_thread_offset(py_proc_t * self, void * thread_raddr) {
 // ----------------------------------------------------------------------------
 int
 py_proc__is_running(py_proc_t * self) {
+  if (self->is_raddr == NULL)
+    return 0;
+  
   #ifdef PL_WIN                                                        /* WIN */
   DWORD ec;
   return GetExitCodeProcess((HANDLE) self->pid, &ec) ? ec : -1;

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -24,6 +24,11 @@
 #define PY_PROC_H
 
 
+#include <sys/types.h>
+
+#include "stats.h"
+
+
 typedef struct {
   void    * base;
   ssize_t   size;
@@ -61,6 +66,9 @@ typedef struct {
   void          * interp_head_raddr;
 
   void          * is_raddr;
+
+  // Temporal profiling support
+  ctime_t         timestamp;
 
   // Memory profiling support
   ssize_t         last_resident_memory;
@@ -181,9 +189,20 @@ py_proc__is_running(py_proc_t *);
  * Get the memory size delta since last call.
  *
  * @param py_proc_t * the process object.
+ *
+ * @return the computed memory usage delta in KB.
  */
 ssize_t
 py_proc__get_memory_delta(py_proc_t *);
+
+
+/**
+ * Sample the frame stack of each thread of the given Python process.
+ *
+ * @param  py_proc_t *  self.
+ */
+void
+py_proc__sample(py_proc_t *);
 
 
 /**

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -1,0 +1,265 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "platform.h"
+
+#ifdef PL_LINUX
+#include <dirent.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "logging.h"
+
+#include "py_proc_list.h"
+
+
+#define UPDATE_INTERVAL           100000  // 0.1s
+
+
+// ----------------------------------------------------------------------------
+static void
+_py_proc_list__add(py_proc_list_t * self, py_proc_t * py_proc) {
+  py_proc_item_t * item = (py_proc_item_t *) malloc(sizeof(py_proc_item_t));
+  if (item == NULL)
+    return;
+
+  // Insert at the beginning of the list
+  item->py_proc = py_proc;
+
+  item->next = self->first;
+  item->prev = NULL;
+
+  if (self->first)
+    self->first->prev = item;
+
+  self->first = item;
+
+  // Update index table.
+  self->index[py_proc->pid] = py_proc;
+
+  self->count++;
+
+  log_d("Added process with PID %d (total number of processes: %d)", py_proc->pid, self->count);
+}
+
+
+// ----------------------------------------------------------------------------
+static int
+_py_proc_list__has_pid(py_proc_list_t * self, pid_t pid) {
+  return self->index[pid] != NULL;
+}
+
+
+// ----------------------------------------------------------------------------
+static void
+_py_proc_list__remove(py_proc_list_t * self, py_proc_item_t * item) {
+  #ifdef DEBUG
+  pid_t pid = item->py_proc->pid;
+  #endif
+
+  self->index[item->py_proc->pid] = NULL;
+
+  if (item == self->first)
+    self->first = item->next;
+
+  if (item->next)
+    item->next->prev = item->prev;
+
+  if (item->prev)
+    item->prev->next = item->next;
+
+  py_proc__destroy(item->py_proc);
+  free(item);
+
+  self->count--;
+
+  log_d("Removed process with PID %d. Items left: %d", pid, self->count);
+}
+
+
+// ----------------------------------------------------------------------------
+py_proc_list_t *
+py_proc_list_new(py_proc_t * parent_py_proc) {
+  py_proc_list_t * list = (py_proc_list_t *) calloc(1, sizeof(py_proc_list_t));
+  if (list == NULL)
+    return NULL;
+
+  FILE * pid_max_file = fopen("/proc/sys/kernel/pid_max", "rb");
+  if (pid_max_file == NULL)
+    return NULL;
+
+  int has_pid_max = (fscanf(pid_max_file, "%d", &(list->pids)) == 1);
+  fclose(pid_max_file);
+  if (!has_pid_max)
+    return NULL;
+
+  log_t("Maximum number of PIDs: %d", list->pids);
+
+  list->index = (py_proc_t **) calloc(list->pids, sizeof(py_proc_t *));
+  if (list->index == NULL)
+    return NULL;
+
+  list->pid_table = (pid_t *) calloc(list->pids, sizeof(pid_t));
+  if (list->pid_table == NULL) {
+    free(list->index);
+    return NULL;
+  }
+
+  // Add the parent process to the list.
+  _py_proc_list__add(list, parent_py_proc);
+
+  return list;
+}
+
+
+// ----------------------------------------------------------------------------
+void
+py_proc_list__add_proc_children(py_proc_list_t * self, pid_t ppid) {
+  for (register pid_t pid = 0; pid < self->max_pid; pid++) {
+    if (self->pid_table[pid] == ppid && !_py_proc_list__has_pid(self, pid)) {
+      py_proc_t * child_proc = py_proc_new();
+      if (child_proc == NULL)
+        continue;
+
+      if (py_proc__attach(child_proc, pid)) {
+        py_proc__destroy(child_proc);
+        continue;
+      }
+
+      _py_proc_list__add(self, child_proc);
+      py_proc_list__add_proc_children(self, pid);
+    }
+  }
+}
+
+
+// ----------------------------------------------------------------------------
+int
+py_proc_list__is_empty(py_proc_list_t * self) {
+  return self->first == NULL;
+}
+
+
+// ----------------------------------------------------------------------------
+void
+py_proc_list__sample(py_proc_list_t * self) {
+  log_t("Sampling from process list");
+
+  for (py_proc_item_t * item = self->first; item != NULL; item = item->next) {
+    log_t("Sampling process with PID %d", item->py_proc->pid);
+    if (py_proc__is_running(item->py_proc))
+      py_proc__sample(item->py_proc);
+  }
+}
+
+
+// ----------------------------------------------------------------------------
+void
+py_proc_list__update(py_proc_list_t * self) {
+  ctime_t now = gettime();
+  if (now - self->timestamp < UPDATE_INTERVAL)
+    return;  // Do not update too frequently as this is an expensive operation.
+
+  #ifdef PL_LINUX                                                    /* LINUX */
+  char stat_path[32];
+  char buffer[1024];
+  struct dirent *ent;
+
+  memset(self->pid_table, 0, self->pids * sizeof(pid_t));
+  self->max_pid = 0;
+
+  DIR * proc_dir = opendir("/proc");
+  {
+    for (;;) {
+      // This code is inspired by the ps util
+      ent = readdir(proc_dir);
+      if (!ent || !ent->d_name) break;
+      if ((*ent->d_name <= '0') || (*ent->d_name > '9')) continue;
+
+      unsigned long pid = strtoul(ent->d_name, NULL, 10);
+      sprintf(stat_path, "/proc/%ld/stat", pid);
+
+      FILE * stat_file = fopen(stat_path, "rb");
+      if (stat_file != NULL) {
+        fscanf(
+          stat_file, "%d %s %c %d",
+          (int *) buffer, buffer, (char *) buffer, &(self->pid_table[pid])
+        );
+
+        if (pid > self->max_pid)
+          self->max_pid = pid;
+
+        fclose(stat_file);
+      }
+    }
+  }
+  closedir(proc_dir);
+  #endif
+
+  log_t("PID table populated");
+
+  // Attach to new PIDs.
+  for (py_proc_item_t * item = self->first; item != NULL; /* item = item->next */) {
+    if (py_proc__is_running(item->py_proc)) {
+      py_proc_list__add_proc_children(self, item->py_proc->pid);
+      item = item->next;
+    }
+    else {
+      py_proc_item_t * next = item->next;
+      _py_proc_list__remove(self, item);
+      item = next;
+    }
+  }
+
+  self->timestamp = now;
+}
+
+
+// ----------------------------------------------------------------------------
+void
+py_proc_list__wait(py_proc_list_t * self) {
+  log_d("Waiting for child processes to terminate");
+
+  for (py_proc_item_t * item = self->first; item != NULL; item = item->next) {
+    if (py_proc__is_running(item->py_proc))
+      py_proc__wait(item->py_proc);
+  }
+}
+
+
+// ----------------------------------------------------------------------------
+void
+py_proc_list__destroy(py_proc_list_t * self) {
+  // Remove all items first
+  while (self->first)
+    _py_proc_list__remove(self, self->first);
+
+  if (self->index != NULL)
+    free(self->index);
+
+  if (self->pid_table != NULL)
+    free(self->pid_table);
+
+  free(self);
+}

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -26,7 +26,7 @@
 #include <dirent.h>
 #elif defined PL_MACOS
 #include <libproc.h>
-#include <sys/proc_internal.h>
+#define PID_MAX 99999  // From sys/proc_internal.h
 #elif defined PL_WIN
 #include <windows.h>
 #include <tlhelp32.h>

--- a/src/py_proc_list.h
+++ b/src/py_proc_list.h
@@ -1,0 +1,126 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef PY_PROC_LIST_H
+#define PY_PROC_LIST_H
+
+
+#include "py_proc.h"
+
+
+typedef struct _py_proc_item {
+  py_proc_t            * py_proc;
+  struct _py_proc_item * next;
+  struct _py_proc_item * prev;
+} py_proc_item_t;
+
+
+typedef struct {
+  int              count;      // Number of entries in the list
+  py_proc_item_t * first;      // First item in the list
+  py_proc_t     ** index;      // Index of PIDs in the list
+  pid_t          * pid_table;  // Table of pids with their parents
+  pid_t            max_pid;    // Highest seen PID in the index
+  int              pids;       // Maximum number of PIDs in the index
+  ctime_t          timestamp;  // Timestamp of the last update
+} py_proc_list_t;
+
+
+/**
+ * Constructor.
+ *
+ * This list manages the children of the given parent process.
+ *
+ * @param  py_proc_t  the parent process.
+ */
+
+py_proc_list_t *
+py_proc_list_new(py_proc_t *);
+
+
+/**
+ * Check if the list is empty.
+ *
+ * @param  py_proc_list_t  the list.
+ *
+ * @return 1 if empty; 0 otherwise.
+ */
+int
+py_proc_list__is_empty(py_proc_list_t *);
+
+
+/**
+ * Add the the children of the given process to the list.
+ *
+ * @param  py_proc_list_t  the list.
+ * @param  pid_t           the PID of the parent process.
+ */
+void
+py_proc_list__add_proc_children(py_proc_list_t *, pid_t);
+
+
+/**
+ * Sample from all the processes in the list.
+ *
+ * @param  py_proc_list_t  the list.
+ */
+void
+py_proc_list__sample(py_proc_list_t *);
+
+
+/**
+ * Update the list.
+ *
+ * Refreshes the internal PID table and adds any new children of the currently
+ * running processes in the list. Old processes that are not running anymore
+ * are removed.
+ *
+ * This method is quite expensive so it is executed no more frequently than
+ * once every 0.1s.
+ *
+ * @param  py_proc_list_t  the list.
+ */
+
+void
+py_proc_list__update(py_proc_list_t *);
+
+
+/**
+ * Wait for all the processes in the list to terminate.
+ *
+ * @param  py_proc_list_t  the list.
+ */
+
+void
+py_proc_list__wait(py_proc_list_t *);
+
+
+/**
+ * Destroy the list from memory.
+ *
+ * @param  py_proc_list_t  the list.
+ */
+void
+py_proc_list__destroy(py_proc_list_t *);
+
+
+#endif

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -23,7 +23,11 @@
 #ifndef PY_THREAD_H
 #define PY_THREAD_H
 
+#include <sys/types.h>
+
 #include "mem.h"
+#include "stats.h"
+
 #include "py_frame.h"
 
 
@@ -61,10 +65,24 @@ py_thread__first_frame(py_thread_t *);
  * Get the next thread, if any.
  *
  * @param  py_thread_t  self.
+ *
  * @return a pointer to the next py_thread_t instance.
  */
 py_thread_t *
 py_thread__next(py_thread_t *);
+
+
+/**
+ * Print the frame stack using the collapsed format.
+ *
+ * @param  py_thread_t  self.
+ * @param  ctime_t      the time delta.
+ * @param  ssize_t      the memory delta.
+ *
+ * @return 0 if the frame stack was printed, 1 otherwise.
+ */
+int
+py_thread__print_collapsed_stack(py_thread_t *, ctime_t, ssize_t);
 
 
 void

--- a/test/target.py
+++ b/test/target.py
@@ -1,5 +1,27 @@
 #!/usr/bin/env python3
 
+# This file is part of "austin" which is released under GPL.
+#
+# See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+# details.
+#
+# Sibilla is a Python ORM for the Oracle Database.
+#
+# Copyright (c) 2019 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import threading
 
 def keep_cpu_busy():

--- a/test/target34.py
+++ b/test/target34.py
@@ -1,5 +1,27 @@
 #!/usr/bin/env python3
 
+# This file is part of "austin" which is released under GPL.
+#
+# See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+# details.
+#
+# Sibilla is a Python ORM for the Oracle Database.
+#
+# Copyright (c) 2019 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import threading
 
 

--- a/test/target_mp.py
+++ b/test/target_mp.py
@@ -20,16 +20,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# source: https://lobste.rs/s/qairy5/austin_python_frame_stack_sampler_for
+
 import time
+import multiprocessing
 
 
-def cpu_bound():
-    a = []
-    for i in range(100000):
-        a.append(i)
+def fact(n):
+    f = 1
+    for i in range(1, n + 1):
+        f *= i
+    return f
+
+
+def do(N):
+    n = 1
+    for _ in range(N):
+        fact(n)
+        n += 1
 
 
 if __name__ == "__main__":
-    for n in range(2):
-        cpu_bound()
-        time.sleep(1)
+    processes = []
+    for _ in range(2):
+        process = multiprocessing.Process(target=do, args=(2000,))
+        process.start()
+        processes.append(process)
+
+    for process in processes:
+        process.join(timeout=5)

--- a/test/test.bats
+++ b/test/test.bats
@@ -10,6 +10,10 @@ test_case() {
   test_case fork
 }
 
+@test "Test Austin: fork multi-process" {
+  test_case fork_mp
+}
+
 @test "Test Austin: attach" {
   if [[ $EUID -ne 0 ]]; then
    skip "requires root"

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -15,7 +15,7 @@ attach_austin_2_3() {
     echo "       Exit code: $status"
     if [ $status != 0 ]; then continue; fi
 
-    if ! echo "$output" | grep -q ";? (test/sleepy.py);L13 "
+    if ! echo "$output" | grep -q ";? (test/sleepy.py);L[[:digit:]]* "
     then
       continue
     fi
@@ -63,7 +63,7 @@ attach_austin() {
     echo "       Exit code: $status"
     if [ $status != 0 ]; then continue; fi
 
-    if ! echo "$output" | grep -q ";<module> (test/sleepy.py);L13 "
+    if ! echo "$output" | grep -q ";<module> (test/sleepy.py);L[[:digit:]]* "
     then
       continue
     fi
@@ -89,6 +89,7 @@ attach_austin() {
   then
     skip "Test failed but marked as 'Ignore'"
   else
+    echo "$output"
     false
   fi
 }

--- a/test/test_fork_mp.bats
+++ b/test/test_fork_mp.bats
@@ -43,14 +43,17 @@ invoke_austin() {
 
 
 @test "Test Austin with Python 2.3" {
-	invoke_austin "2.3" ignore
+  skip "Multiprocessing library introduced in Python 2.6"
+	invoke_austin "2.3"
 }
 
 @test "Test Austin with Python 2.4" {
-	invoke_austin "2.4" ignore
+  skip "Multiprocessing library introduced in Python 2.6"
+	invoke_austin "2.4"
 }
 
 @test "Test Austin with Python 2.5" {
+  skip "Multiprocessing library introduced in Python 2.6"
 	invoke_austin "2.5"
 }
 

--- a/test/test_fork_mp.bats
+++ b/test/test_fork_mp.bats
@@ -9,43 +9,21 @@ invoke_austin() {
 
     # -------------------------------------------------------------------------
 
-    echo "  :: Standard profiling"
-    run src/austin -i 1000 -t 10000 python$1 test/target34.py
+    echo "  :: Profiling of multi-process program"
+    run src/austin -i 10000 -C python$1 test/target_mp.py
 
     echo "       Exit code: $status"
     if [ $status != 0 ]; then continue; fi
 
-    if ! echo "$output" | grep -q "keep_cpu_busy (test/target34.py);L" \
-    || echo "$output" | grep -q "Unwanted"
-    then
-      continue
-    fi
-    echo "       Output: OK"
+    echo "       - Check expected number of processes."
+    expected=3
+    n_procs=$( echo "$output" | sed -r 's/Process ([0-9]+);.+/\1/' | sort | uniq | wc -l )
+    echo "         Expected $expected and got $n_procs"
+    if [ $n_procs != $expected ]
+    then continue; fi
 
-    # -------------------------------------------------------------------------
-
-    echo "  :: Memory profiling"
-    run src/austin -i 1000 -t 10000 -m python$1 test/target34.py
-
-    echo "       Exit code: $status"
-    if [ $status != 0 ]; then continue; fi
-
-    if ! echo "$output" | grep -q "keep_cpu_busy (test/target34.py);L"
-    then
-      continue
-    fi
-    echo "       Output: OK"
-
-    # -------------------------------------------------------------------------
-
-    echo "  :: Output file"
-    run src/austin -i 10000 -t 10000 -o /tmp/austin_out.txt python$1 test/target34.py
-
-    echo "       Exit code: $status"
-    if [ $status != 0 ]; then continue; fi
-
-    if ! echo "$output" | grep -q "Unwanted" \
-    || cat /tmp/austin_out.txt | grep -q "keep_cpu_busy (test/target34.py);L"
+    echo "       - Check output contains frames."
+    if echo "$output" | grep -q "do (test/target_mp.py);L[[:digit:]]*;fact (test/target_mp.py);L"
     then
       echo "       Output: OK"
       return
@@ -62,11 +40,6 @@ invoke_austin() {
 
 
 # -----------------------------------------------------------------------------
-
-
-teardown() {
-  if [ -f /tmp/austin_out.txt ]; then rm /tmp/austin_out.txt; fi
-}
 
 
 @test "Test Austin with Python 2.3" {


### PR DESCRIPTION
### Description of the Change

Created a new module to handle a list of Python processes that are  descendant
of the given command or the attached process. At every  iteration, every valid
running process in the list is sampled.

The new mode can be turned on with the new `-C` or `--children` options. In this
case, the output will contain the process identifier as the first fragment in
each collected sample.

The test suite has been extended to test multi-process support when  starting a
new multi-process Python program.

### Alternate Designs

The code has been refactored. In particular the sample output generation  has
been moved in py_thread.c and the higher level sampling logic in  py_proc.c.
This allows the new data structure to easily call on these  methods.

As for the PID table generation logic on Linux, this has been modelled on the
`ps` utility. Of all the alternative designs that have been tried out, this
seemed to provide the highest performance by at least an order of magnitude.

### Regressions

None expected. The new functionality is an extension of the existing ones. The
output format, however, now depends on whether the new functionality is used or
not.

### Verification Process

The test suite has been extended to test the correct behaviour of the new mode
against a multi-process test target. The new test case checks that the collected
samples contain the expected information and that the expected process count
also matches.
