### PR TITLE
perf: use hash lookup in multiprocess support

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -50,6 +50,14 @@ SCENARIOS = [
         )
         for i in (1, 10, 100, 1000)
     ],
+    *[
+        (
+            "austin",
+            f"Multiprocess wall time [sampling interval: {i}]",
+            ["-CPfi", str(i), sys.executable, target("target_mp.py"), "16"],
+        )
+        for i in (1, 10, 100, 1000)
+    ],
 ]
 
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -497,8 +497,8 @@ lookup__set(lookup_t *self, key_dt key, value_t value) {
     // Double the hash table and move the items across.
     hash_table_t *new_hash = hash_table_new(self->hash->capacity << 1);
     
-    hash_table__iter_start(self->hash, value_t, value) {
-      hash_table__set(new_hash, key, value);
+    hash_table__iteritems_start(self->hash, key_dt, _key, value_t, _value) {
+      hash_table__set(new_hash, _key, _value);
     } hash_table__iter_stop(self->hash);
 
     // Destroy the old hash table and replace it with the new one.
@@ -516,6 +516,17 @@ lookup__del(lookup_t *self, key_dt key) {
     return;
 
   hash_table__del(self->hash, key);
+}
+
+// ----------------------------------------------------------------------------
+void
+lookup__clear(lookup_t *self) {
+  if (!isvalid(self))
+    return;
+
+  size_t size = self->hash->capacity;
+  hash_table__destroy(self->hash);
+  self->hash = hash_table_new(size);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/cache.c
+++ b/src/cache.c
@@ -227,6 +227,7 @@ hash_table_new(int capacity) {
   hash_table_t *hash = (hash_table_t *) calloc(1, sizeof(hash_table_t));
 
   hash->capacity = capacity;
+  hash->load_factor = 0.75 * capacity;
   hash->chains = (chain_t **) calloc(hash->capacity, sizeof(chain_t *));
 
   #ifdef DEBUG
@@ -259,7 +260,15 @@ hash_table__get(hash_table_t *self, key_dt key) {
 }
 
 // ----------------------------------------------------------------------------
+int
+hash_table__is_full(hash_table_t *self) {
+  if (!isvalid(self))
+    return -1;
 
+  return self->size >= self->load_factor;
+}
+
+// ----------------------------------------------------------------------------
 void
 hash_table__set(hash_table_t *self, key_dt key, value_t value) {
   if (!isvalid(self))
@@ -450,6 +459,73 @@ lru_cache__destroy(lru_cache_t *self) {
 
   queue__destroy(self->queue);
   hash_table__destroy(self->hash);
+
+  free(self);
+}
+
+
+// -- Lookup ------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+lookup_t *
+lookup_new(int size) {
+  lookup_t *lookup = (lookup_t *)calloc(1, sizeof(lookup_t));
+  if (!isvalid(lookup))
+    return NULL;
+
+  lookup->hash = hash_table_new(size);
+
+  return lookup;
+}
+
+// ----------------------------------------------------------------------------
+value_t
+lookup__get(lookup_t *self, key_dt key) {
+  if (!isvalid(self))
+    return NULL;
+
+  return hash_table__get(self->hash, key);
+}
+
+// ----------------------------------------------------------------------------
+void
+lookup__set(lookup_t *self, key_dt key, value_t value) {
+  if (!isvalid(self))
+    return;
+
+  if (hash_table__is_full(self->hash)) {
+    // Double the hash table and move the items across.
+    hash_table_t *new_hash = hash_table_new(self->hash->capacity << 1);
+    
+    hash_table__iter_start(self->hash, value_t, value) {
+      hash_table__set(new_hash, key, value);
+    } hash_table__iter_stop(self->hash);
+
+    // Destroy the old hash table and replace it with the new one.
+    hash_table__destroy(self->hash);
+    self->hash = new_hash;
+  }
+
+  hash_table__set(self->hash, key, value);
+}
+
+// ----------------------------------------------------------------------------
+void
+lookup__del(lookup_t *self, key_dt key) {
+  if (!isvalid(self))
+    return;
+
+  hash_table__del(self->hash, key);
+}
+
+// ----------------------------------------------------------------------------
+void
+lookup__destroy(lookup_t *self) {
+  if (!isvalid(self))
+    return;
+
+  hash_table__destroy(self->hash);
+  self->hash = NULL;
 
   free(self);
 }

--- a/src/cache.h
+++ b/src/cache.h
@@ -339,6 +339,18 @@ hash_table__set(hash_table_t *, key_dt, value_t);
             if (!isvalid(valvar))                                              \
                 continue;
 
+#define hash_table__iteritems_start(table, keytype, keyvar, valtype, valvar)   \
+    for (int __i = 0; __i < table->capacity; __i++) {                          \
+        chain_t * chain = table->chains[__i];                                  \
+        if (!isvalid(chain))                                                   \
+            continue;                                                          \
+        while (isvalid(chain->next)) {                                         \
+            chain = chain->next;                                               \
+            keytype keyvar = (keytype) chain->key;                             \
+            valtype valvar = (valtype) chain->value;                           \
+            if (!isvalid(valvar))                                              \
+                continue;
+
 #define hash_table__iter_stop(table) }}
 
 
@@ -499,6 +511,26 @@ lookup__set(lookup_t *, key_dt, value_t);
  */
 void
 lookup__del(lookup_t *, key_dt);
+
+
+/**
+ * Clear the lookup.
+ * 
+ * @param self  the lookup to clear
+ */
+void
+lookup__clear(lookup_t *);
+
+
+/**
+ * Iterate over the lookup.
+*/
+#define lookup__iteritems_start(lu, keytype, keyvar, valtype, valvar) \
+    hash_table__iteritems_start((lu->hash), keytype, keyvar, valtype, valvar)
+
+
+#define lookup__iter_stop(lu) \
+    hash_table__iter_stop((lu->hash))
 
 
 /**

--- a/src/cache.h
+++ b/src/cache.h
@@ -159,6 +159,7 @@ typedef struct _chain_t {
 typedef struct hash_table_t {
     size_t capacity;
     size_t size;
+    size_t load_factor;
     chain_t **chains;
 
     #ifdef DEBUG
@@ -302,6 +303,18 @@ hash_table__get(hash_table_t *, key_dt);
 
 
 /**
+ * Check if the hash table has grown over the load factor.
+ * 
+ * @param self  the hash table
+ * 
+ * @return TRUE if the hash table has grown over the load factor, FALSE
+ * otherwise.
+*/
+int
+hash_table__is_full(hash_table_t *);
+
+
+/**
  * Set a value into the table.
  * 
  * If the key is not already present and the table is full, this method does
@@ -424,5 +437,76 @@ lru_cache__store(lru_cache_t *, key_dt, value_t);
  */
 void
 lru_cache__destroy(lru_cache_t *);
+
+
+// -- Lookup ------------------------------------------------------------------
+
+typedef struct {
+    hash_table_t *hash;
+
+    #ifdef DEBUG
+    const char * name;
+    #endif
+} lookup_t;
+
+
+/**
+ * Create a lookup object.
+ * 
+ * A lookup object is an expandable hash table that can be used to look up
+ * values by key. No ownership of the values is taken.
+ * 
+ * @param size  the initial size of the underlying hash map
+ * 
+ * @return a valid reference to a lookup, NULL otherwise.
+ */
+lookup_t *
+lookup_new(int);
+
+
+/**
+ * Look up a value.
+ * 
+ * Since this method returns NULL on a lookup failure, this only makes sense if
+ * all the objects stored within the lookup are non-NULL.
+ * 
+ * @param self  the lookup to use
+ * @param key   the key to search
+ * 
+ * @return the value associated to the key if the lookup succeeds, NULL
+ *         otherwise.
+ */
+value_t
+lookup__get(lookup_t *, key_dt);
+
+
+/**
+ * Associated a value with a key in the lookup.
+ * 
+ * @param self   the lookup to set into
+ * @param key    the key associated with the value
+ * @param value  the value to associated with the key
+ */
+void
+lookup__set(lookup_t *, key_dt, value_t);
+
+
+/**
+ * Delete a value from the lookup.
+ * 
+ * @param self  the lookup to use
+ * @param key   the key to delete
+ */
+void
+lookup__del(lookup_t *, key_dt);
+
+
+/**
+ * Deallocate a lookup.
+ * 
+ * @param self  the lookup to deallocate
+ */
+void
+lookup__destroy(lookup_t *);
 
 #endif

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -138,7 +138,7 @@ release:
 
 // ----------------------------------------------------------------------------
 void
-py_proc_list__add_proc_children(py_proc_list_t * self, long unsigned ppid) {
+py_proc_list__add_proc_children(py_proc_list_t * self, uintptr_t ppid) {
   lookup__iteritems_start(self->pid_table, key_dt, pid, value_t, pid_ppid) {
     if (pid_ppid == (value_t) ppid && !_py_proc_list__has_pid(self, pid)) {
       py_proc_t * child_proc = py_proc_new(TRUE);
@@ -276,7 +276,7 @@ py_proc_list__update(py_proc_list_t * self) {
     if (proc_pidinfo(pid_list[i], PROC_PIDTBSDINFO, 0, &proc, PROC_PIDTBSDINFO_SIZE) == -1)
       continue;
 
-    lookup__set(self->pid_table, pid_list[i], (value_t) proc.pbi_ppid);
+    lookup__set(self->pid_table, pid_list[i], (value_t) (uintptr_t) proc.pbi_ppid);
   }
 
   #elif defined PL_WIN                                                 /* WIN */
@@ -289,7 +289,7 @@ py_proc_list__update(py_proc_list_t * self) {
 
   if (Process32First(h, &pe)) {
     do {
-      lookup__set(self->pid_table, pe.th32ProcessID, (value_t) pe.th32ParentProcessID);
+      lookup__set(self->pid_table, pe.th32ProcessID, (value_t) (uintptr_t) pe.th32ParentProcessID);
     } while (Process32Next(h, &pe));
   }
 

--- a/src/py_proc_list.h
+++ b/src/py_proc_list.h
@@ -73,7 +73,7 @@ py_proc_list__is_empty(py_proc_list_t *);
  * @param  long unsigned   the PID of the parent process.
  */
 void
-py_proc_list__add_proc_children(py_proc_list_t *, long unsigned);
+py_proc_list__add_proc_children(py_proc_list_t *, uintptr_t);
 
 
 /**

--- a/src/py_proc_list.h
+++ b/src/py_proc_list.h
@@ -38,9 +38,7 @@ typedef struct {
   int              count;      // Number of entries in the list
   py_proc_item_t * first;      // First item in the list
   lookup_t       * index;      // Map PID to py_proc_t currently in the list.
-  pid_t          * pid_table;  // Table of pids with their parents
-  pid_t            max_pid;    // Highest seen PID in the index
-  int              pids;       // Maximum number of PIDs in the index
+  lookup_t       * pid_table;  // PID to PPID lookup table.
   ctime_t          timestamp;  // Timestamp of the last update
 } py_proc_list_t;
 
@@ -72,10 +70,10 @@ py_proc_list__is_empty(py_proc_list_t *);
  * Add the the children of the given process to the list.
  *
  * @param  py_proc_list_t  the list.
- * @param  pid_t           the PID of the parent process.
+ * @param  long unsigned   the PID of the parent process.
  */
 void
-py_proc_list__add_proc_children(py_proc_list_t *, pid_t);
+py_proc_list__add_proc_children(py_proc_list_t *, long unsigned);
 
 
 /**

--- a/src/py_proc_list.h
+++ b/src/py_proc_list.h
@@ -23,7 +23,7 @@
 #ifndef PY_PROC_LIST_H
 #define PY_PROC_LIST_H
 
-
+#include "cache.h"
 #include "py_proc.h"
 
 
@@ -37,7 +37,7 @@ typedef struct _py_proc_item {
 typedef struct {
   int              count;      // Number of entries in the list
   py_proc_item_t * first;      // First item in the list
-  py_proc_t     ** index;      // Index of PIDs in the list
+  lookup_t       * index;      // Map PID to py_proc_t currently in the list.
   pid_t          * pid_table;  // Table of pids with their parents
   pid_t            max_pid;    // Highest seen PID in the index
   int              pids;       // Maximum number of PIDs in the index

--- a/src/py_proc_list.h
+++ b/src/py_proc_list.h
@@ -35,11 +35,11 @@ typedef struct _py_proc_item {
 
 
 typedef struct {
-  int              count;      // Number of entries in the list
-  py_proc_item_t * first;      // First item in the list
-  lookup_t       * index;      // Map PID to py_proc_t currently in the list.
-  lookup_t       * pid_table;  // PID to PPID lookup table.
-  ctime_t          timestamp;  // Timestamp of the last update
+  int              count;            // Number of entries in the list
+  py_proc_item_t * first;            // First item in the list
+  lookup_t       * py_proc_for_pid;  // PID to py_proc_t lookup table
+  lookup_t       * ppid_for_pid;     // PID to PPID lookup table
+  ctime_t          timestamp;        // Timestamp of the last update
 } py_proc_list_t;
 
 
@@ -70,7 +70,7 @@ py_proc_list__is_empty(py_proc_list_t *);
  * Add the the children of the given process to the list.
  *
  * @param  py_proc_list_t  the list.
- * @param  long unsigned   the PID of the parent process.
+ * @param  uintptr_t       the PID of the parent process.
  */
 void
 py_proc_list__add_proc_children(py_proc_list_t *, uintptr_t);

--- a/test/cunit/test_cache.py
+++ b/test/cunit/test_cache.py
@@ -1,8 +1,14 @@
 from ctypes import c_void_p
 from test.cunit import C
-from test.cunit.cache import Chain, HashTable, Lookup, LruCache, Queue, QueueItem
+from test.cunit.cache import Chain
+from test.cunit.cache import HashTable
+from test.cunit.cache import Lookup
+from test.cunit.cache import LruCache
+from test.cunit.cache import Queue
+from test.cunit.cache import QueueItem
 
 import pytest
+
 
 NULL = 0
 C.free.argtypes = [c_void_p]

--- a/test/cunit/test_cache.py
+++ b/test/cunit/test_cache.py
@@ -1,13 +1,8 @@
 from ctypes import c_void_p
 from test.cunit import C
-from test.cunit.cache import Chain
-from test.cunit.cache import HashTable
-from test.cunit.cache import LruCache
-from test.cunit.cache import Queue
-from test.cunit.cache import QueueItem
+from test.cunit.cache import Chain, HashTable, Lookup, LruCache, Queue, QueueItem
 
 import pytest
-
 
 NULL = 0
 C.free.argtypes = [c_void_p]
@@ -133,3 +128,23 @@ def test_lru_cache_expand():
     # Check that we still have all the items
     for k, v in values:
         assert c.maybe_hit(k) == v
+
+
+def test_lookup():
+    lu = Lookup(8)
+
+    assert not lu.get(42)
+
+    for i in range(1000):
+        lu.set(42 + i, i + 1)
+
+    for i in range(1000):
+        assert lu.get(42 + i) == i + 1
+
+    getattr(lu, "del")(42)
+    assert not lu.get(42)
+
+    lu.clear()
+
+    for i in range(1000):
+        assert not lu.get(42 + i)

--- a/test/targets/target_mp.py
+++ b/test/targets/target_mp.py
@@ -40,8 +40,15 @@ def do(N):
 
 
 if __name__ == "__main__":
+    import sys
+
+    try:
+        nproc = int(sys.argv[1])
+    except Exception:
+        nproc = 2
+
     processes = []
-    for _ in range(2):
+    for _ in range(nproc):
         process = multiprocessing.Process(target=do, args=(3000,))
         process.start()
         processes.append(process)


### PR DESCRIPTION
### Description of the Change

We use a hash lookup structure instead of plain lookup arrays in multiprocessing support to reduce the overall memory requirements for Austin when sampling child processes.

### Alternate Designs

n/a

### Regressions

None expected

### Verification Process

Existing test suite. Added a multiprocess benchmark scenario to monitor performance changes across releases.