### PR TITLE
fix _pthread_tid_offset check for older versions of glibc

### DIFF
--- a/src/linux/py_thread.h
+++ b/src/linux/py_thread.h
@@ -50,9 +50,9 @@ _infer_tid_field_offset(py_thread_t * py_thread) {
       PTHREAD_BUFFER_SIZE * sizeof(void *),
       _pthread_buffer
   ))) {
-    for (register int i = 0; i < PTHREAD_BUFFER_SIZE; i++) {
+    for (register int i = 0; i < PTHREAD_BUFFER_SIZE * sizeof(void *) / sizeof(pid_t); i++) {
       log_d("pthread_t at %p", py_thread->tid);
-      if (py_thread->raddr.pid == (uintptr_t) _pthread_buffer[i]) {
+      if (py_thread->raddr.pid == *((pid_t *) _pthread_buffer + i)) {
         log_d("TID field offset: %d", i);
         _pthread_tid_offset = i;
         return;


### PR DESCRIPTION
### Requirements for Adding, Changing, Fixing or Removing a Feature

This fixes #93 

For recent versions of glic, the pthread struct is like,

```
struct pthread {
    ...
    pid_t tid,          // size_of(pid_t) == 4
    pid_t pid_unused,   // value is 0
    ...
}
```
Before this commit, the _pthread_tid_offset check logic iterates the memory
block in every 8 bytes (uintptr_t), and it works because pid_unused is 0.

However, in older versions of glibc like 2.17 which is used by RHEL/Centos 7,
its pthread struct is like below and comparing 8 bytes it does not match
the tid because the pid field is non-zero.
```
struct pthread {
    ...
    pid_t tid,          // sizeof(pid_t) == 4
    pid_t pid,          // value is not 0 but pid
    ...
}
```
### Description of the Change

Instead of iterating the memory block in uintptr_t size that is 8 bytes on 64bit Linux, iterate in pid_t size that should be 4 bytes. 

### Verification Process

Tested on both a Debian 11 host and a RHEL7 host. 
