### PR TITLE
ci(cunit): set generic argument and return types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,26 +32,29 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get -y install \
             valgrind \
-            gdb \
-            python${{ matrix.python-version }} \
-            python3.10{,-full}
+            gdb
 
-      # Using these actions lead to Python binaries that cause SIGSEGV during
-      # C unit tests. See
-      # https://github.com/actions/setup-python/issues/442.
+      # See (https://github.com/actions/setup-python/issues/442#issuecomment-1167837162)
+      - name: Temprorary setup-python workaround
+        run: |
+          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
+          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi7_3.3-4_amd64.deb
+          sudo dpkg -i libffi6_3.2.1-8_amd64.deb
+          sudo ln -sf libffi.so.6.0.4 /usr/lib/x86_64-linux-gnu/libffi.so
+          sudo dpkg -i libffi7_3.3-4_amd64.deb
+          sudo ln -sf libffi.so.7.1.0 /lib/x86_64-linux-gnu/libffi.so.7
 
-      # - name: Install Python
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      # - name: Install Python 3.10
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: "3.10"
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Compile Austin
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,20 +36,10 @@ jobs:
             valgrind \
             gdb
 
-      # See (https://github.com/actions/setup-python/issues/442#issuecomment-1167837162)
-      - name: Temprorary setup-python workaround
-        run: |
-          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
-          curl -LO http://archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi7_3.3-4_amd64.deb
-          sudo dpkg -i libffi6_3.2.1-8_amd64.deb
-          sudo ln -sf libffi.so.6.0.4 /usr/lib/x86_64-linux-gnu/libffi.so
-          sudo dpkg -i libffi7_3.3-4_amd64.deb
-          sudo ln -sf libffi.so.7.1.0 /lib/x86_64-linux-gnu/libffi.so.7
-
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}-dev
 
       - name: Install Python 3.10
         uses: actions/setup-python@v4

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -1,6 +1,6 @@
 import ctypes
 import re
-from ctypes import CDLL, POINTER, Structure, c_char_p, cast
+from ctypes import CDLL, POINTER, Structure, c_char_p, c_void_p, cast
 from pathlib import Path
 from subprocess import PIPE, STDOUT, run
 from types import ModuleType
@@ -87,6 +87,10 @@ def compile(
 
 
 C = CDLL("libc.so.6")
+
+# https://github.com/actions/setup-python/issues/442#issuecomment-1193140956
+C.malloc.restype = ctypes.c_void_p
+C.free.argtypes = [ctypes.c_void_p]
 
 
 class CFunctionDef:
@@ -231,6 +235,8 @@ class DeclCollector(c_ast.NodeVisitor):
             if isinstance(ret_type, c_ast.PtrDecl):
                 if "".join(ret_type.type.type.names) == "char":
                     rtype = c_char_p
+                else:
+                    rtype = c_void_p
             args = (
                 [_.name if hasattr(_, "name") else None for _ in node.type.args.params]
                 if node.type.args is not None

--- a/test/cunit/test_cache.py
+++ b/test/cunit/test_cache.py
@@ -1,9 +1,12 @@
+from ctypes import c_void_p
 from test.cunit import C
 from test.cunit.cache import Chain, HashTable, LruCache, Queue, QueueItem
 
 import pytest
 
 NULL = 0
+C.free.argtypes = [c_void_p]
+C.malloc.restype = c_void_p
 
 
 def test_queue_item():
@@ -31,7 +34,7 @@ def test_queue(qsize):
 
     assert qsize == 0 or not q.is_empty()
     assert q.is_full()
-    assert q.enqueue(42, 42) is NULL
+    assert q.enqueue(42, 42) is None
 
     assert values == [q.dequeue() for _ in range(qsize)]
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -27,6 +27,7 @@ from asyncio.subprocess import STDOUT
 from collections import Counter, defaultdict
 from io import BytesIO, StringIO
 from pathlib import Path
+from shutil import rmtree
 from subprocess import PIPE, CompletedProcess, Popen, check_output, run
 from test import PYTHON_VERSIONS
 from time import sleep
@@ -109,7 +110,7 @@ def bt(binary: Path) -> str:
             result = gdb(["bt full", "q"], str(binary), target_dir / "CoreDump")
 
             crash.unlink()
-            target_dir.rmdir()
+            rmtree(str(target_dir))
 
             return result
 


### PR DESCRIPTION
### Description of the Change

Depending on how Python is compiled on certain architectures, not giving types to C functions using `ctypes` can lead to mangled values (e.g. a 64-bit pointer having its top 32 bits set to 1). This is a highly likely source of segmentation faults, and they were discovered using the Python builds from the setup-python action.

With this change, we ensure that all arguments and return values get a default type. We use `c_void_p` for any pointer and `c_long` for any non-pointer argument/return value, to ensure that the passed bits are not altered by unwanted conversions.

### Alternate Designs

N. A.

### Regressions

N. A.

### Verification Process

Existing test suite.