### PR TITLE
ci: hardened runtime workaround

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -98,47 +98,9 @@ jobs:
           python-version: "3.10"
 
       - name: Remove signature from the Python binary
-        run: sudo codesign --remove-signature `which python${{ matrix.python-version }}` || true
-
-      - name: Run tests
         run: |
-          python3.10 -m pip install --upgrade pip
-          python3.10 -m pip install -r test/requirements.txt
-          python${{ matrix.python-version }} -m venv .venv \
-            || (python${{ matrix.python-version }} -m pip install virtualenv && python${{ matrix.python-version }} -m virtualenv .venv)
-          source .venv/bin/activate
-          sudo -E pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -sr a
-          deactivate
-
-  tests-osx-pyenv:
-    runs-on: macos-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
-
-    env:
-      AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
-
-    name: Tests on macOS with Python ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Compile Austin
-        run: gcc -Wall -O3 -g src/*.c -o src/austin
-
-      - name: Install Python
-        uses: gabrielfalcao/pyenv-action@v9
-        with:
-          default: "${{ matrix.python-version }}:latest"
-
-      - name: Install Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
-      - name: Remove signature from the Python binary
-        run: sudo codesign --remove-signature `which python${{ matrix.python-version }}` || true
+          codesign --remove-signature /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin/python3 || true
+          codesign --remove-signature /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/Resources/Python.app/Contents/MacOS/Python || true
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -96,6 +96,49 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+
+      - name: Remove signature from the Python binary
+        run: sudo codesign --remove-signature `which python${{ matrix.python-version }}` || true
+
+      - name: Run tests
+        run: |
+          python3.10 -m pip install --upgrade pip
+          python3.10 -m pip install -r test/requirements.txt
+          python${{ matrix.python-version }} -m venv .venv \
+            || (python${{ matrix.python-version }} -m pip install virtualenv && python${{ matrix.python-version }} -m virtualenv .venv)
+          source .venv/bin/activate
+          sudo -E pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -sr a
+          deactivate
+
+  tests-osx-pyenv:
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+
+    env:
+      AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
+
+    name: Tests on macOS with Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Compile Austin
+        run: gcc -Wall -O3 -g src/*.c -o src/austin
+
+      - name: Install Python
+        uses: gabrielfalcao/pyenv-action@v9
+        with:
+          default: "${{ matrix.python-version }}:latest"
+
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Remove signature from the Python binary
+        run: sudo codesign --remove-signature `which python${{ matrix.python-version }}` || true
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -604,16 +604,22 @@ when starting a container.
 
 ## On MacOS
 
-Due to the **System Integrity Protection** introduced in **MacOS** with El
-Capitan, Austin cannot profile Python processes that use an executable located
+Due to the **System Integrity Protection**, introduced in **MacOS** with El
+Capitan, and the [Hardened Runtime][hardened runtime], introduced in Mojave,
+Austin cannot profile Python processes that use an executable located
 in the `/bin` folder, even with `sudo`. This is the case for the system-provided
-version of Python, or the one installed with the official installers from
+version of Python, and the one installed with the official installers from
 [python.org](https://python.org). Creating a virtual environment with the
 `--copies` flag to `venv` might not solve the issue as the binary might link to
 a shared library that still resides in a protected area of the file system.
 Other installation methods, like [pyenv][pyenv] or [Anaconda][anaconda] or
 [Homebrew](https://formulae.brew.sh/formula/austin) are known to work with
 Austin.
+
+To use Austin with Python from the official installer, you could try removing
+the signature from the Python binaries with `codesign --remove-signature`, or
+self-sign the Austin binary with the [Debugging Tool Entitlement][dte], but note
+that these workarounds haven't been tested and are not guaranteed to work.
 
 > Austin requires the use of `sudo` to work on MacOS. To avoid having to type
 > the password every time you use Austin, consider adding a rule to the
@@ -856,7 +862,9 @@ by chipping in a few pennies on [PayPal.Me](https://www.paypal.me/gtornetta/1).
 [Chocolatey]: https://chocolatey.org/
 [Conda Forge]: https://anaconda.org/conda-forge/austin
 [d3-flame-graph]: https://github.com/spiermar/d3-flame-graph
+[dte]: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_debugger
 [FlameGraph]: https://github.com/brendangregg/FlameGraph
+[hardened runtume]: https://developer.apple.com/documentation/security/hardened_runtime
 [Homebrew]: https://formulae.brew.sh/formula/austin
 [latest release]: https://github.com/P403n1x87/austin/releases/latest
 [MOJO]: https://github.com/P403n1x87/austin/wiki/The-MOJO-file-format

--- a/README.md
+++ b/README.md
@@ -606,20 +606,23 @@ when starting a container.
 
 Due to the **System Integrity Protection**, introduced in **MacOS** with El
 Capitan, and the [Hardened Runtime][hardened runtime], introduced in Mojave,
-Austin cannot profile Python processes that use an executable located
-in the `/bin` folder, even with `sudo`. This is the case for the system-provided
+Austin cannot profile Python processes that use an executable located in the
+`/bin` folder, even with `sudo`. This is the case for the system-provided
 version of Python, and the one installed with the official installers from
-[python.org](https://python.org). Creating a virtual environment with the
-`--copies` flag to `venv` might not solve the issue as the binary might link to
-a shared library that still resides in a protected area of the file system.
-Other installation methods, like [pyenv][pyenv] or [Anaconda][anaconda] or
+[python.org](https://python.org). Other installation methods, like
+[pyenv][pyenv] or [Anaconda][anaconda] or
 [Homebrew](https://formulae.brew.sh/formula/austin) are known to work with
-Austin.
+Austin, out of the box.
 
-To use Austin with Python from the official installer, you could try removing
-the signature from the Python binaries with `codesign --remove-signature`, or
-self-sign the Austin binary with the [Debugging Tool Entitlement][dte], but note
-that these workarounds haven't been tested and are not guaranteed to work.
+To use Austin with Python from the official installer, you could remove the
+signature from the binaries with
+~~~ console
+codesign --remove-signature /Library/Frameworks/Python.framework/Versions/<M.m>/bin/python3
+codesign --remove-signature /Library/Frameworks/Python.framework/Versions/<M.m>/Resources/Python.app/Contents/MacOS/Python
+~~~
+Alternatively, you could self-sign the Austin binary with the [Debugging Tool
+Entitlement][dte], as done for debugging tools like GDB. However, this method
+has not been tested.
 
 > Austin requires the use of `sudo` to work on MacOS. To avoid having to type
 > the password every time you use Austin, consider adding a rule to the
@@ -864,7 +867,7 @@ by chipping in a few pennies on [PayPal.Me](https://www.paypal.me/gtornetta/1).
 [d3-flame-graph]: https://github.com/spiermar/d3-flame-graph
 [dte]: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_debugger
 [FlameGraph]: https://github.com/brendangregg/FlameGraph
-[hardened runtume]: https://developer.apple.com/documentation/security/hardened_runtime
+[hardened runtime]: https://developer.apple.com/documentation/security/hardened_runtime
 [Homebrew]: https://formulae.brew.sh/formula/austin
 [latest release]: https://github.com/P403n1x87/austin/releases/latest
 [MOJO]: https://github.com/P403n1x87/austin/wiki/The-MOJO-file-format


### PR DESCRIPTION
### Description of the Change

This PR implements a workaround for the latest release of Python on MacOS to allow the tests to work in CI. The setup-python GitHub Action has started using the official Python installer on MacOS runners, that comes with the Hardened Runtime enabled. Removing the signature from the binaries allows Austin to work with them, thus allowing the CI job to work. This can also be used by Austin users as a workaround, and mentions of this have been added to the documentation.

### Alternate Designs

The signing of the Austin binary with Debugging Tools Entitlements might have provided an alternative, but it requires more effort to get it to work.

### Regressions

N.A.

### Verification Process

Existing test suite.