### PR TITLE
Allow disabling logging by setting AUSTIN_NO_LOGGING in the environment

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 
   Added support for Python 3.11.
 
+  Allowed disabling logging by setting the environment variable
+  AUSTIN_NO_LOGGING.
+
   Improved permission error reporting on MacOS.
 
   Improved MacOS support.

--- a/README.md
+++ b/README.md
@@ -355,6 +355,15 @@ where the structure of `[frame]` and the number and type of metrics on each line
 depend on the mode.
 
 
+## Environment variables
+
+Some behaviour of Austin can be configured via environment variables.
+
+| Variable            | Effect |
+| ------------------- | ------ |
+| `AUSTIN_NO_LOGGING` | Disables all [log messages](#logging) (since Austin 3.4.0). |
+
+
 ## Normal Mode
 
 In normal mode, the `[frame]` part of each emitted sample has the structure
@@ -521,6 +530,8 @@ for log messages, so make sure to watch these to get execution details and
 statistics. _Bad_ frames are output together with the other frames. In general,
 entries for bad frames will not be visible in a flame graph as all tests show
 error rates below 1% on average.
+
+Logging can be disabled using [environment variables](#environment-variables).
 
 
 ## Cheat sheet

--- a/src/logging.c
+++ b/src/logging.c
@@ -50,9 +50,11 @@ FILE * logfile = NULL;
 #include "austin.h"
 #include "logging.h"
 
+int logging = 1;
 
 void
 _log_writer(int prio, const char * fmt, va_list ap) {
+  if (!logging) return;
   #ifdef PL_UNIX
   vsyslog(prio, fmt, ap);
 
@@ -69,9 +71,16 @@ _log_writer(int prio, const char * fmt, va_list ap) {
   #endif
 }
 
+static int
+has_nonempty_env(const char * s) {
+  const char * v = getenv(s);
+  return v != NULL && *v != '\0';
+}
 
 void
 logger_init(void) {
+  if (has_nonempty_env("AUSTIN_NO_LOGGING")) logging = 0;
+  if (!logging) return;
   #ifdef PL_UNIX
   setlogmask (LOG_UPTO (LOG_DEBUG));
   openlog ("austin", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);
@@ -162,6 +171,7 @@ log_t(const char * fmt, ...) {
 
 void
 logger_close(void) {
+  if (!logging) return;
   #ifdef PL_UNIX
   closelog();
 

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -235,3 +235,13 @@ def test_qualnames(py, austin):
 
     assert has_pattern(result.stdout, "qualnames.py:Foo.run"), compress(result.stdout)
     assert has_pattern(result.stdout, "qualnames.py:Bar.run"), compress(result.stdout)
+
+
+@allpythons()
+def test_no_logging(py, monkeypatch):
+    monkeypatch.setenv("AUSTIN_NO_LOGGING", "1")
+    result = austin("-i", "1ms", *python(py), target("target34.py"))
+    assert has_pattern(result.stdout, "target34.py:keep_cpu_busy:3"), compress(
+        result.stdout
+    )
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
Add a check in logging.c for the environment variable AUSTIN_NO_LOGGING. If it is nonempty, logging is disabled on all platforms.

### Alternate Designs

None considered.

### Regressions

No possible side-effects, as the odds of existing users inadvertently setting AUSTIN_NO_LOGGING are minimal.

### Verification Process

To test (on Linux):

1. Compile with `gcc -O3 -Os -Wall -pthread src/*.c -o src/austin`
2. Open a separate terminal to watch the syslog output with `journalctl -f -t austin -n0`
3. Run `AUSTIN_NO_LOGGING=1 ./src/austin python3 -c 'import time; time.sleep(1)'` and observe that nothing is output to syslog
4. Run `AUSTIN_NO_LOGGING= ./src/austin python3 -c 'import time; time.sleep(1)'` and observe the usual output to syslog
5. Run `./src/austin python3 -c 'import time; time.sleep(1)'` and observe the usual output to syslog