### PR TITLE
fix(austinp): libbfd build issue workaround

### DIFF
--- a/src/linux/addr2line.h
+++ b/src/linux/addr2line.h
@@ -23,6 +23,9 @@
 // This source has been adapted from
 // https://github.com/bminor/binutils-gdb/blob/ce230579c65b9e04c830f35cb78ff33206e65db1/binutils/addr2line.c
 
+
+#define PACKAGE "austinp"  // https://github.com/P403n1x87/austin/issues/152
+
 #include <bfd.h>
 #include <ctype.h>
 #include <stdbool.h>


### PR DESCRIPTION
### Description of the Change

The libbfd project is affected by a known issue that is marked as WONTFIX. However, we can easily implement a workaround to allow austinp to be built on Linux distros that don't ship a patched version of the libbfd sources where the issue is removed.

Fixes #152.

### Alternate Designs

N.A.

### Regressions

The issue affected the build process on certain Linux distros.

### Verification Process

Existing build and test scripts.