### PR TITLE
fix(mojo): use string key for ref and more bytes for frame refs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-10-26 v3.4.1
+
+  Fixed a bug with the MOJO binary format.
+
+
 2022-10-25 v3.4.0
 
   Added support for Python 3.11.

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.69])
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"AC_INIT([austin], [{version()}], [https://github.com/p403n1x87/austin/issues])")
 # ]]]
-AC_INIT([austin], [3.4.0], [https://github.com/p403n1x87/austin/issues])
+AC_INIT([austin], [3.4.1], [https://github.com/p403n1x87/austin/issues])
 # [[[end]]]
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ base: core20
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"version: '{version()}+git'")
 # ]]]
-version: '3.4.0+git'
+version: '3.4.1+git'
 # [[[end]]]
 summary: A Python frame stack sampler for CPython
 description: |

--- a/src/austin.h
+++ b/src/austin.h
@@ -32,7 +32,7 @@
 from scripts.utils import get_current_version_from_changelog as version
 print(f'#define VERSION                         "{version()}"')
 ]]] */
-#define VERSION                         "3.4.0"
+#define VERSION                         "3.4.1"
 // [[[end]]]
 
 #endif

--- a/src/cache.c
+++ b/src/cache.c
@@ -428,24 +428,6 @@ lru_cache__store(lru_cache_t *self, key_dt key, value_t value) {
 
 // ----------------------------------------------------------------------------
 void
-lru_cache__invalidate(lru_cache_t *self) {
-  if (!isvalid(self) || queue__is_empty(self->queue))
-    return;
-
-  void (*deallocator)(value_t) = self->queue->deallocator;
-
-  queue__destroy(self->queue);
-  hash_table__destroy(self->hash);
-
-  int capacity = self->capacity;
-
-  self->queue = queue_new(capacity, deallocator);
-  self->hash  = hash_table_new((capacity * 4 / 3) | 1);
-}
-
-
-// ----------------------------------------------------------------------------
-void
 lru_cache__destroy(lru_cache_t *self) {
   if (!isvalid(self))
     return;

--- a/src/cache.c
+++ b/src/cache.c
@@ -334,8 +334,11 @@ lru_cache_new(int capacity, void (*deallocator)(value_t)) {
   lru_cache_t *cache = (lru_cache_t *)calloc(1, sizeof(lru_cache_t));
 
   cache->capacity = capacity;
-  cache->queue    = queue_new(capacity, deallocator);
-  cache->hash     = hash_table_new((capacity * 4 / 3) | 1);
+  
+  capacity = capacity ? capacity : 1024;
+  
+  cache->queue = queue_new(capacity, deallocator);
+  cache->hash  = hash_table_new((capacity * 4 / 3) | 1);
 
   #ifdef DEBUG
   cache->hits = 0;
@@ -397,11 +400,27 @@ lru_cache__store(lru_cache_t *self, key_dt key, value_t value) {
   queue_t * queue = self->queue;
 
   if (queue__is_full(queue)) {
-    hash_table__del(self->hash, queue->rear->key);
-    
-    value_t value = queue__dequeue(queue);
-    if (isvalid(value))
-      queue->deallocator(value);
+    if (self->capacity == LRU_CACHE_EXPAND) {
+      // Double the queue capacity.
+      unsigned capacity = queue->capacity = (queue->capacity << 1);
+
+      // Double the hash table and move the items across.
+      hash_table_t *new_hash = hash_table_new((capacity * 4 / 3) | 1);
+      
+      hash_table__iter_start(self->hash, queue_item_t *, item) {
+        hash_table__set(new_hash, item->key, item);
+      } hash_table__iter_stop(self->hash);
+
+      // Destroy the old hash table and replace it with the new one.
+      hash_table__destroy(self->hash);
+      self->hash = new_hash;
+    } else {
+      hash_table__del(self->hash, queue->rear->key);
+      
+      value_t value = queue__dequeue(queue);
+      if (isvalid(value))
+        queue->deallocator(value);
+    }
   }
 
   hash_table__set(self->hash, key, queue__enqueue(self->queue, value, key));

--- a/src/cache.h
+++ b/src/cache.h
@@ -418,15 +418,6 @@ lru_cache__store(lru_cache_t *, key_dt, value_t);
 
 
 /**
- * Invalidate the cache.
- * 
- * @param self  the cache to invalidate
- */
-void
-lru_cache__invalidate(lru_cache_t *);
-
-
-/**
  * Deallocate a cache.
  * 
  * @param self  the cache to deallocate

--- a/src/cache.h
+++ b/src/cache.h
@@ -271,10 +271,14 @@ void
 chain__destroy(chain_t *);
 
 
+#define LRU_CACHE_EXPAND 0
+
+
 /**
  * Create a new hash table.
  * 
- * @param capacity  the hash table maximum capacity
+ * @param capacity  the hash table maximum capacity. Pass ``LRU_CACHE_EXPAND``
+ *                   to allow the hash table to expand.
  * 
  * @return a valid reference to a new hash table, NULL otherwise.
  */
@@ -311,15 +315,16 @@ void
 hash_table__set(hash_table_t *, key_dt, value_t);
 
 
-#define hash_table__iter_start(table)                                          \
-    for (int i = 0; i < table->capacity; i++) {                                \
-        chain_t * chain = table->chains[i];                                    \
+#define hash_table__iter_start(table, valtype, valvar)                         \
+    for (int __i = 0; __i < table->capacity; __i++) {                          \
+        chain_t * chain = table->chains[__i];                                  \
         if (!isvalid(chain))                                                   \
             continue;                                                          \
         while (isvalid(chain->next)) {                                         \
             chain = chain->next;                                               \
-            value_t value = chain->value;                                      \
-      
+            valtype valvar = (valtype) chain->value;                           \
+            if (!isvalid(valvar))                                              \
+                continue;
 
 #define hash_table__iter_stop(table) }}
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -390,6 +390,17 @@ lru_cache__maybe_hit(lru_cache_t *, key_dt);
 
 
 /**
+ * Check if the cache is full.
+ * 
+ * @param self  the cache
+ * 
+ * @return TRUE if the cache is full, else FALSE.
+ */
+int
+lru_cache__is_full(lru_cache_t *);
+
+
+/**
  * Store a value within the cache at the given key. If the cache is full, the
  * least recently used key/value pair is evicted.
  * 
@@ -399,6 +410,15 @@ lru_cache__maybe_hit(lru_cache_t *, key_dt);
  */
 void
 lru_cache__store(lru_cache_t *, key_dt, value_t);
+
+
+/**
+ * Invalidate the cache.
+ * 
+ * @param self  the cache to invalidate
+ */
+void
+lru_cache__invalidate(lru_cache_t *);
 
 
 /**

--- a/src/mojo.h
+++ b/src/mojo.h
@@ -127,14 +127,14 @@ static inline void mojo_integer(mojo_int_t integer, int sign) {
 
 #define mojo_frame(frame)    \
   mojo_event(MOJO_FRAME);    \
-  mojo_ref(frame->key);      \
+  mojo_integer(frame->key, 0);      \
   mojo_ref(frame->filename); \
   mojo_ref(frame->scope);    \
   mojo_integer(frame->line, 0);
 
 #define mojo_frame_ref(frame) \
   mojo_event(MOJO_FRAME_REF); \
-  mojo_ref(frame->key);
+  mojo_integer(frame->key, 0);
 
 #define mojo_frame_kernel(scope) \
   mojo_event(MOJO_FRAME_KERNEL); \

--- a/src/mojo.h
+++ b/src/mojo.h
@@ -62,7 +62,6 @@ typedef unsigned long mojo_int_t;
 typedef unsigned long long mojo_int_t;
 #endif
 
-
 // Bitmask to ensure that we encode at most 4 bytes for an integer.
 #define MOJO_INT32 ((mojo_int_t)(1 << (6 + 7 * 3)) - 1)
 
@@ -125,11 +124,11 @@ static inline void mojo_integer(mojo_int_t integer, int sign) {
   mojo_integer(pid, 0);      \
   mojo_fstring(FORMAT_TID, tid);
 
-#define mojo_frame(frame)    \
-  mojo_event(MOJO_FRAME);    \
-  mojo_integer(frame->key, 0);      \
-  mojo_ref(frame->filename); \
-  mojo_ref(frame->scope);    \
+#define mojo_frame(frame)      \
+  mojo_event(MOJO_FRAME);      \
+  mojo_integer(frame->key, 0); \
+  mojo_ref(frame->filename);   \
+  mojo_ref(frame->scope);      \
   mojo_integer(frame->line, 0);
 
 #define mojo_frame_ref(frame) \

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -849,7 +849,7 @@ py_proc_new(int child) {
 
   py_proc->frames_heap = py_proc->frames = NULL_MEM_BLOCK;
 
-  py_proc->frame_cache = lru_cache_new(MAX_STACK_SIZE, (void (*)(value_t)) frame__destroy);
+  py_proc->frame_cache = lru_cache_new(MAX_FRAME_CACHE_SIZE, (void (*)(value_t)) frame__destroy);
   if (!isvalid(py_proc->frame_cache)) {
     log_e("Failed to allocate frame cache");
     goto error;

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -233,10 +233,4 @@ py_proc__terminate(py_proc_t *);
 void
 py_proc__destroy(py_proc_t *);
 
-
-static inline void
-_py_proc__store_string(py_proc_t * self, key_dt key, char * value) {
-  lru_cache__store(self->string_cache, key, (value_t) value);
-}
-
 #endif // PY_PROC_H

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -233,4 +233,16 @@ py_proc__terminate(py_proc_t *);
 void
 py_proc__destroy(py_proc_t *);
 
+
+static inline void
+_py_proc__store_string(py_proc_t * self, key_dt key, char * value) {
+  // If we need to evict a string from the cache we must invalidate the frame
+  // cache to avoid any cached frames to reference an evicted string.
+  // NOTE: This method should be called only on a string cache miss.
+  if (lru_cache__is_full(self->string_cache)) {
+    lru_cache__invalidate(self->frame_cache);
+  }
+  lru_cache__store(self->string_cache, key, (value_t) value);
+}
+
 #endif // PY_PROC_H

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -236,12 +236,6 @@ py_proc__destroy(py_proc_t *);
 
 static inline void
 _py_proc__store_string(py_proc_t * self, key_dt key, char * value) {
-  // If we need to evict a string from the cache we must invalidate the frame
-  // cache to avoid any cached frames to reference an evicted string.
-  // NOTE: This method should be called only on a string cache miss.
-  if (lru_cache__is_full(self->string_cache)) {
-    lru_cache__invalidate(self->frame_cache);
-  }
   lru_cache__store(self->string_cache, key, (value_t) value);
 }
 

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -648,7 +648,7 @@ _py_thread__unwind_native_frame_stack(py_thread_t * self) {
           if (!isvalid(scope)) {
             if (unw_get_proc_name(&cursor, _native_buf, MAXLEN, &offset) == 0) {
               scope = strdup(_native_buf);
-              _py_proc__store_string(self->proc, scope_key, scope);
+              lru_cache__store(string_cache, scope_key, scope);
               if (pargs.binary) {
                 mojo_string_event(scope_key, scope);
               }
@@ -676,7 +676,7 @@ _py_thread__unwind_native_frame_stack(py_thread_t * self) {
           if (!isvalid(filename)) {
             sprintf(_native_buf, "native@" ADDR_FMT, pc);
             filename = strdup(_native_buf);
-            _py_proc__store_string(self->proc, (key_dt) pc, filename);
+            lru_cache__store(string_cache, (key_dt) pc, filename);
             if (pargs.binary) {
               mojo_string_event(filename_key, filename);
             }

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include "cache.h"
 #include "mem.h"
 #include "py_proc.h"
 #include "stats.h"
@@ -33,9 +34,15 @@
 
 #define MAXLEN                      1024
 #define MAX_STACK_SIZE              2048
-// We make the string cache large to reduce the chances of having to invalidate
-// the frame cache because of string evictions.
-#define MAX_STRING_CACHE_SIZE       (1 << 16)  // 64K entries
+#ifdef NATIVE
+// In native mode we have both the Python and native stacks (the kernel stack
+// is negligible). We make sure we have a cache large enough to hold the full.
+// stack.
+#define MAX_FRAME_CACHE_SIZE        (MAX_STACK_SIZE << 1)
+#else
+#define MAX_FRAME_CACHE_SIZE        MAX_STACK_SIZE
+#endif
+#define MAX_STRING_CACHE_SIZE       LRU_CACHE_EXPAND
 
 
 typedef struct thread {

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -33,7 +33,9 @@
 
 #define MAXLEN                      1024
 #define MAX_STACK_SIZE              2048
-#define MAX_STRING_CACHE_SIZE       1024
+// We make the string cache large to reduce the chances of having to invalidate
+// the frame cache because of string evictions.
+#define MAX_STRING_CACHE_SIZE       (1 << 16)  // 64K entries
 
 
 typedef struct thread {

--- a/src/stack.h
+++ b/src/stack.h
@@ -244,7 +244,7 @@ _frame_from_code_raddr(py_thread_t * py_thread, void * code_raddr, int lasti, py
       log_ie("Cannot get file name from PyCodeObject");
       return NULL;
     }
-    lru_cache__store(py_proc->string_cache, string_key, filename);
+    _py_proc__store_string(py_proc, string_key, filename);
     if (pargs.binary) {
       mojo_string_event(string_key, filename);
     }
@@ -263,7 +263,7 @@ _frame_from_code_raddr(py_thread_t * py_thread, void * code_raddr, int lasti, py
       log_ie("Cannot get scope name from PyCodeObject");
       return NULL;
     }
-    lru_cache__store(py_proc->string_cache, string_key, scope);
+    _py_proc__store_string(py_proc, string_key, scope);
     if (pargs.binary) {
       mojo_string_event(string_key, scope);
     }

--- a/src/stack.h
+++ b/src/stack.h
@@ -236,15 +236,17 @@ _frame_from_code_raddr(py_thread_t * py_thread, void * code_raddr, int lasti, py
     return NULL;
   }
 
+  lru_cache_t * cache = py_proc->string_cache;
+
   key_dt string_key = py_string_key(code, o_filename);
-  char * filename = lru_cache__maybe_hit(py_proc->string_cache, string_key);
+  char * filename = lru_cache__maybe_hit(cache, string_key);
   if (!isvalid(filename)) {
     filename = _code__get_filename(&code, pref, py_v);
     if (!isvalid(filename)) {
       log_ie("Cannot get file name from PyCodeObject");
       return NULL;
     }
-    _py_proc__store_string(py_proc, string_key, filename);
+    lru_cache__store(cache, string_key, filename);
     if (pargs.binary) {
       mojo_string_event(string_key, filename);
     }
@@ -254,7 +256,7 @@ _frame_from_code_raddr(py_thread_t * py_thread, void * code_raddr, int lasti, py
   }
 
   string_key = V_MIN(3, 11) ? py_string_key(code, o_qualname) : py_string_key(code, o_name);
-  char * scope = lru_cache__maybe_hit(py_proc->string_cache, string_key);
+  char * scope = lru_cache__maybe_hit(cache, string_key);
   if (!isvalid(scope)) {
     scope = V_MIN(3, 11)
       ? _code__get_qualname(&code, pref, py_v)
@@ -263,7 +265,7 @@ _frame_from_code_raddr(py_thread_t * py_thread, void * code_raddr, int lasti, py
       log_ie("Cannot get scope name from PyCodeObject");
       return NULL;
     }
-    _py_proc__store_string(py_proc, string_key, scope);
+    lru_cache__store(cache, string_key, scope);
     if (pargs.binary) {
       mojo_string_event(string_key, scope);
     }

--- a/test/cunit/test_cache.py
+++ b/test/cunit/test_cache.py
@@ -101,22 +101,6 @@ def test_lru_cache():
     assert c.maybe_hit(50) is NULL
 
 
-def test_lru_cache_invalidate():
-    c = LruCache(10, C.free)
-    assert c.maybe_hit(42) is NULL
-
-    values = [(42 + i, C.malloc(8)) for i in range(10)]
-    for k, v in values:
-        c.store(k, v)
-
-    assert c.maybe_hit(42) == values[0][1]
-
-    c.invalidate()
-    c.invalidate()
-
-    assert c.maybe_hit(42) is NULL
-
-
 def test_lru_cache_expand():
     c = LruCache(0, C.free)
 

--- a/test/cunit/test_cache.py
+++ b/test/cunit/test_cache.py
@@ -115,3 +115,32 @@ def test_lru_cache_invalidate():
     c.invalidate()
 
     assert c.maybe_hit(42) is NULL
+
+
+def test_lru_cache_expand():
+    c = LruCache(0, C.free)
+
+    # Fill the cache to the initial size
+    values = [(i + 1, C.malloc(8)) for i in range(1024)]
+    for k, v in values:
+        c.store(k, v)
+
+    # Check that we can retrieve the values
+    for k, v in values:
+        assert c.maybe_hit(k) == v
+
+    # Check that the cache is now full
+    assert c.is_full()
+
+    # Add a new value
+    new_value = C.malloc(8)
+    c.store(1025, new_value)
+
+    # Check that the cache has been resized and not full
+    assert not c.is_full()
+
+    values.append((1025, new_value))
+
+    # Check that we still have all the items
+    for k, v in values:
+        assert c.maybe_hit(k) == v

--- a/test/cunit/test_cache.py
+++ b/test/cunit/test_cache.py
@@ -81,11 +81,16 @@ def test_hash_table_full():
 
 def test_lru_cache():
     c = LruCache(10, C.free)
+
+    assert not c.is_full()
+
     assert c.maybe_hit(42) is NULL
 
     values = [(42 + i, C.malloc(8)) for i in range(10)]
     for k, v in values:
         c.store(k, v)
+
+    assert c.is_full()
 
     for i in range(8):
         assert c.maybe_hit(42 + i) == values[i][1]
@@ -94,3 +99,19 @@ def test_lru_cache():
 
     c.store(100, C.malloc(8))
     assert c.maybe_hit(50) is NULL
+
+
+def test_lru_cache_invalidate():
+    c = LruCache(10, C.free)
+    assert c.maybe_hit(42) is NULL
+
+    values = [(42 + i, C.malloc(8)) for i in range(10)]
+    for k, v in values:
+        c.store(k, v)
+
+    assert c.maybe_hit(42) == values[0][1]
+
+    c.invalidate()
+    c.invalidate()
+
+    assert c.maybe_hit(42) is NULL

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -173,8 +173,9 @@ def test_fork_output(py, tmp_path: Path, mojo):
 @flaky
 @pytest.mark.xfail(platform.system() == "Windows", reason="Does not pass in Windows CI")
 @allpythons(min=(3, 7) if platform.system() == "Windows" else None)
-def test_fork_multiprocess(py):
-    result = austin("-Ci", "1ms", *python(py), target("target_mp.py"))
+@mojo
+def test_fork_multiprocess(py, mojo):
+    result = austin("-Ci", "1ms", *python(py), target("target_mp.py"), mojo=mojo)
     assert result.returncode == 0, result.stderr or result.stdout
 
     ps = processes(result.stdout)
@@ -185,7 +186,7 @@ def test_fork_multiprocess(py):
     assert meta["mode"] == "wall", meta
 
     assert has_pattern(result.stdout, "target_mp.py:do:"), compress(result.stdout)
-    assert has_pattern(result.stdout, "target_mp.py:fact:"), compress(result.stdout)
+    assert has_pattern(result.stdout, "target_mp.py:fact:31 "), compress(result.stdout)
 
 
 @flaky


### PR DESCRIPTION
### Description of the Change

This change fixes issues with the MOJO format that mostly arise in multiprocess applications and when there is a considerable number of strings and frames. We move to an expandable string cache and better MOJO references in events.

### Alternate Designs

We could have stored the string key on the frame object. On the one hand, this allows for fixed-size string caches, but on the other, it would require two cache lookups whenever a frame is retrieved from the frame cache.

### Regressions

None expected. The only concern is a potential memory usage increase, but it is bounded by a factor of the total memory used by Python code objects from the running process(es).

### Verification Process

Added MOJO variant to the multiprocess fork tests.