### PR TITLE
ci(arch): factor out build script

### DIFF
--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout sources
+        
       - uses: uraimo/run-on-arch-action@v2.0.5
         name: Build on ${{ matrix.arch }}
         id: build-on-arch
@@ -28,28 +29,7 @@ jobs:
           dockerRunArgs:  --volume "${GITHUB_WORKSPACE}/artifacts:/artifacts"
           setup: |
             mkdir -p ./artifacts
-          run: |
-            apt-get update
-            apt-get -y install autoconf build-essential libunwind-dev binutils-dev libiberty-dev musl-tools zlib1g-dev
-
-            # Build austin
-            autoreconf --install
-            ./configure
-            make
-
-            export VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
-
-            pushd src
-            tar -Jcf austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austin
-            tar -Jcf austinp-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austinp
-
-            musl-gcc -O3 -Os -s -Wall -pthread *.c -o austin -D__MUSL__
-            tar -Jcf austin-$VERSION-musl-linux-${{ matrix.arch }}.tar.xz austin
-
-            mv austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz /artifacts
-            mv austinp-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz /artifacts
-            mv austin-$VERSION-musl-linux-${{ matrix.arch }}.tar.xz /artifacts
-            popd
+          run: ARCH=${{ matrix.arch }} bash scripts/build_arch.sh
 
       - name: Show artifacts
         run: |

--- a/.github/workflows/release_arch.yml
+++ b/.github/workflows/release_arch.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout sources
+      
       - uses: uraimo/run-on-arch-action@v2.0.5
         name: Run tests on ${{ matrix.arch }}
         id: run-tests-on-arch
@@ -24,28 +25,7 @@ jobs:
           dockerRunArgs:  --volume "${GITHUB_WORKSPACE}/artifacts:/artifacts"
           setup: |
             mkdir -p ./artifacts
-          run: |
-            apt-get update
-            apt-get -y install autoconf build-essential libunwind-dev binutils-dev libiberty-dev musl-tools zlib1g-dev
-
-            # Build austin
-            autoreconf --install
-            ./configure
-            make
-
-            export VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
-
-            pushd src
-            tar -Jcf austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austin
-            tar -Jcf austinp-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austinp
-
-            musl-gcc -O3 -Os -s -Wall -pthread *.c -o austin -D__MUSL__
-            tar -Jcf austin-$VERSION-musl-linux-${{ matrix.arch }}.tar.xz austin
-
-            mv austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz /artifacts
-            mv austinp-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz /artifacts
-            mv austin-$VERSION-musl-linux-${{ matrix.arch }}.tar.xz /artifacts
-            popd
+          run: ARCH=${{ matrix.arch }} bash scripts/build_arch.sh
 
       - name: Show artifacts
         run: |

--- a/scripts/build_arch.sh
+++ b/scripts/build_arch.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+
+set -e
+set -u
+
+# Install build dependencies
+apt-get update
+apt-get -y install \
+    autoconf \
+    build-essential \
+    libunwind-dev \
+    binutils-dev \
+    libiberty-dev \
+    musl-tools \
+    zlib1g-dev
+
+# Build Austin
+autoreconf --install
+./configure
+make
+
+export VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
+
+pushd src
+    tar -Jcf austin-$VERSION-gnu-linux-$ARCH.tar.xz austin
+    tar -Jcf austinp-$VERSION-gnu-linux-$ARCH.tar.xz austinp
+
+    musl-gcc -O3 -Os -s -Wall -pthread *.c -o austin -D__MUSL__
+    tar -Jcf austin-$VERSION-musl-linux-$ARCH.tar.xz austin
+
+    mv austin-$VERSION-gnu-linux-$ARCH.tar.xz /artifacts
+    mv austinp-$VERSION-gnu-linux-$ARCH.tar.xz /artifacts
+    mv austin-$VERSION-musl-linux-$ARCH.tar.xz /artifacts
+popd


### PR DESCRIPTION
The architectures build and release workflow share the same build script. This has been factored out into a script to reduce duplication and improve maintenance.