### PR TITLE
checks: add dev dependency to coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,7 +119,7 @@ jobs:
             valgrind \
             python2.7 \
             python3.{5..11} \
-            python3.10-full
+            python3.10-full python3.10-dev
 
       - name: Compile Austin
         run: |


### PR DESCRIPTION
The use of the setup-python action should speed up the coverage run and introduce the dev sources with no extra dependencies.