### PR TITLE
perf: cache string objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@
 
   Improved austinp support on fork.
 
+  Small performance improvements.
+
   Renamed the austinp binary installed from the Snap Store from austin.austinp
   to austin.p.
   

--- a/src/austin.c
+++ b/src/austin.c
@@ -314,6 +314,7 @@ int main(int argc, char ** argv) {
 
   stats_start();
 
+
   // Start sampling
   if (pargs.children) {
     do_child_processes(py_proc);

--- a/src/austin.c
+++ b/src/austin.c
@@ -314,7 +314,6 @@ int main(int argc, char ** argv) {
 
   stats_start();
 
-
   // Start sampling
   if (pargs.children) {
     do_child_processes(py_proc);

--- a/src/cache.c
+++ b/src/cache.c
@@ -229,6 +229,11 @@ hash_table_new(int capacity) {
   hash->capacity = capacity;
   hash->chains = (chain_t **) calloc(hash->capacity, sizeof(chain_t *));
 
+  #ifdef DEBUG
+  hash->set_total = 0;
+  hash->set_empty = 0;
+  #endif
+
   return hash;
 }
 
@@ -254,10 +259,6 @@ hash_table__get(hash_table_t *self, key_dt key) {
 }
 
 // ----------------------------------------------------------------------------
-#ifdef DEBUG
-static unsigned int _set_total = 0;
-static unsigned int _set_empty = 0;
-#endif
 
 void
 hash_table__set(hash_table_t *self, key_dt key, value_t value) {
@@ -267,7 +268,7 @@ hash_table__set(hash_table_t *self, key_dt key, value_t value) {
   index_t index = _hash_table__index(self, key);
 
   #ifdef DEBUG
-  _set_total++;
+  self->set_total++;
   #endif
 
   chain_t * chain = self->chains[index];
@@ -275,7 +276,7 @@ hash_table__set(hash_table_t *self, key_dt key, value_t value) {
     if (self->size >= self->capacity)
       return;
     #ifdef DEBUG
-    _set_empty++;
+    self->set_empty++;
     #endif
     self->chains[index] = chain_head();
     self->size += chain__add(self->chains[index], key, value);
@@ -336,6 +337,11 @@ lru_cache_new(int capacity, void (*deallocator)(value_t)) {
   cache->queue    = queue_new(capacity, deallocator);
   cache->hash     = hash_table_new((capacity * 4 / 3) | 1);
 
+  #ifdef DEBUG
+  cache->hits = 0;
+  cache->misses = 0;
+  #endif
+
   return cache;
 }
 
@@ -344,8 +350,16 @@ value_t
 lru_cache__maybe_hit(lru_cache_t *self, key_dt key) {
   queue_item_t *item = (queue_item_t *)hash_table__get(self->hash, key);
 
-  if (!isvalid(item))
+  if (!isvalid(item)) {
+    #ifdef DEBUG
+    self->misses++;
+    #endif
     return NULL;
+  }
+
+  #ifdef DEBUG
+  self->hits++;
+  #endif
 
   // Bring hit element to the front of the queue
   if (item != self->queue->front)
@@ -393,13 +407,21 @@ lru_cache__destroy(lru_cache_t *self) {
   if (!isvalid(self))
     return;
 
+  #ifdef DEBUG
+  size_t total = self->hits + self->misses;
   log_d(
-    "LRU cache collisions: %d/%d (%0.2f%%, prob: %0.2f%%)\n",
-    _set_total - _set_empty,
-    _set_total,
-    (_set_total - _set_empty) * 100.0 / _set_total,
+    "(%s) hit ratio: %d/%d (%0.2f%%)\n",
+    self->name, self->hits, total, (self->hits) * 100.0 / total
+  );
+  log_d(
+    "(%s) hash collisions: %d/%d (%0.2f%%, prob: %0.2f%%)\n",
+    self->name,
+    self->hash->set_total - self->hash->set_empty,
+    self->hash->set_total,
+    (self->hash->set_total - self->hash->set_empty) * 100.0 / self->hash->set_total,
     100.0 * (1 - exp(-((double) self->queue->count) * (self->queue->count - 1.0) / 2.0 / self->hash->capacity))
   );
+  #endif
 
   queue__destroy(self->queue);
   hash_table__destroy(self->hash);

--- a/src/cache.h
+++ b/src/cache.h
@@ -160,6 +160,11 @@ typedef struct hash_table_t {
     size_t capacity;
     size_t size;
     chain_t **chains;
+
+    #ifdef DEBUG
+    size_t set_total;
+    size_t set_empty;
+    #endif
 } hash_table_t;
 
 
@@ -344,6 +349,12 @@ typedef struct {
     int capacity;
     queue_t *queue;
     hash_table_t *hash;
+
+    #ifdef DEBUG
+    const char * name;
+    size_t hits;
+    size_t misses;
+    #endif
 } lru_cache_t;
 
 

--- a/src/events.h
+++ b/src/events.h
@@ -26,6 +26,7 @@
 #include <stdio.h>
 
 #include "argparse.h"
+#include "hints.h"
 #include "logging.h"
 #include "mojo.h"
 #include "platform.h"
@@ -81,13 +82,15 @@
     }                                                             \
   }
 
-#define emit_frame_ref(format, frame)                                                  \
-  {                                                                                    \
-    if (pargs.binary) {                                                                \
-      mojo_frame_ref(frame);                                                           \
-    } else {                                                                           \
-      fprintfp(pargs.output_file, format, frame->filename, frame->scope, frame->line); \
-    }                                                                                  \
+#define emit_frame_ref(format, frame)                                      \
+  {                                                                        \
+    if (pargs.binary) {                                                    \
+      mojo_frame_ref(frame);                                               \
+    } else {                                                               \
+      fprintfp(pargs.output_file, format, frame->filename,                 \
+               frame->scope == UNKNOWN_SCOPE ? "<unknown>" : frame->scope, \
+               frame->line);                                               \
+    }                                                                      \
   }
 
 #define emit_time_metric(value)                                \

--- a/src/hints.h
+++ b/src/hints.h
@@ -50,4 +50,6 @@
 #define NOK                             {retval = 1; goto release;}
 #define released                        return retval;
 
+#define UNKNOWN_SCOPE                   ((char *) 1)
+
 #endif

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -78,6 +78,7 @@ typedef struct {
   void          * is_raddr;
 
   lru_cache_t   * frame_cache;
+  lru_cache_t   * string_cache;
 
   // Temporal profiling support
   ctime_t         timestamp;

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -33,6 +33,7 @@
 
 #define MAXLEN                      1024
 #define MAX_STACK_SIZE              2048
+#define MAX_STRING_CACHE_SIZE       1024
 
 
 typedef struct thread {

--- a/src/stack.h
+++ b/src/stack.h
@@ -28,7 +28,9 @@
 
 #include "cache.h"
 #include "hints.h"
+#include "py_proc.h"
 #include "py_string.h"
+#include "py_thread.h"
 #include "version.h"
 
 typedef struct {
@@ -220,34 +222,48 @@ _read_signed_varint(unsigned char * lnotab, size_t * i) {
 
 // ----------------------------------------------------------------------------
 static inline frame_t *
-_frame_from_code_raddr(raddr_t * raddr, int lasti, python_v * py_v) {
+_frame_from_code_raddr(py_thread_t * py_thread, void * code_raddr, int lasti, python_v * py_v) {
   PyCodeObject    code;
   unsigned char * lnotab = NULL;
+  py_proc_t     * py_proc = py_thread->proc;
+  pid_t           pid = py_thread->raddr.pid;
 
-  if (fail(copy_from_raddr_v(raddr, code, py_v->py_code.size))) {
+  if (fail(copy_py(pid, code_raddr, py_code, code))) {
     log_ie("Cannot read remote PyCodeObject");
     return NULL;
   }
 
-  char * filename = _code__get_filename(&code, raddr->pid, py_v);
+  key_dt string_key = ((key_dt) *((void **) ((void *) &code + py_v->py_code.o_filename)));
+  char * filename = lru_cache__maybe_hit(py_proc->string_cache, string_key);
   if (!isvalid(filename)) {
-    log_ie("Cannot get file name from PyCodeObject");
-    return NULL;
+    filename = _code__get_filename(&code, pid, py_v);
+    if (!isvalid(filename)) {
+      log_ie("Cannot get file name from PyCodeObject");
+      return NULL;
+    }
+    lru_cache__store(py_proc->string_cache, string_key, filename);
   }
 
-  char * scope = V_MIN(3, 11)
-    ? _code__get_qualname(&code, raddr->pid, py_v)
-    : _code__get_name(&code, raddr->pid, py_v);
+  string_key = V_MIN(3, 11)
+    ? ((key_dt) *((void **) ((void *) &code + py_v->py_code.o_qualname)))
+    : ((key_dt) *((void **) ((void *) &code + py_v->py_code.o_name)));
+  char * scope = lru_cache__maybe_hit(py_proc->string_cache, string_key);
   if (!isvalid(scope)) {
-    log_ie("Cannot get scope name from PyCodeObject");
-    goto failed;
+    scope = V_MIN(3, 11)
+      ? _code__get_qualname(&code, pid, py_v)
+      : _code__get_name(&code, pid, py_v);
+    if (!isvalid(scope)) {
+      log_ie("Cannot get scope name from PyCodeObject");
+      return NULL;
+    }
+    lru_cache__store(py_proc->string_cache, string_key, scope);
   }
 
   ssize_t len = 0;
   int lineno = V_FIELD(unsigned int, code, py_code, o_firstlineno);
 
   if (V_MIN(3, 11)) {
-    lnotab = _code__get_lnotab(&code, raddr->pid, &len, py_v);
+    lnotab = _code__get_lnotab(&code, pid, &len, py_v);
     if (!isvalid(lnotab) || len == 0) {
       log_ie("Cannot get line information from PyCodeObject");
       goto failed;
@@ -289,7 +305,7 @@ _frame_from_code_raddr(raddr_t * raddr, int lasti, python_v * py_v) {
     }
   }
   else {
-    lnotab = _code__get_lnotab(&code, raddr->pid, &len, py_v);
+    lnotab = _code__get_lnotab(&code, pid, &len, py_v);
     if (!isvalid(lnotab) || len % 2) {
       log_ie("Cannot get line information from PyCodeObject");
       goto failed;
@@ -331,7 +347,7 @@ _frame_from_code_raddr(raddr_t * raddr, int lasti, python_v * py_v) {
 
   free(lnotab);
 
-  frame_t * frame = frame_new(py_frame_key(raddr->addr, lasti), filename, scope, lineno);
+  frame_t * frame = frame_new(py_frame_key(code_raddr, lasti), filename, scope, lineno);
   if (!isvalid(frame)) {
     log_e("Failed to create frame object");
     goto failed;
@@ -341,8 +357,6 @@ _frame_from_code_raddr(raddr_t * raddr, int lasti, python_v * py_v) {
 
 failed:
   sfree(lnotab);
-  sfree(filename);
-  sfree(scope);
   
   return NULL;
 }
@@ -356,9 +370,6 @@ static inline void
 frame__destroy(frame_t * self) {
   if (!isvalid(self))
     return;
-
-  sfree(self->filename);
-  sfree(self->scope);
 
   free(self);
 }


### PR DESCRIPTION
### Description of the Change

Some strings may be shared across code objects and therefore it makes sense to store them in a cache for faster access.

### Alternate Designs

N.A.

### Regressions

We expect string objects attached to code objects to live as long as the latter so that addresses are not reused for different string objects.

### Verification Process

Existing test suite.