### PR TITLE
Deploy MSI installer to GitHub and nupkg to Chocolatey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,12 @@ before_script:
       brew cask install anaconda         || true;
     fi
 
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]];
+    then
+      powershell Install-WindowsFeature Net-Framework-Core;
+      cinst -y wixtoolset;
+    fi
+
 script:
   - echo $TRAVIS_OS_NAME -- $TARGET
 
@@ -59,7 +65,7 @@ script:
       make &&
       sudo make check;
     fi
-  
+
   - if [[ "$TRAVIS_OS_NAME" == "osx"     ]];
     then
       gcc -s -Wall -O3 -o src/austin src/*.c &&
@@ -77,7 +83,7 @@ after_success:
 after_failure:
   - if [[ "$TRAVIS_OS_NAME" == "linux"   ]];
     then
-      test -f /var/log/syslog.log && cat /var/log/syslog.log | grep austin; 
+      test -f /var/log/syslog.log && cat /var/log/syslog.log | grep austin;
       test -f test-suite.log      && cat test-suite.log;
     fi
 
@@ -113,6 +119,12 @@ before_deploy:
       export ZIP_CMD="7z a -tzip";
       export ZIP_SUFFIX="win-${TARGET%%-*}.zip";
       export AUSTIN_EXE=austin.exe;
+
+      export WIN_MSI="austin-$VERSION-win64.msi";
+
+      sed -i "s/%VERSION%/$VERSION/g" wix/Austin.wxs;
+      candle wix/Austin.wxs -out wix/Austin.wixobj;
+      light -ext WixUIExtension wix/Austin.wixobj -out $WIN_MSI;
     fi
 
   - export ARTEFACT="austin-${VERSION}-${ZIP_SUFFIX}"
@@ -128,8 +140,30 @@ before_deploy:
   - git tag -a -f -m "Release $VERSION" $TRAVIS_TAG
 
 deploy:
-  provider: releases
-  edge: true
-  token: $GITHUB_TOKEN
-  file: $ARTEFACT
-  overwrite: true
+  - provider: releases
+    edge: true
+    token: $GITHUB_TOKEN
+    file: $ARTEFACT
+    overwrite: true
+
+  - provider: releases
+    edge: true
+    token: $GITHUB_TOKEN
+    file: $WIN_MSI
+    overwrite: true
+    on:
+      condition: "$TRAVIS_OS_NAME = windows"
+
+after_deploy:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]];
+    then
+      export WIN_MSI_HASH=$( sha256sum $WIN_MSI | head -c 64 );
+
+      cd choco;
+
+      sed -i "s/%WIN_MSI_HASH%/$WIN_MSI_HASH/g" tools/chocolateyinstall.ps1;
+      /bin/find . -type f -exec sed -i "s/%VERSION%/$VERSION/g" {} \; ;
+      choco apikey --key $CHOCO_APIKEY --source https://push.chocolatey.org/;
+      choco pack;
+      choco push;
+    fi

--- a/choco/austin.nuspec
+++ b/choco/austin.nuspec
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase
+  omega letter enclosed in quotation marks, you should use an editor that
+  supports UTF-8, not this one.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>austin</id>
+    <version>%VERSION%</version>
+    <packageSourceUrl>https://github.com/P403n1x87/austin/tree/release/choco/choco</packageSourceUrl>
+    <owners>Gabriele N. Tornetta</owners>
+
+    <title>Austin (Install)</title>
+    <authors>Gabriele N. Tornetta</authors>
+    <projectUrl>https://github.com/P403n1x87/austin</projectUrl>
+    <iconUrl>https://rawcdn.githack.com/P403n1x87/austin/8bea939fc7088a7ed1d2012d819890eecd8753c4/art/austin_logo.png</iconUrl>
+    <copyright>2018 Gabriele N. Tornetta</copyright>
+    <licenseUrl>https://github.com/P403n1x87/austin/raw/master/LICENSE.md</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/P403n1x87/austin</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/P403n1x87/austin/issues</bugTrackerUrl>
+    <tags>python profiling</tags>
+    <summary>A Frame Stack Sampler for CPython</summary>
+    <description>
+      Austin is a Python frame stack sampler for CPython written in pure C. It
+      samples the stack traces of a Python application so that they can be
+      visualised and analysed. As such, it serves the basis for building
+      powerful profilers for Python.
+    </description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop';
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$url64      = 'https://github.com/P403n1x87/austin/releases/download/v%VERSION%/austin-%VERSION%-win64.msi'
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
+  fileType      = 'MSI'
+  url64bit      = $url64
+
+  softwareName  = 'austin*'
+
+  checksum64    = '%WIN_MSI_HASH%'
+  checksumType64= 'sha256'
+
+  silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  validExitCodes= @(0, 3010, 1641)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/wix/Austin.wxs
+++ b/wix/Austin.wxs
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+  <Product
+    Name='Austin %VERSION%'
+    Manufacturer='Gabriele N. Tornetta'
+
+    Id='2c5be9da-e66c-4eec-a8ea-facaedaa17e3'
+    UpgradeCode='7ae63393-fefa-49c2-bb04-41ce4a552d59'
+
+    Language='1033'
+    Codepage='1252'
+    Version='%VERSION%'>
+
+    <Package Id='*'
+      Keywords='Installer'
+      Platform="x64"
+
+      Description="Austin %VERSION% Installer"
+      Comments='Austin is an open source frame stack sampler for CPython'
+      Manufacturer='Gabriele N. Tornetta'
+
+      InstallerVersion='200'
+      Languages='1033'
+      Compressed='yes'
+      SummaryCodepage='1252'
+    />
+
+    <Media Id='1' Cabinet='Austin.cab' EmbedCab='yes' />
+
+    <Condition Message="This version of Austin requires a 64-bit version of Windows.">
+      Msix64
+    </Condition>
+
+    <Directory Id='TARGETDIR' Name='SourceDir'>
+      <Directory Id='ProgramFiles64Folder' Name='PFiles'>
+        <Directory Id='PhoenixDir' Name='P403n1x87'>
+          <Directory Id='INSTALLDIR' Name='Austin'>
+            <Component Id='MainExecutable' Win64='yes' Guid='7e897bf3-8bc4-470e-bab3-376bc89ba1d1'>
+              <File Id='AustinEXE'
+                Name='austin.exe'
+                Source='../src/austin.exe'
+                ProcessorArchitecture='x64'
+                KeyPath='yes'
+              />
+              <Environment Id="PATH"
+                Name="PATH"
+                Value="[INSTALLDIR]"
+                Permanent="no"
+                Part="last"
+                Action="set"
+                System="yes"
+              />
+              <RemoveFolder Id='AustinRemoval' On='uninstall' Directory="PhoenixDir" />
+            </Component>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+    <UI>
+      <UIRef Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg"
+        Control="Next"
+        Event="NewDialog"
+        Value="InstallDirDlg"
+        Order="2">1</Publish>
+      <Publish Dialog="InstallDirDlg"
+        Control="Back"
+        Event="NewDialog"
+        Value="WelcomeDlg"
+        Order="2">1</Publish>
+    </UI>
+
+    <Feature Id='Complete'
+      Level='1'
+      Title='Austin %VERSION%'
+      ConfigurableDirectory='INSTALLDIR'>
+      <ComponentRef Id='MainExecutable' />
+    </Feature>
+
+  </Product>
+</Wix>


### PR DESCRIPTION
### Description of the Change

Automate the generation of the MSI installer with Travis by installing 
the wixtoolset and building the installer. After deployment to GitHub 
Releases, we try to package the project and deploy to Chocolatey.

### Alternate Designs

N. A.

### Regressions

Deployment won't be tested until this PR is merged. There is a risk that the Travis job will fail when it comes to this phase.

### Verification Process

N. A.