### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
     sudo add-apt-repository ppa:deadsnakes/ppa -y;
     sudo add-apt-repository ppa:duggan/bats -y;
 
-    sudo apt install bats valgrind python2.{3..7} python3.{3..7} -y;
+    sudo apt install bats valgrind python2.{3..7} python3.{3..8} -y;
   fi
 
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then autoreconf --install; fi

--- a/src/python.h
+++ b/src/python.h
@@ -125,10 +125,32 @@ typedef struct {
     PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) */
 } PyCodeObject3_6;
 
+typedef struct {
+    PyObject_HEAD
+    int co_argcount;            /* #arguments, except *args */
+    int co_posonlyargcount;     /* #positional only arguments */
+    int co_kwonlyargcount;      /* #keyword only arguments */
+    int co_nlocals;             /* #local variables */
+    int co_stacksize;           /* #entries needed for evaluation stack */
+    int co_flags;               /* CO_..., see below */
+    int co_firstlineno;         /* first source line number */
+    PyObject *co_code;          /* instruction opcodes */
+    PyObject *co_consts;        /* list (constants used) */
+    PyObject *co_names;         /* list of strings (names used) */
+    PyObject *co_varnames;      /* tuple of strings (local variable names) */
+    PyObject *co_freevars;      /* tuple of strings (free variable names) */
+    PyObject *co_cellvars;      /* tuple of strings (cell variable names) */
+    Py_ssize_t *co_cell2arg;    /* Maps cell vars which are arguments. */
+    PyObject *co_filename;      /* unicode (where it was loaded from) */
+    PyObject *co_name;          /* unicode (name, for reference) */
+    PyObject *co_lnotab;        /* string (encoding addr<->lineno mapping) */
+} PyCodeObject3_8;
+
 typedef union {
   PyCodeObject2   v2;
   PyCodeObject3_3 v3_3;
   PyCodeObject3_6 v3_6;
+  PyCodeObject3_8 v3_8;
 } PyCodeObject;
 
 

--- a/src/version.c
+++ b/src/version.c
@@ -29,7 +29,7 @@
 
 #define UNSUPPORTED_VERSION             log_w("Unsupported Python version detected. Austin might not work as expected.")
 
-#define LATEST_VERSION                  &python_v3_7
+#define LATEST_VERSION                  (&python_v3_8)
 
 #define PY_CODE(s) {                    \
   sizeof(s),                            \
@@ -128,6 +128,17 @@ python_v python_v3_7 = {
   PY_RUNTIME  (0)
 };
 
+// ---- Python 3.8 ------------------------------------------------------------
+
+python_v python_v3_8 = {
+  PY_CODE     (PyCodeObject3_8),
+  PY_FRAME    (PyFrameObject3_7),
+  PY_THREAD   (PyThreadState3_4),
+  PY_UNICODE  (3),
+  PY_BYTES    (3),
+  PY_RUNTIME  (0)
+};
+
 
 // ----------------------------------------------------------------------------
 void
@@ -178,6 +189,9 @@ set_version(int version) {
 
     // 3.7
     case 7: py_v = &python_v3_7; break;
+
+    // 3.8
+    case 8: py_v = &python_v3_8; break;
 
     default: py_v = LATEST_VERSION;
       UNSUPPORTED_VERSION;

--- a/test/test_attach.bats
+++ b/test/test_attach.bats
@@ -42,6 +42,12 @@ attach_austin_2_3() {
   then
     skip "Test failed but marked as 'Ignore'"
   else
+    echo
+    echo "Collected Output"
+    echo "================"
+    echo
+    echo "$output"
+    echo
     false
   fi
 }
@@ -136,4 +142,8 @@ attach_austin() {
 
 @test "Test Austin with Python 3.7" {
   attach_austin "3.7"
+}
+
+@test "Test Austin with Python 3.8" {
+  attach_austin "3.8"
 }

--- a/test/test_fork.bats
+++ b/test/test_fork.bats
@@ -56,6 +56,12 @@ invoke_austin() {
   then
     skip "Test failed but marked as 'Ignore'"
   else
+    echo
+    echo "Collected Output"
+    echo "================"
+    echo
+    echo "$output"
+    echo
     false
   fi
 }
@@ -109,6 +115,6 @@ teardown() {
   invoke_austin "3.7"
 }
 
-# @test "Test Austin with Python 3.8" {
-#   invoke_austin "3.8"
-# }
+@test "Test Austin with Python 3.8" {
+  invoke_austin "3.8"
+}

--- a/test/test_fork_mp.bats
+++ b/test/test_fork_mp.bats
@@ -34,6 +34,12 @@ invoke_austin() {
   then
     skip "Test failed but marked as 'Ignore'"
   else
+    echo
+    echo "Collected Output"
+    echo "================"
+    echo
+    echo "$output"
+    echo 
     false
   fi
 }
@@ -85,6 +91,6 @@ invoke_austin() {
   invoke_austin "3.7"
 }
 
-# @test "Test Austin with Python 3.8" {
-#   invoke_austin "3.8"
-# }
+@test "Test Austin with Python 3.8" {
+  invoke_austin "3.8"
+}

--- a/test/test_valgrind.bats
+++ b/test/test_valgrind.bats
@@ -30,6 +30,12 @@ invoke_austin() {
   then
     skip "Test failed but marked as 'Ignore'"
   else
+    echo
+    echo "Collected Output"
+    echo "================"
+    echo
+    echo "$output"
+    echo
     false
   fi
 }
@@ -76,4 +82,8 @@ invoke_austin() {
 
 @test "Test Austin with Python 3.7" {
   invoke_austin "3.7"
+}
+
+@test "Test Austin with Python 3.8" {
+  invoke_austin "3.8"
 }


### PR DESCRIPTION
### Description of the Change

Added support for the CPython 3.8 API.

### Alternate Designs

N. A.

### Regressions

None expected

### Verification Process

The existing test suite, which has been extended to cover CPython 3.8