### PR TITLE
feat(mac)!: use sleepless mode to estimate CPU time

### DIFF
--- a/src/argparse.c
+++ b/src/argparse.c
@@ -186,7 +186,7 @@ static struct argp_option options[] = {
   },
   {
     "sleepless",    's', NULL,          0,
-    "Suppress idle samples."
+    "Suppress idle samples to estimate CPU time."
   },
   {
     "memory",       'm', NULL,          0,
@@ -461,7 +461,7 @@ static const char * help_msg = \
 "  -o, --output=FILE          Specify an output file for the collected samples.\n"
 "  -p, --pid=PID              The the ID of the process to which Austin should\n"
 "                             attach.\n"
-"  -s, --sleepless            Suppress idle samples.\n"
+"  -s, --sleepless            Suppress idle samples to estimate CPU time.\n"
 "  -t, --timeout=n_ms         Start up wait time in milliseconds (default is\n"
 "                             100). Accepted units: s, ms.\n"
 "  -x, --exposure=n_sec       Sample for n_sec seconds only.\n"

--- a/src/austin.c
+++ b/src/austin.c
@@ -65,7 +65,7 @@ do_single_process(py_proc_t * py_proc) {
     while(interrupt == FALSE) {
       timer_start();
 
-      if (py_proc__sample(py_proc))
+      if (fail(py_proc__sample(py_proc)))
         break;
 
       timer_pause(timer_stop());

--- a/src/hints.h
+++ b/src/hints.h
@@ -37,4 +37,8 @@
 
 #define isvalid(x)                      ((x) != NULL)
 
+#ifndef unlikely
+#define unlikely(x)                     __builtin_expect(!!(x), 1)
+#endif
+
 #endif

--- a/src/mac/py_thread.h
+++ b/src/mac/py_thread.h
@@ -1,0 +1,110 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifdef PY_THREAD_C
+
+#include <libproc.h>
+
+#include "../logging.h"
+#include "../py_thread.h"
+
+
+// This offset was discovered by looking at the result of PROC_PIDLISTTHREADS.
+// It's unclear whether we can rely on it always being the same, regardless of
+// interpreter and OS versions.
+#define SILLY_OFFSET                0xe0
+
+#define MAX_THREADS                 4096
+
+
+static uint64_t _silly_offset = 0;
+
+
+// ----------------------------------------------------------------------------
+static void
+_infer_thread_id_offset(py_thread_t * py_thread) {
+    // Set the default value, in case we fail to find the actual one.
+    _silly_offset = SILLY_OFFSET;
+
+    uint64_t * tids = (uint64_t *) calloc(MAX_THREADS, sizeof(uint64_t));
+    if (!isvalid(tids)) {
+        return;
+    }
+
+    int n = proc_pidinfo(
+        py_thread->proc->pid,
+        PROC_PIDLISTTHREADS,
+        0,
+        tids,
+        MAX_THREADS * sizeof(uint64_t)
+    ) / sizeof(uint64_t);
+    if (n >= MAX_THREADS) {
+        log_w("More than %d threads. Thread module initialisation might fail", MAX_THREADS);
+    }
+    else if (n <= 0) {
+        log_w("No native threads found. This is weird.");
+        goto release;
+    }
+
+    // Find the thread ID offset
+    uint64_t min = 0x100;
+    for (int i = 0; i < n; i++) {
+        uint64_t offset = tids[i] - py_thread->tid;
+        if (offset < min) {
+            min = offset;
+        }
+    }
+    _silly_offset = min;
+    log_t("Silly thread id offset: %x", _silly_offset);
+
+release:
+    sfree(tids);
+}
+
+
+// ----------------------------------------------------------------------------
+static int
+_py_thread__is_idle(py_thread_t * self) {
+    if (unlikely(_silly_offset == 0)) {
+        _infer_thread_id_offset(self);
+    }
+
+    // Here we could potentially be more accurate than just reporting the
+    // thread as idle, since proc_threadinfo has the pth_user_time and
+    // pth_system_time fields.
+    struct proc_threadinfo ti;
+
+    if (proc_pidinfo(
+            self->proc->pid,
+            PROC_PIDTHREADINFO,
+            self->tid + _silly_offset,
+            &ti,
+            sizeof(ti))
+    != sizeof(ti)) {
+        log_d("Cannot get thread info for thread :%lx", self->tid);
+        return -1;
+    }
+    
+    return ti.pth_run_state != TH_STATE_RUNNING;
+}
+
+#endif

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -27,12 +27,15 @@
 #include <sys/types.h>
 
 #include "mem.h"
+#include "py_proc.h"
 #include "stats.h"
 
 
 typedef struct thread {
   raddr_t         raddr;
   raddr_t         next_raddr;
+
+  py_proc_t     * proc;
 
   uintptr_t       tid;
   struct thread * next;
@@ -48,9 +51,10 @@ typedef struct thread {
  *
  * @param py_thread_t  the structure to fill.
  * @param raddr_t      the remote address to read from.
+ * @param py_proc_t    the Python process the thread belongs to.
  */
 int
-py_thread__fill_from_raddr(py_thread_t *, raddr_t *);
+py_thread__fill_from_raddr(py_thread_t *, raddr_t *, py_proc_t *);
 
 
 /**

--- a/test/macos/test.bats
+++ b/test/macos/test.bats
@@ -49,3 +49,7 @@ test_case() {
 @test "Test Austin: error messages" {
   test_case error
 }
+
+@test "Test Austin: sleepless" {
+  test_case sleepless
+}

--- a/test/macos/test_sleepless.bats
+++ b/test/macos/test_sleepless.bats
@@ -1,0 +1,60 @@
+# This file is part of "austin" which is released under GPL.
+#
+# See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+# details.
+#
+# Austin is a Python frame stack sampler for CPython.
+#
+# Copyright (c) 2019 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+load "../common"
+
+
+function invoke_austin {
+  python_bin="${1}"
+
+  if ! $python_bin -V; then skip "$python_bin not found."; fi
+
+    log "Fork [Python $python_bin]"
+
+  # -------------------------------------------------------------------------
+  step "Sleepless test"
+  # -------------------------------------------------------------------------
+    run sudo $AUSTIN -si 10ms -t 1s $python_bin test/sleepy.py
+
+    assert_success
+    assert_output "cpu_bound (.*test/sleepy.py)"
+    assert_not_output ";L35"
+}
+
+
+# -----------------------------------------------------------------------------
+# -- Test Cases
+# -----------------------------------------------------------------------------
+
+@test "Test Austin with default Python 3 from Homebrew" {
+	repeat 3 invoke_austin "/usr/local/bin/python3"
+}
+
+@test "Test Austin with Python 3.8 from Homebrew (if available)" {
+  ignore
+  repeat 3 invoke_austin "/usr/local/opt/python@3.8/bin/python3"
+}
+
+@test "Test Austin with Python 3 from Anaconda (if available)" {
+  ignore
+  repeat 3 invoke_austin "/usr/local/anaconda3/bin/python"
+}


### PR DESCRIPTION
### Description of the Change

The initial implementation of the sleepless mode was not particularly useful. With this change, sleepless mode can be used to estimate CPU time on macOS by filtering out samples collected while a thread is not running.

### Alternate Designs

The macOS API actually offers a bit more than just the thread status, namely both user and system time for each thread. This implementation only reports the thread status and uses the real clock to give an estimate of CPU time.

### Regressions

Anybody relying on the old semantics for the sleepless mode should be aware of this breaking change.

### Verification Process

Added a test case to check that no idle frames are emitted while an idle thread is being sampled.