### PR TITLE
fix: multiprocess fail-fast

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+xxxx-xx-xx v3.5.0
+
+  Improved multiprocess support.
+
+
 2022-10-26 v3.4.1
 
   Fixed a bug with the MOJO binary format.


### PR DESCRIPTION
### Description of the Change

When trying to profile a child process that is not recognised as a Python process, Austin tries to resolve the interpreter state too many times, causing poor overall performance. This change ensures that if we fail to attach to a child Process we give up quickly to allow for samples to be collected efficiently for the processes that are correctly identified as Python processes.

### Alternate Designs

None considered

### Regressions

None expected, based on the current test suite

### Verification Process

The issue was brought to light by uWSGI support tests. Those will be added in a separate PR.