### PR TITLE
Add Mac OS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ before_script:
 
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
     then
-      brew install python;
+      brew install python || brew upgrade python;
       brew install python@3.8            || true;
       brew install bats-core;
       brew install --HEAD valgrind       || true;
-      sudo brew cask install anaconda    || true;
+      brew cask install anaconda         || true;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ compiler:
 git:
   depth: 1
 
-osx_image: xcode10
+osx_image: xcode11.4
 
-sudo: required
+os: linux
 dist: bionic
 
-matrix:
+jobs:
   include:
     # Linux
     - env: TARGET=arm-unknown-linux-gnueabi
@@ -31,38 +31,92 @@ matrix:
 
 before_script:
   # Linux Dependencies
-  if [[ "$TRAVIS_OS_NAME" == "linux" ]];
-  then
-    sudo add-apt-repository ppa:deadsnakes/ppa -y;
-    sudo add-apt-repository ppa:duggan/bats -y;
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+    then
+      sudo add-apt-repository ppa:deadsnakes/ppa -y;
+      sudo add-apt-repository ppa:duggan/bats -y;
 
-    sudo apt install bats valgrind python2.{3..7} python3.{3..8} -y;
-  fi
+      sudo apt install bats valgrind python2.{3..7} python3.{3..8} -y;
 
-  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then autoreconf --install; fi
+      autoreconf --install;
+    fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
+    then
+      brew install python;
+      brew install python@3.8            || true;
+      brew install bats-core;
+      brew install --HEAD valgrind       || true;
+      sudo brew cask install anaconda    || true;
+    fi
 
 script:
   - echo $TRAVIS_OS_NAME -- $TARGET
-  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then ./configure && make && sudo make check;         fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"     ]]; then gcc -s -Wall -O3 -o src/austin src/*.c;         fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then gcc -s -Wall -O3 -o src/austin src/*.c -lpsapi; fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]];
+    then
+      ./configure &&
+      make &&
+      sudo make check;
+    fi
+  
+  - if [[ "$TRAVIS_OS_NAME" == "osx"     ]];
+    then
+      gcc -s -Wall -O3 -o src/austin src/*.c &&
+      sudo bats test/macos/test.bats;
+    fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]];
+    then
+      gcc -s -Wall -O3 -o src/austin src/*.c -lpsapi;
+    fi
 
 after_success:
   ./src/austin --usage
 
 after_failure:
-  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then cat /var/log/syslog.log | grep austin; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then cat test-suite.log;                    fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]];
+    then
+      test -f /var/log/syslog.log && cat /var/log/syslog.log | grep austin; 
+      test -f test-suite.log      && cat test-suite.log;
+    fi
 
 before_deploy:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export VERSION=$(cat src/austin.h | sed -n -E "s/.*VERSION[ ]+\"(.+)\"/\1/p"); else export VERSION=$(cat src/austin.h | sed -r -n "s/.*VERSION[ ]+\"(.+)\"/\1/p"); fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
+    then
+      SED_FLAGS="-n -E";
+    else
+      SED_FLAGS="-r -n";
+    fi;
+    export VERSION=$(cat src/austin.h | sed $SED_FLAGS "s/.*VERSION[ ]+\"(.+)\"/\1/p");
+
   - export TRAVIS_TAG=v$VERSION
+
   - echo "==== Preparing to create GitHub Release for version $VERSION ===="
 
-  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then export ZIP_CMD="tar -Jcf"   && export ZIP_SUFFIX="linux-${TARGET%%-*}.tar.xz" && export AUSTIN_EXE=austin;     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"     ]]; then export ZIP_CMD="zip -r"     && export ZIP_SUFFIX="mac-${TARGET%%-*}.zip"      && export AUSTIN_EXE=austin;     fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export ZIP_CMD="7z a -tzip" && export ZIP_SUFFIX="win-${TARGET%%-*}.zip"      && export AUSTIN_EXE=austin.exe; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux"   ]];
+    then
+      export ZIP_CMD="tar -Jcf";
+      export ZIP_SUFFIX="linux-${TARGET%%-*}.tar.xz";
+      export AUSTIN_EXE=austin;
+    fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "osx"     ]];
+    then
+      export ZIP_CMD="zip -r";
+      export ZIP_SUFFIX="mac-${TARGET%%-*}.zip";
+      export AUSTIN_EXE=austin;
+    fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]];
+    then
+      export ZIP_CMD="7z a -tzip";
+      export ZIP_SUFFIX="win-${TARGET%%-*}.zip";
+      export AUSTIN_EXE=austin.exe;
+    fi
+
   - export ARTEFACT="austin-${VERSION}-${ZIP_SUFFIX}"
+
   - echo " - Using command $ZIP_CMD to create artefact $ARTEFACT"
 
   - cd src
@@ -75,7 +129,7 @@ before_deploy:
 
 deploy:
   provider: releases
-  api_key: $GITHUB_TOKEN
+  edge: true
+  token: $GITHUB_TOKEN
   file: $ARTEFACT
-  skip_cleanup: true
   overwrite: true

--- a/test/macos/test.bats
+++ b/test/macos/test.bats
@@ -1,0 +1,23 @@
+test_case() {
+  run bats test/macos/test_$1.bats
+  echo "$output"
+  [ $status = 0 ]
+}
+
+@test "Test Austin: fork" {
+  test_case fork
+}
+
+@test "Test Austin: fork multi-process" {
+  test_case fork_mp
+}
+
+@test "Test Austin: attach" {
+  test_case attach
+}
+
+@test "Test Austin: valgrind" {
+  if ! which valgrind; then skip "Valgrind not found"; fi
+
+  test_case valgrind
+}

--- a/test/macos/test.bats
+++ b/test/macos/test.bats
@@ -17,6 +17,8 @@ test_case() {
 }
 
 @test "Test Austin: valgrind" {
+  skip "We skip valgrind on Mac OS for now"
+  
   if ! which valgrind; then skip "Valgrind not found"; fi
 
   test_case valgrind

--- a/test/macos/test_attach.bats
+++ b/test/macos/test_attach.bats
@@ -61,12 +61,12 @@ attach_austin() {
 # -----------------------------------------------------------------------------
 
 
-@test "Test Austin with the default Python 3" {
-  python -m venv /tmp/py3
-  source /tmp/py3/bin/activate
-	attach_austin "python"
-  test -d /tmp/py3 && rm -rf /tmp/py3
-}
+# @test "Test Austin with the default Python 3" {
+#   /usr/bin/python3 -m venv /tmp/py3
+#   source /tmp/py3/bin/activate
+# 	attach_austin "python3"
+#   test -d /tmp/py3 && rm -rf /tmp/py3
+# }
 
 @test "Test Austin with default Python 3 from Homebrew" {
 	attach_austin "/usr/local/bin/python3"

--- a/test/macos/test_attach.bats
+++ b/test/macos/test_attach.bats
@@ -1,0 +1,81 @@
+attach_austin() {
+  python_bin=$1
+  ignore=$2
+
+  if ! $python_bin -V; then skip "$python_bin not found."; fi
+
+  for i in {1..3}
+  do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Time profiling"
+    $python_bin test/sleepy.py &
+    sleep 1
+    run sudo src/austin -i 10000 -t 10000 -p $!
+
+    echo "       Exit code: $status"
+    if [ $status != 0 ]; then continue; fi
+
+    if ! echo "$output" | grep -q ";<module> (test/sleepy.py);L[[:digit:]]* "
+    then
+      echo "       Output: NOK"
+      continue
+    fi
+    echo "       Output: OK"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Memory profiling"
+    $python_bin test/sleepy.py &
+    sleep 1
+    run sudo src/austin -mi 100 -t 10000 -p $!
+
+    echo "       Exit code: $status"
+    if [ $status != 0 ]; then continue; fi
+
+    if echo "$output" | grep -q "Thread "
+    then
+      echo "       Output: OK"
+      return
+    fi
+    echo "       Output: NOK"
+  done
+
+  if [ $ignore ]
+  then
+    echo "Test marked as 'Ignore' failed"
+  fi
+  echo
+  echo "Collected Output"
+  echo "================"
+  echo
+  echo "$output"
+  echo
+  
+  false
+}
+
+
+# -----------------------------------------------------------------------------
+
+
+@test "Test Austin with the default Python 3" {
+  python -m venv /tmp/py3
+  source /tmp/py3/bin/activate
+	attach_austin "python"
+  test -d /tmp/py3 && rm -rf /tmp/py3
+}
+
+@test "Test Austin with default Python 3 from Homebrew" {
+	attach_austin "/usr/local/bin/python3"
+}
+
+@test "Test Austin with Python 3.8 from Homebrew (if available)" {
+  attach_austin "/usr/local/opt/python@3.8/bin/python3" ignore
+}
+
+@test "Test Austin with Python 3 from Anaconda (if available)" {
+  attach_austin "/usr/local/anaconda3/bin/python" ignore
+}

--- a/test/macos/test_fork.bats
+++ b/test/macos/test_fork.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+invoke_austin() {
+  python_bin=$1
+  ignore=$2
+  
+  if ! $python_bin -V; then skip "$python_bin not found."; fi
+
+  for i in {1..3}
+  do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Standard profiling"
+    run sudo src/austin -i 1000 -t 10000 $python_bin test/target34.py
+
+    echo "       Exit code: $status"
+    if [ $status != 0 ]; then continue; fi
+
+    if ! echo "$output" | grep -q "keep_cpu_busy (test/target34.py);L" \
+    || echo "$output" | grep -q "Unwanted"
+    then
+      continue
+    fi
+    echo "       Output: OK"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Memory profiling"
+    run sudo src/austin -i 1000 -t 10000 -m $python_bin test/target34.py
+
+    echo "       Exit code: $status"
+    if [ $status != 0 ]; then continue; fi
+
+    if ! echo "$output" | grep -q "keep_cpu_busy (test/target34.py);L"
+    then
+      continue
+    fi
+    echo "       Output: OK"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Output file"
+    run sudo src/austin -i 10000 -t 10000 -o /tmp/austin_out.txt $python_bin test/target34.py
+
+    echo "       Exit code: $status"
+    if [ $status != 0 ]; then continue; fi
+
+    if ! echo "$output" | grep -q "Unwanted" \
+    || cat /tmp/austin_out.txt | grep -q "keep_cpu_busy (test/target34.py);L"
+    then
+      echo "       Output: OK"
+      return
+    fi
+  done
+
+  if [ $ignore ]
+  then
+    skip "Test failed but marked as 'Ignore'"
+  else
+    echo
+    echo "Collected Output"
+    echo "================"
+    echo
+    echo "$output"
+    echo
+    false
+  fi
+}
+
+
+# -----------------------------------------------------------------------------
+
+
+teardown() {
+  if [ -f /tmp/austin_out.txt ]; then rm /tmp/austin_out.txt; fi
+}
+
+
+@test "Test Austin with the default Python 3" {
+  python -m venv /tmp/py3
+  source /tmp/py3/bin/activate
+	invoke_austin "python"
+  test -d /tmp/py3 && rm -rf /tmp/py3
+}
+
+@test "Test Austin with default Python 3 from Homebrew" {
+	invoke_austin "/usr/local/bin/python3"
+}
+
+@test "Test Austin with Python 3.8 from Homebrew (if available)" {
+  invoke_austin "/usr/local/opt/python@3.8/bin/python3" ignore
+}
+
+@test "Test Austin with Python 3 from Anaconda (if available)" {
+  invoke_austin "/usr/local/anaconda3/bin/python" ignore
+}

--- a/test/macos/test_fork.bats
+++ b/test/macos/test_fork.bats
@@ -78,12 +78,12 @@ teardown() {
 }
 
 
-@test "Test Austin with the default Python 3" {
-  python -m venv /tmp/py3
-  source /tmp/py3/bin/activate
-	invoke_austin "python"
-  test -d /tmp/py3 && rm -rf /tmp/py3
-}
+# @test "Test Austin with the default Python 3" {
+#   /usr/bin/python3 -m venv --copies --without-pip /tmp/py3
+#   source /tmp/py3/bin/activate
+# 	invoke_austin "python3"
+#   test -d /tmp/py3 && rm -rf /tmp/py3
+# }
 
 @test "Test Austin with default Python 3 from Homebrew" {
 	invoke_austin "/usr/local/bin/python3"

--- a/test/macos/test_fork_mp.bats
+++ b/test/macos/test_fork_mp.bats
@@ -1,0 +1,69 @@
+invoke_austin() {
+  python_bin=$1
+  ignore=$2
+
+  if ! $python_bin -V; then skip "$python_bin not found."; fi
+
+  for i in {1..3}
+  do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Profiling of multi-process program"
+    run sudo src/austin -i 100000 -C $python_bin test/target_mp.py
+
+    echo "       Exit code: $status"
+    if [ $status != 0 ]; then continue; fi
+
+    echo "       - Check expected number of processes."
+    expected=3
+    n_procs=$( echo "$output" | sed -E 's/Process ([0-9]+);.+/\1/' | sort | uniq | wc -l )
+    echo "         Expected at least $expected and got $n_procs"
+    if [ $n_procs -lt $expected ]; then continue; fi
+
+    echo "       - Check output contains frames."
+    if echo "$output" | grep -q "fact"
+    then
+      echo "       Output: OK"
+      return
+    fi
+    echo "       Output: NOK"
+  done
+
+  if [ $ignore ]
+  then
+    echo "Test marked as 'Ignore' failed"
+  fi
+  echo
+  echo "Collected Output"
+  echo "================"
+  echo
+  echo "$output"
+  echo
+  
+  false
+}
+
+
+# -----------------------------------------------------------------------------
+
+
+@test "Test Austin with the default Python 3" {
+  python -m venv /tmp/py3
+  source /tmp/py3/bin/activate
+	invoke_austin "python"
+  test -d /tmp/py3 && rm -rf /tmp/py3
+}
+
+@test "Test Austin with default Python 3 from Homebrew" {
+	invoke_austin "/usr/local/bin/python3"
+}
+
+@test "Test Austin with Python 3.8 from Homebrew (if available)" {
+  invoke_austin "/usr/local/opt/python@3.8/bin/python3" ignore
+}
+
+@test "Test Austin with Python 3 from Anaconda (if available)" {
+  invoke_austin "/usr/local/anaconda3/bin/python" ignore
+}

--- a/test/macos/test_fork_mp.bats
+++ b/test/macos/test_fork_mp.bats
@@ -49,12 +49,12 @@ invoke_austin() {
 # -----------------------------------------------------------------------------
 
 
-@test "Test Austin with the default Python 3" {
-  python -m venv /tmp/py3
-  source /tmp/py3/bin/activate
-	invoke_austin "python"
-  test -d /tmp/py3 && rm -rf /tmp/py3
-}
+# @test "Test Austin with the default Python 3" {
+#   /usr/bin/python3 -m venv /tmp/py3
+#   source /tmp/py3/bin/activate
+# 	invoke_austin "python3"
+#   test -d /tmp/py3 && rm -rf /tmp/py3
+# }
 
 @test "Test Austin with default Python 3 from Homebrew" {
 	invoke_austin "/usr/local/bin/python3"

--- a/test/macos/test_valgrind.bats
+++ b/test/macos/test_valgrind.bats
@@ -1,0 +1,65 @@
+invoke_austin() {
+  python_bin=$1
+  ignore=$2
+
+  if ! $python_bin -V; then skip "$python not found."; fi
+
+  for i in {1..3}
+  do
+    echo "> Run $i of 3"
+
+    # -------------------------------------------------------------------------
+
+    echo "  :: Valgrind test"
+    run sudo valgrind \
+      --error-exitcode=42 \
+      --leak-check=full \
+      --show-leak-kinds=all \
+      --errors-for-leak-kinds=all \
+      --track-fds=yes \
+      src/austin -i 100000 -t 10000 $python_bin test/target34.py
+    echo "       Exit code: $status"
+    echo "       Valgrind report: <"
+    echo "$output"
+  	if [ $status = 0 ]
+    then
+      return
+    fi
+  done
+
+  if [ $ignore ]
+  then
+    echo "Test marked as 'Ignore' failed"
+  fi
+  echo
+  echo "Collected Output"
+  echo "================"
+  echo
+  echo "$output"
+  echo
+  
+  false
+}
+
+
+# -----------------------------------------------------------------------------
+
+
+@test "Test Austin with the default Python 3" {
+  python -m venv /tmp/py3
+  source /tmp/py3/bin/activate
+	invoke_austin "python"
+  test -d /tmp/py3 && rm -rf /tmp/py3
+}
+
+@test "Test Austin with default Python 3 from Homebrew" {
+	invoke_austin "/usr/local/bin/python3"
+}
+
+@test "Test Austin with Python 3.8 from Homebrew (if available)" {
+  invoke_austin "/usr/local/opt/python@3.8/bin/python3" ignore
+}
+
+@test "Test Austin with Python 3 from Anaconda (if available)" {
+  invoke_austin "/usr/local/anaconda3/bin/python" ignore
+}

--- a/test/macos/test_valgrind.bats
+++ b/test/macos/test_valgrind.bats
@@ -17,6 +17,7 @@ invoke_austin() {
       --show-leak-kinds=all \
       --errors-for-leak-kinds=all \
       --track-fds=yes \
+      --track-origins=yes \
       src/austin -i 100000 -t 10000 $python_bin test/target34.py
     echo "       Exit code: $status"
     echo "       Valgrind report: <"
@@ -45,12 +46,12 @@ invoke_austin() {
 # -----------------------------------------------------------------------------
 
 
-@test "Test Austin with the default Python 3" {
-  python -m venv /tmp/py3
-  source /tmp/py3/bin/activate
-	invoke_austin "python"
-  test -d /tmp/py3 && rm -rf /tmp/py3
-}
+# @test "Test Austin with the default Python 3" {
+#   /usr/bin/python3 -m venv /tmp/py3
+#   source /tmp/py3/bin/activate
+# 	invoke_austin "python3"
+#   test -d /tmp/py3 && rm -rf /tmp/py3
+# }
 
 @test "Test Austin with default Python 3 from Homebrew" {
 	invoke_austin "/usr/local/bin/python3"


### PR DESCRIPTION
### Description of the Change

The test suite has been enlarged to include test cases for Mac OS to run with bats-core. The Linux tests form the basis on top of which the new tests build. However, only the Python versions from Homebrew and the Anaconda cask are tested. They provide examples of distributions respectively with and without a shared library. Valgrind tests seemed to report false problems so they are being skipped at the moment.

### Alternate Designs

No alternative design considered.

### Regressions

None expected

### Verification Process

The new test suite.