### PR TITLE
ci: use matrix for Python versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,8 +109,8 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r test/requirements.txt
-          .venv/bin/pytest --pastebin=failed --no-flaky-report -sr fE || true
-          sudo .venv/bin/pytest --pastebin=failed --no-flaky-report -sr fE || true
+          .venv/bin/pytest --pastebin=failed --no-flaky-report -sr fE -n auto || true
+          sudo .venv/bin/pytest --pastebin=failed --no-flaky-report -sr fE -n auto || true
           deactivate
 
       - name: Generate Cobertura report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,16 @@ concurrency:
 jobs:
   tests-linux:
     runs-on: ubuntu-latest
+    
     strategy:
       fail-fast: false
-    name: Tests on Linux
+      matrix:
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+    
+    env:
+      AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
+    
+    name: Tests on Linux with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
 
@@ -22,9 +29,22 @@ jobs:
           sudo apt-get -y install \
             valgrind \
             gdb \
-            python2.7 \
-            python3.{5..11} \
-            python3.10-full
+            python${{ matrix.python-version }} \
+            python3.10{,-full}
+
+      # Using these actions lead to Python binaries that cause SIGSEGV during
+      # C unit tests. See
+      # https://github.com/actions/setup-python/issues/442.
+
+      # - name: Install Python
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: ${{ matrix.python-version }}
+
+      # - name: Install Python 3.10
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: "3.10"
 
       - name: Compile Austin
         run: |
@@ -39,42 +59,59 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r test/requirements.txt
-          .venv/bin/pytest --pastebin=failed --no-flaky-report -sr a -n auto
-          sudo .venv/bin/pytest --pastebin=failed --no-flaky-report -sr a -n auto
+          sudo -E .venv/bin/pytest --pastebin=failed --no-flaky-report -sr a
+          .venv/bin/pytest --pastebin=failed --no-flaky-report -sr a
           deactivate
 
   tests-osx:
     runs-on: macos-latest
+
     strategy:
       fail-fast: false
-    name: Tests on macOS
+      matrix:
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    env:
+      AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
+
+    name: Tests on macOS with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - name: Compile Austin
         run: gcc -Wall -O3 -g src/*.c -o src/austin
 
-      - name: Install test dependencies
-        run: |
-          brew update
-          brew install python@3.7
-          brew install python@3.8
-          brew install python@3.9
-          brew install python@3.10
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}-dev
+
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Run tests
         run: |
-          $(brew --prefix)/opt/python@3.10/bin/python3 -m venv .venv
+          python3.10 -m pip install --upgrade pip
+          python3.10 -m pip install -r test/requirements.txt
+          python${{ matrix.python-version }} -m venv .venv \
+            || (python${{ matrix.python-version }} -m pip install virtualenv && python${{ matrix.python-version }} -m virtualenv .venv)
           source .venv/bin/activate
-          pip install --upgrade pip
-          pip install -r test/requirements.txt
-          sudo .venv/bin/pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -sr a -n auto
+          sudo -E pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -sr a
           deactivate
 
   tests-win:
     runs-on: windows-latest
+
     strategy:
       fail-fast: false
-    name: Tests on Windows
+      matrix:
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    env:
+      AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
+    
+    name: Tests on Windows with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
 
@@ -83,21 +120,15 @@ jobs:
           gcc.exe -O3 -g -o src/austin.exe src/*.c -lpsapi -lntdll -Wall
           src\austin.exe --help
 
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}-dev
+
       - uses: actions/setup-python@v2
-        name: Setup Python
+        name: Install Python 3.10
         with:
           python-version: '3.10'
-
-      - name: Install test dependencies
-        run: |
-          choco install python --no-progress -y --version=2.7.11
-          choco install python --no-progress -y --version=3.5.4
-          choco install python --no-progress -y --version=3.6.8
-          choco install python --no-progress -y --version=3.7.9
-          choco install python --no-progress -y --version=3.8.10
-          choco install python --no-progress -y --version=3.9.10
-          choco install python --no-progress -y --version=3.11.0-b3 --pre 
-          refreshenv
 
       - name: Run tests
         run: |
@@ -105,5 +136,5 @@ jobs:
           venv\Scripts\Activate.ps1
           python -m pip install --upgrade pip
           python -m pip install -r test/requirements.txt
-          python -m pytest --ignore=test\cunit --pastebin=failed --no-flaky-report -sr a -n auto
+          python -m pytest --ignore=test\cunit --pastebin=failed --no-flaky-report -sr a
           deactivate

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,9 +1,23 @@
+import os
 import platform
 
 PY3_LATEST = 11
 
+try:
+    REQUESTED_PYTHON_VERSIONS = [
+        tuple(int(_) for _ in v.split("."))
+        for v in os.getenv("AUSTIN_TESTS_PYTHON_VERSIONS", "").split(",")
+    ]
+except Exception:
+    REQUESTED_PYTHON_VERSIONS = None
+
+
 match platform.system():
     case "Darwin":
-        PYTHON_VERSIONS = [(3, _) for _ in range(7, PY3_LATEST + 1)]
+        PYTHON_VERSIONS = REQUESTED_PYTHON_VERSIONS or [
+            (3, _) for _ in range(7, PY3_LATEST + 1)
+        ]
     case _:
-        PYTHON_VERSIONS = [(2, 7)] + [(3, _) for _ in range(5, PY3_LATEST + 1)]
+        PYTHON_VERSIONS = REQUESTED_PYTHON_VERSIONS or [(2, 7)] + [
+            (3, _) for _ in range(5, PY3_LATEST + 1)
+        ]

--- a/test/test_attach.py
+++ b/test/test_attach.py
@@ -43,8 +43,13 @@ from flaky import flaky
 
 
 def allpythons():
-    # Attach tests fail on Windows for Python < 3.7
-    return _allpythons(min=(3, 7) if platform.system() == "Windows" else None)
+    # Attach tests fail on Windows for Python < 3.7 and on MacOS for Python < 3
+    match platform.system():
+        case "Windows":
+            return _allpythons(min=(3, 7))
+        case "Darwin":
+            return _allpythons(min=(3,))
+    return _allpythons()
 
 
 @flaky(max_runs=6)


### PR DESCRIPTION
With this change, we can use the install-python action for installing Python on all supported platforms.