### PR TITLE
Fix py_proc__wait on Linux

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,8 @@
 
 AM_CFLAGS =-I$(top_srcdir)/src -Wall -O3
 
+AM_LDFLAGS = -lpthread
+
 bin_PROGRAMS = austin
 austin_SOURCES = \
   argparse.c     \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,9 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
-AM_CFLAGS =-I$(top_srcdir)/src -Wall -O3
-
-AM_LDFLAGS = -lpthread
+AM_CFLAGS =-I$(top_srcdir)/src -Wall -O3 -pthread
 
 bin_PROGRAMS = austin
 austin_SOURCES = \

--- a/src/austin.c
+++ b/src/austin.c
@@ -112,7 +112,7 @@ do_child_processes(py_proc_t * py_proc) {
 
     // Since the parent process is not running we probably have waited long
     // enough so we can try to attach to child processes straight away.
-    pargs.timeout = 0;
+    pargs.timeout = 1;
 
     // Store the PID before it gets deleted by the update.
     pid_t ppid = py_proc->pid;

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -24,6 +24,7 @@
 
 #include <elf.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -57,6 +58,7 @@
 struct _proc_extra_info {
   unsigned int page_size;
   char         statm_file[24];
+  pthread_t    wait_thread_id;
 };
 
 
@@ -64,6 +66,14 @@ union {
   Elf32_Ehdr v32;
   Elf64_Ehdr v64;
 } ehdr_v;
+
+
+// ----------------------------------------------------------------------------
+static void *
+wait_thread(void * py_proc) {
+  waitpid(((py_proc_t *) py_proc)->pid, 0, 0);
+  return NULL;
+}
 
 
 // ----------------------------------------------------------------------------

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -699,7 +699,8 @@ py_proc__start(py_proc_t * self, const char * exec, char * argv[]) {
     // not writing to stdout.
     if (pargs.output_file == NULL) {
       log_d("Redirecting child's STDOUT to " NULL_DEVICE);
-      freopen(NULL_DEVICE, "w", stdout);
+      if (freopen(NULL_DEVICE, "w", stdout) == NULL)
+        log_e("Unable to redirect child's STDOUT to " NULL_DEVICE);
     }
 
     execvp(exec, argv);

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -226,11 +226,6 @@ _py_proc__check_interp_state(py_proc_t * self, void * raddr) {
   if (py_proc__get_type(self, raddr, is))
     return OUT_OF_BOUND;
 
-  log_t(
-    "PyInterpreterState loaded @ %p. Thread State head @ %p",
-    raddr, is.tstate_head
-  );
-
   if (py_proc__get_type(self, is.tstate_head, tstate_head))
     return 1;
 
@@ -242,6 +237,11 @@ _py_proc__check_interp_state(py_proc_t * self, void * raddr) {
   log_d(
     "Found possible interpreter state @ %p (offset %p).",
     raddr, raddr - self->map.heap.base
+  );
+
+  log_t(
+    "PyInterpreterState loaded @ %p. Thread State head @ %p",
+    raddr, is.tstate_head
   );
 
   // As an extra sanity check, verify that the thread state is valid
@@ -707,8 +707,14 @@ py_proc__start(py_proc_t * self, const char * exec, char * argv[]) {
     log_e("Failed to fork process");
     exit(127);
   }
-
   #endif                                                               /* ANY */
+
+  #if defined PL_LINUX
+  // On Linux we need to wait for the forked process or otherwise it will
+  // become a zombie and we cannot tell with kill if it has terminated.
+  pthread_create(&(self->extra->wait_thread_id), NULL, wait_thread, (void *) self);
+  log_d("Wait thread created with ID %x", self->extra->wait_thread_id);
+  #endif
 
   log_d("New process created with PID %d", self->pid);
 
@@ -731,6 +737,12 @@ py_proc__memcpy(py_proc_t * self, void * raddr, ssize_t size, void * dest) {
 void
 py_proc__wait(py_proc_t * self) {
   log_d("Waiting for process to terminate");
+
+  #if defined PL_LINUX
+  if (self->extra->wait_thread_id) {
+    pthread_join(self->extra->wait_thread_id, NULL);
+  }
+  #endif
 
   #ifdef PL_WIN                                                        /* WIN */
   WaitForSingleObject(self->extra->h_proc, INFINITE);
@@ -829,8 +841,7 @@ py_proc__is_running(py_proc_t * self) {
   return pid_to_task(self->pid) != 0;
 
   #else                                                              /* LINUX */
-  kill(self->pid, 0);
-  return errno == ESRCH ? 0 : 1;
+  return !(kill(self->pid, 0) == -1 && errno == ESRCH);
   #endif
 }
 

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -283,6 +283,8 @@ py_proc_list__update(py_proc_list_t * self) {
       item = item->next;
     }
     else {
+      py_proc__wait(item->py_proc);
+      
       py_proc_item_t * next = item->next;
       _py_proc_list__remove(self, item);
       item = next;
@@ -299,10 +301,8 @@ void
 py_proc_list__wait(py_proc_list_t * self) {
   log_d("Waiting for child processes to terminate");
 
-  for (py_proc_item_t * item = self->first; item != NULL; item = item->next) {
-    if (py_proc__is_running(item->py_proc))
-      py_proc__wait(item->py_proc);
-  }
+  for (py_proc_item_t * item = self->first; item != NULL; item = item->next)
+    py_proc__wait(item->py_proc);
 } /* py_proc_list__wait */
 
 

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -223,10 +223,11 @@ py_proc_list__update(py_proc_list_t * self) {
     if (stat_file == NULL)
       continue;
 
-    fscanf(
+    if (fscanf(
       stat_file, "%d %s %c %d",
       (int *) buffer, buffer, (char *) buffer, &(self->pid_table[pid])
-    );
+    ) != 4)
+      log_w("Failed to parse stat file for process %d", pid);
 
     if (pid > self->max_pid)
       self->max_pid = pid;
@@ -284,7 +285,7 @@ py_proc_list__update(py_proc_list_t * self) {
     }
     else {
       py_proc__wait(item->py_proc);
-      
+
       py_proc_item_t * next = item->next;
       _py_proc_list__remove(self, item);
       item = next;


### PR DESCRIPTION
### Description of the Change

In order to avoid zombie processes, a thread is required on Linux that 
waits the forked child process. This way it is terminated correctly 
instead of being reported as still running.

### Alternate Designs

N. A.

### Regressions

None expected.

### Verification Process

The existing test suite.