### PR TITLE
ci: turn compilation warnings into errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Compile Austin
-        run: gcc -Wall -O3 -g src/*.c -o src/austin
+        run: gcc -Wall -Werror -O3 -g src/*.c -o src/austin
 
       - name: Install Python
         uses: actions/setup-python@v4
@@ -123,7 +123,7 @@ jobs:
       - name: Compile Austin
         run: |
           gcc.exe --version
-          gcc.exe -O3 -g -o src/austin.exe src/*.c -lpsapi -lntdll -Wall
+          gcc.exe -O3 -g -o src/austin.exe src/*.c -lpsapi -lntdll -Wall -Werror
           src\austin.exe --help
 
       - name: Install Python

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
-AM_CFLAGS = -I$(srcdir) -Wall -pthread
+AM_CFLAGS = -I$(srcdir) -Wall -Werror -pthread
 OPT_FLAGS = -O3
 STRIP_FLAGS = -Os -s
 


### PR DESCRIPTION
### Description of the Change

Catch potential issues during compilation by forcing workflows to fail on compilation warnings.

### Alternate Designs

N.A.

### Regressions

N.A.

### Verification Process

Existing test suite