### PR TITLE
feat(austinp): resolve native stacks

### DIFF
--- a/.github/workflows/dev_release.yml
+++ b/.github/workflows/dev_release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate artifacts
         run: |
           sudo apt-get update
-          sudo apt-get -y install autoconf build-essential libunwind-dev musl-tools
+          sudo apt-get -y install autoconf build-essential libunwind-dev musl-tools binutils-dev
 
           # Build austin
           autoreconf --install
@@ -29,7 +29,7 @@ jobs:
           sed -i "s/$PREV_VERSION/$VERSION/g" src/austin.h
 
           # Build austinp
-          gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a
+          gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a -lbfd
 
           pushd src
           tar -Jcf austin-$VERSION-gnu-linux-amd64.tar.xz austin

--- a/.github/workflows/dev_release_arch.yml
+++ b/.github/workflows/dev_release_arch.yml
@@ -31,7 +31,7 @@ jobs:
             sed -i "s/$PREV_VERSION/$VERSION/g" src/austin.h
           run: |
             apt-get update
-            apt-get -y install autoconf build-essential libunwind-dev musl-tools
+            apt-get -y install autoconf build-essential libunwind-dev musl-tools binutils-dev
 
             # Build austin
             autoreconf --install
@@ -41,7 +41,7 @@ jobs:
             export VERSION=$(cat src/austin.h | sed -r -n "s/.*VERSION[ ]+\"(.+)\"/\1/p")
 
             # Build austinp
-            gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a
+            gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a -lbfd
 
             pushd src
             tar -Jcf austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate artifacts
         run: |
           sudo apt-get update
-          sudo apt-get -y install autoconf build-essential libunwind-dev musl-tools
+          sudo apt-get -y install autoconf build-essential libunwind-dev musl-tools binutils-dev
 
           # Build austin
           autoreconf --install
@@ -26,7 +26,7 @@ jobs:
           export VERSION=$(cat src/austin.h | sed -r -n "s/.*VERSION[ ]+\"(.+)\"/\1/p");
 
           # Build austinp
-          gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a
+          gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a -lbfd
 
           pushd src
           tar -Jcf austin-$VERSION-gnu-linux-amd64.tar.xz austin

--- a/.github/workflows/release_arch.yml
+++ b/.github/workflows/release_arch.yml
@@ -26,7 +26,7 @@ jobs:
             mkdir -p ./artifacts
           run: |
             apt-get update
-            apt-get -y install autoconf build-essential libunwind-dev musl-tools
+            apt-get -y install autoconf build-essential libunwind-dev musl-tools binutils-dev
 
             # Build austin
             autoreconf --install
@@ -36,7 +36,7 @@ jobs:
             export VERSION=$(cat src/austin.h | sed -r -n "s/.*VERSION[ ]+\"(.+)\"/\1/p")
 
             # Build austinp
-            gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a
+            gcc -O3 -Os -s -Wall -pthread src/*.c -o src/austinp -DAUSTINP -l:libunwind-ptrace.a -l:liblzma.a -l:libunwind-generic.a -l:libunwind.a -lbfd
 
             pushd src
             tar -Jcf austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austin

--- a/README.md
+++ b/README.md
@@ -442,13 +442,13 @@ sources make sure that you have the development version of the `libunwind`
 library available on your system, for example on Ubuntu,
 
 ~~~ console
-sudo apt install libunwind-dev
+sudo apt install libunwind-dev binutils-dev
 ~~~
 
 and compile with
 
 ~~~ console
-gcc -O3 -Os -Wall -pthread src/*.c -DAUSTINP -lunwind-ptrace -lunwind-generic -o src/austinp
+gcc -O3 -Os -Wall -pthread src/*.c -DAUSTINP -lunwind-ptrace -lunwind-generic -lbfd -o src/austinp
 ~~~
 
 then use as per normal. The extra `-k/--kernel` option is available with
@@ -470,6 +470,11 @@ python3 utils/resolve.py mysamples.austin > mysamples_resolved.austin
 
 Internally, the script uses `addr2line(1)` to determine source and line number
 given an address, when possible.
+
+> Whilst `austinp` comes with a stripped-down implementation of `addr2line`, it
+> is only used for the "where" mode, as resolving symbols at runtime is
+> expensive. This is to minimise the impact of austinp on the tracee, increase
+> accuracy and maximise the sampling rate.
 
 
 ## Logging

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -401,9 +401,6 @@ parse_opt (int key, char *arg, struct argp_state *state)
     #ifdef NATIVE
     pargs.native_format = (char *) SAMPLE_FORMAT_WHERE_NATIVE;
     #endif
-    
-    // We use the exposure branch to emulate sampling once
-    pargs.exposure = 1;
     break;
 
   #ifdef NATIVE
@@ -698,9 +695,6 @@ cb(const char opt, const char * arg) {
 
     pargs.head_format = (char *) HEAD_FORMAT_WHERE;
     pargs.format = (char *) SAMPLE_FORMAT_WHERE;
-    
-    // We use the exposure branch to emulate sampling once
-    pargs.exposure = 1;
     break;
 
   case 'o':

--- a/src/austin.c
+++ b/src/austin.c
@@ -276,7 +276,14 @@ int main(int argc, char ** argv) {
   if (pargs.output_file != stdout)
     log_i("Output file: %s", pargs.output_filename);
 
-  log_i("Sampling interval: %lu μs", pargs.t_sampling_interval);
+  if (pargs.where) {
+    log_i("Where mode on process %d", pargs.attach_pid);
+    pargs.t_sampling_interval = 1;
+    // We use the exposure branch to emulate sampling once
+    pargs.exposure = 1;
+  }
+  else
+    log_i("Sampling interval: %lu μs", pargs.t_sampling_interval);
 
   if (pargs.heap)
     log_i("Maximum frame heap size: %d MB", pargs.heap >> 20);

--- a/src/linux/addr2line.h
+++ b/src/linux/addr2line.h
@@ -1,0 +1,226 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018-2022 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// This source has been adapted from
+// https://github.com/bminor/binutils-gdb/blob/ce230579c65b9e04c830f35cb78ff33206e65db1/binutils/addr2line.c
+
+#include <bfd.h>
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libiberty/demangle.h>
+
+#include "../logging.h"
+#include "../stack.h"
+
+static asymbol **syms; /* Symbol table.  */
+
+static void slurp_symtab(bfd *);
+static void find_address_in_section(bfd *, asection *, void *);
+
+#define string__startswith(str, head) (strncmp(head, str, strlen(head)) == 0)
+
+// TODO: This is incomplete or plain incorrect
+static inline char *
+demangle_cython(char *function)
+{
+    if (!isvalid(function))
+        return NULL;
+
+    char *f = function;
+
+    if (string__startswith(f, "__pyx_pw_") || string__startswith(f, "__pyx_pf_"))
+        return function;
+
+    if (string__startswith(function, "__pyx_pymod_"))
+        return strchr(f + 12, '_') + 1;
+
+    if (string__startswith(f, "__pyx_fuse_"))
+        function = strstr(f + 12, "__pyx_") + 12;
+
+    while (!isdigit(*f))
+    {
+        if (*(f++) == '\0')
+            return function;
+    }
+
+    int n = 0;
+    while (*f != '\0')
+    {
+        puts(f);
+        char c = *(f++);
+        if (isdigit(c))
+            n = n * 10 + (c - '0');
+        else
+        {
+            f += n;
+            n = 0;
+            if (!isdigit(*f))
+                return f;
+        }
+    }
+
+    return function;
+}
+
+/* Read in the symbol table.  */
+
+static void
+slurp_symtab(bfd *abfd)
+{
+    long storage;
+    long symcount;
+    bool dynamic = false;
+
+    if ((bfd_get_file_flags(abfd) & HAS_SYMS) == 0)
+        return;
+
+    storage = bfd_get_symtab_upper_bound(abfd);
+    if (storage == 0)
+    {
+        storage = bfd_get_dynamic_symtab_upper_bound(abfd);
+        dynamic = true;
+    }
+    if (storage < 0)
+        return;
+
+    syms = (asymbol **)malloc(storage);
+    if (dynamic)
+        symcount = bfd_canonicalize_dynamic_symtab(abfd, syms);
+    else
+        symcount = bfd_canonicalize_symtab(abfd, syms);
+    if (symcount < 0)
+        return;
+
+    /* If there are no symbols left after canonicalization and
+     we have not tried the dynamic symbols then give them a go.  */
+    if (symcount == 0 && !dynamic && (storage = bfd_get_dynamic_symtab_upper_bound(abfd)) > 0)
+    {
+        free(syms);
+        syms = (asymbol **)malloc(storage);
+        symcount = bfd_canonicalize_dynamic_symtab(abfd, syms);
+    }
+
+    /* PR 17512: file: 2a1d3b5b.
+     Do not pretend that we have some symbols when we don't.  */
+    if (symcount <= 0)
+    {
+        free(syms);
+        syms = NULL;
+    }
+}
+
+static bfd_vma pc;
+static const char *filename;
+static const char *functionname;
+static unsigned int line;
+static unsigned int discriminator;
+
+/* Look for an address in a section.  This is called via
+   bfd_map_over_sections.  */
+
+static void
+find_address_in_section(bfd *abfd, asection *section, void *data ATTRIBUTE_UNUSED)
+{
+    bfd_vma vma;
+    bfd_size_type size;
+
+    if ((bfd_section_flags(section) & SEC_ALLOC) == 0)
+        return;
+
+    vma = bfd_section_vma(section);
+    if (pc < vma)
+        return;
+
+    size = bfd_section_size(section);
+    if (pc >= vma + size)
+        return;
+
+    bfd_find_nearest_line_discriminator(abfd, section, syms, pc - vma,
+                                        &filename, &functionname,
+                                        &line, &discriminator);
+}
+
+static inline frame_t *
+get_native_frame(const char *file_name, bfd_vma addr)
+{
+    bfd *abfd;
+    char **matching;
+
+    // TODO: This would be much cheaper if we could read directly from memory.
+    abfd = bfd_openr(file_name, NULL);
+    if (abfd == NULL)
+    {
+        log_e("Failed to open %s", file_name);
+        return NULL;
+    }
+
+    /* Decompress sections.  */
+    abfd->flags |= BFD_DECOMPRESS;
+
+    if (bfd_check_format(abfd, bfd_archive))
+    {
+        log_e("BFD format check failed");
+        return NULL;
+    }
+
+    if (!bfd_check_format_matches(abfd, bfd_object, &matching))
+    {
+        free(matching);
+        log_d("BFC format matches check failed.");
+        return NULL;
+    }
+
+    slurp_symtab(abfd);
+
+    // Reset global state for a new lookup
+    filename = functionname = NULL;
+    line = discriminator = 0;
+    pc = addr;
+
+    bfd_map_over_sections(abfd, find_address_in_section, NULL);
+
+    const char *name;
+    char *alloc = NULL;
+
+    name = functionname;
+    if (name == NULL || *name == '\0')
+        name = "<unnamed>";
+    else
+    {
+        alloc = bfd_demangle(abfd, name, DMGL_PARAMS | DMGL_ANSI);
+        if (alloc != NULL)
+            name = alloc;
+    }
+
+    free(syms);
+    syms = NULL;
+
+    frame_t *frame = isvalid(filename) && isvalid(name)
+                         ? frame_new(strdup(filename), strdup(name), line)
+                         : NULL;
+
+    bfd_close(abfd);
+
+    return frame;
+}

--- a/src/linux/vm-range-tree.h
+++ b/src/linux/vm-range-tree.h
@@ -1,0 +1,237 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018-2022 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef VM_RANGE_TREE_H
+#define VM_RANGE_TREE_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../hints.h"
+
+typedef uintptr_t addr_t;
+
+typedef struct _vmrange {
+  addr_t            lo, hi;
+  char            * name;
+  struct _vmrange * left;
+  struct _vmrange * right;
+  int               height;
+} vm_range_t;
+
+typedef struct{
+  vm_range_t *root;
+} vm_range_tree_t;
+
+#define max(a, b) ((a > b) ? a : b)
+#define vm_range__height(r) (isvalid(r) ? r->height : 0)
+
+#ifdef PY_PROC_C
+
+/**
+ * Create a new VM range.
+ * 
+ * @param lo    the range lower bound
+ * @param hi    the range upper bound
+ * @param name  the name of the VM map (takes ownership)
+ * 
+ * @return a valid reference to a VM range object, NULL otherwise.
+ */
+vm_range_t *
+vm_range_new(addr_t lo, addr_t hi, char *name) {
+  vm_range_t *range = (vm_range_t *)malloc(sizeof(vm_range_t));
+
+  range->lo = lo;
+  range->hi = hi;
+  range->name = name;
+  range->left = NULL;
+  range->right = NULL;
+  range->height = 1;
+
+  return range;
+}
+
+/**
+ * Deallocate a VM range.
+ * 
+ * @param self  the VM range to deallocate.
+ */
+void
+vm_range__destroy(vm_range_t *self) {
+  if (!isvalid(self))
+    return;
+
+  sfree(self->name);
+  
+  vm_range__destroy(self->left);
+  vm_range__destroy(self->right);
+
+  free(self);
+}
+
+
+static inline vm_range_t *
+_vm_range__rrot(vm_range_t *self) {
+  vm_range_t *x = self->left;
+  vm_range_t *T2 = x->right;
+
+  x->right = self;
+  self->left = T2;
+
+  self->height = max(vm_range__height(self->left), vm_range__height(self->right)) + 1;
+  x->height = max(vm_range__height(x->left), vm_range__height(x->right)) + 1;
+
+  return x;
+}
+
+
+static inline vm_range_t *
+_vm_range__lrot(vm_range_t *self) {
+  vm_range_t *y = self->right;
+  vm_range_t *T2 = y->left;
+
+  y->left = self;
+  self->right = T2;
+
+  self->height = max(vm_range__height(self->left), vm_range__height(self->right)) + 1;
+  y->height = max(vm_range__height(y->left), vm_range__height(y->right)) + 1;
+
+  return y;
+}
+
+
+static inline int
+_vm_range__bf(vm_range_t *self) {
+  return isvalid(self)
+             ? vm_range__height(self->left) - vm_range__height(self->right)
+             : 0;
+}
+
+static inline vm_range_t *
+_vm_range__add(vm_range_t *self, vm_range_t *range) {
+  if (!isvalid(self))
+    return range;
+
+  if (range->lo < self->lo)
+    self->left = _vm_range__add(self->left, range);
+  else
+    self->right = _vm_range__add(self->right, range);
+
+  self->height = 1 + max(vm_range__height(self->left), vm_range__height(self->right));
+
+  // Balance the tree
+  int balance = _vm_range__bf(self);
+  if (balance > 1)
+  {
+    if (range->lo < self->left->lo)
+      return _vm_range__rrot(self);
+    else
+    {
+      self->left = _vm_range__lrot(self->left);
+      return _vm_range__rrot(self);
+    }
+  }
+  else if (balance < -1)
+  {
+    if (range->lo > self->right->lo)
+      return _vm_range__lrot(self);
+    else
+    {
+      self->right = _vm_range__rrot(self->right);
+      return _vm_range__lrot(self);
+    }
+  }
+
+  return self;
+}
+
+
+/**
+ * Create a new VM range tree. This is an implementation of an AVL tree that
+ * is meant to store *non-overlapping* VM ranges for a fast look-up.
+ * 
+ * @return a valid reference to a new VM range tree, NULL otherwise.
+ */
+vm_range_tree_t *
+vm_range_tree_new() {
+  return (vm_range_tree_t *)calloc(1, sizeof(vm_range_tree_t));
+}
+
+
+/**
+ * Add a new range to the VM range tree.
+ * 
+ * The callee has the responsibility of ensuring that all the VM ranges that
+ * are added to this data structure are *non-overlapping*. Failure to comply to
+ * this constraint will make lookups fairly pointless.
+ */
+void
+vm_range_tree__add(vm_range_tree_t *self, vm_range_t *range) {
+  self->root = _vm_range__add(self->root, range);
+}
+
+
+void
+vm_range_tree__destroy(vm_range_tree_t *self) {
+  if (!isvalid(self))
+    return;
+
+  vm_range__destroy(self->root);
+
+  free(self);
+}
+
+#endif // PY_PROC_C
+
+#ifdef PY_THREAD_C
+
+static inline vm_range_t *
+_vm_range__find(vm_range_t *self, addr_t addr) {
+  if (!isvalid(self))
+    return NULL;
+
+  if (addr >= self->lo && addr < self->hi)
+    return self;
+
+  return _vm_range__find(addr < self->lo ? self->left : self->right, addr);
+}
+
+
+/**
+ * Query the tree for the range that contains the given address (if any).
+ * 
+ * If any of the ranges stored within the VM range tree data structure overlap,
+ * the result of this method might be meaningless.
+ *
+ * @param self  the VM range tree to query.
+ * @param addr  the address to look up.
+ * 
+ * @return a valid reference to a VM range, NULL otherwise.
+ */
+vm_range_t *
+vm_range_tree__find(vm_range_tree_t *self, addr_t addr) {
+  return _vm_range__find(self->root, addr);
+}
+
+#endif // PY_THREAD_C
+
+#endif

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -29,6 +29,8 @@
 #ifdef NATIVE
 #include <sys/ptrace.h>
 #include <libunwind-ptrace.h>
+#include "linux/vm-range-tree.h"
+#include "cache.h"
 #endif
 
 #include "cache.h"
@@ -93,8 +95,10 @@ typedef struct {
 
   #ifdef NATIVE
   struct _puw {
-    unw_addr_space_t   as;
-  } unwind;
+    unw_addr_space_t as;
+  }                 unwind;
+  vm_range_tree_t * maps_tree;
+  hash_table_t    * base_table;
   #endif
 
   // Platform-dependent fields

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -17,9 +17,6 @@ def demangle_cython(function: str) -> str:
     else:
         raise ValueError(f"Invalid Cython mangled name: {function}")
 
-    if function.startswith("__pyx_pf_"):
-        function = function[: function.rindex(".isra.")]
-
     n = 0
     while i < len(function):
         c = function[i]
@@ -83,13 +80,17 @@ class Maps:
         parts = []
         frames, _, metrics = line.strip().rpartition(" ")
         for part in frames.split(";"):
-            if part.startswith("native@"):
+            try:
                 head, function, lineno = part.split(":")
-                if function.startswith("__pyx_pw_"):
-                    # skip Cython wrappers (cpdef)
-                    continue
-                if function.startswith("__pyx_"):
-                    function = demangle_cython(function)
+            except ValueError:
+                parts.append(part)
+                continue
+            if function.startswith("__pyx_pw_") or function.startswith("__pyx_pf_"):
+                # skip Cython wrappers (cpdef)
+                continue
+            if function.startswith("__pyx_"):
+                function = demangle_cython(function)
+            if head.startswith("native@"):
                 _, _, address = head.partition("@")
                 resolved = self.addr2line(address)
                 if resolved is None:
@@ -98,7 +99,7 @@ class Maps:
                     source, native_lineno = resolved
                     parts.append(f"{source}:{function}:{native_lineno or lineno}")
             else:
-                parts.append(part)
+                parts.append(":".join((head, function, lineno)))
 
         return " ".join((";".join(parts), metrics))
 


### PR DESCRIPTION
### Description of the Change

Implemented a stripped-down version of the addr2line utility to resolve the source file and line number of native stacks in where mode. Normal sampling mode does not benefit from this to ensure the best sample throughput.

Also ensure that we retry initialising the unwind cursor in case of an expected error code, to prevent skipping samples.

### Alternate Designs

Manually parsing the DWARF information is an alternative design, but the effort would be much larger.


### Regressions

None expected

### Verification Process

Existing test suite.
