### PR TITLE
fix(linux): fall-back inference of TID offset

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,12 @@
 2021-xx-xx v3.2.0
 
+  Improved detection of invalid samples
+
   Added support for Python launchers on Windows
 
   Improved Python version detection on Linux
 
-  Improved detection of invalid samples
+  Fixed support of older versions of glibc on Linux
 
 
 2021-08-18 v3.1.0


### PR DESCRIPTION
### Description of the Change

Older versions of glibc have a different struct pthread definition that requires scanning the pthread buffer with smaller steps in order to find the actual offset.

Mitigates #93. A cleaner fix will be provided by #95.

### Alternate Designs

An alternative and cleaner fix is described in the comments to #95. The currently proposed fix is just mitigation.

### Regressions

None expected.

### Verification Process

The existing test suite.