### PR TITLE
ci: add cog support and checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -122,3 +122,23 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./cobertura.xml
           verbose: true
+
+  check-cog:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Check cog output
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install cog
+        run: pip install cogapp
+
+      - name: Compile Austin
+        run: |
+          autoreconf --install
+          ./configure
+          make
+
+      - name: Run cog check
+        run: bash scripts/cog.sh --check

--- a/README.md
+++ b/README.md
@@ -297,6 +297,12 @@ bug with Austin and you want to report it here.
 
 # Usage
 
+<!-- [[[cog
+from subprocess import check_output
+print("~~~")
+print(check_output(["src/austin", "--help"]).decode().strip())
+print("~~~")
+]]] -->
 ~~~
 Usage: austin [OPTION...] command [ARG...]
 Austin is a frame stack sampler for CPython that is used to extract profiling
@@ -332,6 +338,7 @@ for any corresponding short options.
 
 Report bugs to <https://github.com/P403n1x87/austin/issues>.
 ~~~
+<!-- [[[end]]] -->
 
 The output is a sequence of frame stack samples, one on each line. The format is
 the collapsed one that is recognised by [FlameGraph] so that it can be piped

--- a/scripts/cog.sh
+++ b/scripts/cog.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    args="-r"
+else
+    args=$@
+fi
+
+cog -P $args \
+    README.md \
+    src/argparse.c 

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -547,6 +547,12 @@ _handle_opts(arg_option * opts, arg_callback cb, int * argi, int argc, char ** a
 
 
 static const char * help_msg = \
+/*[[[cog
+from subprocess import check_output
+for line in check_output(["src/austin", "--help"]).decode().splitlines():
+  print(f'"{line}\\n"')
+print(";")
+]]]*/
 "Usage: austin [OPTION...] command [ARG...]\n"
 "Austin is a frame stack sampler for CPython that is used to extract profiling\n"
 "data out of a running Python process (and all its children, if required) that\n"
@@ -579,14 +585,25 @@ static const char * help_msg = \
 "Mandatory or optional arguments to long options are also mandatory or optional\n"
 "for any corresponding short options.\n"
 "\n"
-"Report bugs to <https://github.com/P403n1x87/austin/issues>.\n";
+"Report bugs to <https://github.com/P403n1x87/austin/issues>.\n"
+;
+/*[[[end]]]*/
 
 static const char * usage_msg = \
+/*[[[cog
+from subprocess import check_output
+for line in check_output(["src/austin", "--usage"]).decode().splitlines():
+  print(f'"{line}\\n"')
+print(";")
+]]]*/
 "Usage: austin [-aCefgmPs?V] [-h n_mb] [-i n_us] [-o FILE] [-p PID] [-t n_ms]\n"
-"            [-x n_sec] [--alt-format] [--children] [--exclude-empty] [--full]\n"
-"            [--gc] [--heap=n_mb] [--interval=n_us] [--memory] [--output=FILE]\n"
-"            [--pid=PID] [--pipe] [--sleepless] [--timeout=n_ms]\n"
-"            [--exposure=n_sec] [--help] [--usage] [--version] command [ARG...]\n";
+"            [-w PID] [-x n_sec] [--alt-format] [--children] [--exclude-empty]\n"
+"            [--full] [--gc] [--heap=n_mb] [--interval=n_us] [--memory]\n"
+"            [--output=FILE] [--pid=PID] [--pipe] [--sleepless] [--timeout=n_ms]\n"
+"            [--where=PID] [--exposure=n_sec] [--help] [--usage] [--version]\n"
+"            command [ARG...]\n"
+;
+/*[[[end]]]*/
 
 
 static void


### PR DESCRIPTION
### Description of the Change

Use cog to autogenerate the content of some sources to ensure they
are up-to-date with the latest changes.

### Alternate Designs

N. A.

### Regressions

N. A.

### Verification Process

New CI job to run cog checks.