### PR TITLE
chore(linux): better Python detection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ xxxx-xx-xx v3.5.0
 
   Dropped the alternative output format.
 
+  Improved interpreter detection on Linux.
+
 
 2022-10-26 v3.4.1
 

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -45,8 +45,8 @@
 #else
 #define DEFAULT_SAMPLING_INTERVAL    100
 #endif
-#define DEFAULT_INIT_RETRY_CNT       100
-#define DEFAULT_HEAP_SIZE            0
+#define DEFAULT_INIT_TIMEOUT_MS      100  // 0.1 seconds
+#define DEFAULT_HEAP_SIZE              0
 
 const char SAMPLE_FORMAT_NORMAL[]      = ";%s:%s:%d";
 const char SAMPLE_FORMAT_WHERE[]       = "    \033[33;1m%2$s\033[0m (\033[36;1m%1$s\033[0m:\033[32;1m%3$d\033[0m)\n";
@@ -67,7 +67,7 @@ const char HEAD_FORMAT_WHERE[]         = "\n\n%3$s%4$s Process \033[35;1m%1$d\03
 // Globals for command line arguments
 parsed_args_t pargs = {
   /* t_sampling_interval */ DEFAULT_SAMPLING_INTERVAL,
-  /* timeout             */ DEFAULT_INIT_RETRY_CNT * 1000,
+  /* timeout             */ DEFAULT_INIT_TIMEOUT_MS * 1000,
   /* attach_pid          */ 0,
   /* where               */ 0,
   /* exclude_empty       */ 0,

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -418,6 +418,9 @@ _py_proc__parse_maps_file(py_proc_t * self) {
     log_e("Cannot readlink %s", file_name);
     goto release;
   }
+  if (strcmp(pd->exe_path + (strlen(pd->exe_path) - 10), " (deleted)") == 0) {
+    pd->exe_path[strlen(pd->exe_path) - 10] = '\0';
+  }
   log_d("Executable path: %s", pd->exe_path);
 
   while (getline(&line, &len, fp) != -1) {

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -64,12 +64,35 @@
 #define ELF_SH_OFF(ehdr, i) /* as */ (ehdr->e_shoff + i * ehdr->e_shentsize)
 
 
-
-
 union {
   Elf32_Ehdr v32;
   Elf64_Ehdr v64;
 } ehdr_v;
+
+
+struct vm_map{
+  char    * path;
+  ssize_t   file_size;
+  void    * base;
+  size_t    size;
+  void    * bss_base;
+  size_t    bss_size;
+  int       has_symbols;
+};
+
+
+enum {
+  MAP_BIN,
+  MAP_LIBSYM,
+  MAP_LIBNEEDLE,
+  MAP_COUNT,
+};
+
+
+struct proc_desc {
+  char          exe_path[1024];
+  struct vm_map maps[MAP_COUNT];
+};
 
 
 // ----------------------------------------------------------------------------
@@ -85,7 +108,8 @@ static ssize_t
 _file_size(char * file) {
   struct stat statbuf;
 
-  stat(file, &statbuf);
+  if (fail(stat(file, &statbuf)))
+    return -1;
 
   return statbuf.st_size;
 }
@@ -105,7 +129,7 @@ _get_base_64(Elf64_Ehdr * ehdr, void * elf_map)
 
 
 static int
-_py_proc__analyze_elf64(py_proc_t * self, void * elf_map) {
+_py_proc__analyze_elf64(py_proc_t * self, void * elf_map, void * elf_base) {
   register int symbols = 0;
 
   Elf64_Ehdr * ehdr = elf_map;
@@ -119,6 +143,9 @@ _py_proc__analyze_elf64(py_proc_t * self, void * elf_map) {
   char        * sh_name_base = elf_map + p_shstrtab->sh_offset;
   Elf64_Shdr  * p_dynsym     = NULL;
   Elf64_Addr    base         = _get_base_64(ehdr, elf_map);
+
+  void         * bss_base    = NULL;
+  size_t         bss_size    = 0;
 
   if (base != UINT64_MAX) {
     log_d("Base @ %p", base);
@@ -146,9 +173,8 @@ _py_proc__analyze_elf64(py_proc_t * self, void * elf_map) {
       //   map_flag |= RODATA_MAP;
       // }
       else if (strcmp(sh_name_base + p_shdr->sh_name, ".bss") == 0) {
-        self->map.bss.base = self->map.elf.base + (p_shdr->sh_addr - base);
-        self->map.bss.size = p_shdr->sh_size;
-        log_d("BSS @ %p, (size %x)", self->map.bss.base, self->map.bss.size);
+        bss_base = elf_base + (p_shdr->sh_addr - base);
+        bss_size = p_shdr->sh_size;
       }
     }
 
@@ -163,7 +189,7 @@ _py_proc__analyze_elf64(py_proc_t * self, void * elf_map) {
         ) {
           Elf64_Sym * sym      = (Elf64_Sym *) (elf_map + tab_off);
           char      * sym_name = (char *) (elf_map + p_strtabsh->sh_offset + sym->st_name);
-          void      * value    = self->map.elf.base + (sym->st_value - base);
+          void      * value    = elf_base + (sym->st_value - base);
           if ((symbols += _py_proc__check_sym(self, sym_name, value)) >= SYMBOLS)
             break;
         }
@@ -175,6 +201,11 @@ _py_proc__analyze_elf64(py_proc_t * self, void * elf_map) {
     log_e("ELF binary has no Python symbols");
     FAIL;
   }
+
+  // Communicate BSS data back to the caller
+  self->map.bss.base = bss_base;
+  self->map.bss.size = bss_size;
+  log_d("BSS @ %p (size %x, offset %x)", self->map.bss.base, self->map.bss.size, self->map.bss.base - elf_base);
 
   SUCCESS;
 } /* _py_proc__analyze_elf64 */
@@ -194,7 +225,7 @@ _get_base_32(Elf32_Ehdr * ehdr, void * elf_map)
 
 
 static int
-_py_proc__analyze_elf32(py_proc_t * self, void * elf_map) {
+_py_proc__analyze_elf32(py_proc_t * self, void * elf_map, void * elf_base) {
   register int symbols = 0;
 
   Elf32_Ehdr * ehdr = elf_map;
@@ -208,6 +239,9 @@ _py_proc__analyze_elf32(py_proc_t * self, void * elf_map) {
   char        * sh_name_base = elf_map + p_shstrtab->sh_offset;
   Elf32_Shdr  * p_dynsym     = NULL;
   Elf32_Addr    base         = _get_base_32(ehdr, elf_map);
+
+  void         * bss_base    = NULL;
+  size_t         bss_size    = 0;
 
   if (base != UINT32_MAX) {
     log_d("Base @ %p", base);
@@ -234,6 +268,10 @@ _py_proc__analyze_elf32(py_proc_t * self, void * elf_map) {
       //   self->map.rodata.size = p_shdr->sh_size;
       //   map_flag |= RODATA_MAP;
       // }
+      else if (strcmp(sh_name_base + p_shdr->sh_name, ".bss") == 0) {
+        bss_base = elf_base + (p_shdr->sh_addr - base);
+        bss_size = p_shdr->sh_size;
+      }
     }
 
     if (p_dynsym != NULL) {
@@ -247,7 +285,7 @@ _py_proc__analyze_elf32(py_proc_t * self, void * elf_map) {
         ) {
           Elf32_Sym * sym      = (Elf32_Sym *) (elf_map + tab_off);
           char      * sym_name = (char *) (elf_map + p_strtabsh->sh_offset + sym->st_name);
-          void      * value    = self->map.elf.base + (sym->st_value - base);
+          void      * value    = elf_base + (sym->st_value - base);
           if ((symbols += _py_proc__check_sym(self, sym_name, value)) >= SYMBOLS)
             break;
         }
@@ -260,13 +298,25 @@ _py_proc__analyze_elf32(py_proc_t * self, void * elf_map) {
     FAIL;
   }
 
+  // Communicate BSS data back to the caller
+  self->map.bss.base = bss_base;
+  self->map.bss.size = bss_size;
+  log_d("BSS @ %p (size %x, offset %x)", self->map.bss.base, self->map.bss.size, self->map.bss.base - elf_base);
+
   SUCCESS;
 } /* _py_proc__analyze_elf32 */
 
 
 // ----------------------------------------------------------------------------
 static int
-_py_proc__analyze_elf(py_proc_t * self, char * path) {
+_elf_check(Elf64_Ehdr * ehdr) {
+  return (ehdr->e_shoff == 0 || ehdr->e_shnum < 2 || memcmp(ehdr->e_ident, ELFMAG, SELFMAG));
+}
+
+
+// ----------------------------------------------------------------------------
+static int
+_py_proc__analyze_elf(py_proc_t * self, char * path, void * elf_base) {
   int fd = open (path, O_RDONLY);
   if (fd == -1) {
     log_e("Cannot open binary file %s", path);
@@ -295,24 +345,25 @@ _py_proc__analyze_elf(py_proc_t * self, char * path) {
   Elf64_Ehdr * ehdr = binary_map;
   log_t("Analysing ELF");
 
-  if (ehdr->e_shoff == 0 || ehdr->e_shnum < 2 || memcmp(ehdr->e_ident, ELFMAG, SELFMAG)) {
-    log_d("Bad ELF magic");
+  if (fail(_elf_check(ehdr))) {
+    log_e("Bad ELF header");
     NOK;
   }
 
   // Dispatch
   switch (ehdr->e_ident[EI_CLASS]) {
   case ELFCLASS64:
-    log_d("64-bit ELF detected");
-    retval = _py_proc__analyze_elf64(self, binary_map);
+    log_d("%s is 64-bit ELF", path);
+    retval = _py_proc__analyze_elf64(self, binary_map, elf_base);
     break;
 
   case ELFCLASS32:
-    retval = _py_proc__analyze_elf32(self, binary_map);
+    log_d("%s is 32-bit ELF", path);
+    retval = _py_proc__analyze_elf32(self, binary_map, elf_base);
     break;
 
   default:
-    log_e("Invalid ELF class");
+    log_e("%s has invalid ELF class", path);
     NOK;
   }
 
@@ -326,34 +377,15 @@ release:
 
 // ----------------------------------------------------------------------------
 static int
-_elf_is_executable(char * object_file) {
-  int fd = open(object_file, O_RDONLY);
-  if (fd == -1)
-    return FALSE;
-
-  Elf64_Ehdr * ehdr = (Elf64_Ehdr *) mmap(NULL, sizeof(Elf64_Ehdr), PROT_READ, MAP_SHARED, fd, 0);
-  if (ehdr == MAP_FAILED) {
-    close(fd);
-    return FALSE;
-  }
-  
-  int is_exec = ehdr->e_type == ET_EXEC;
-
-  munmap(ehdr, sizeof(Elf64_Ehdr));
-  close(fd);
-
-  return is_exec;
-} /* _elf_is_executable */
-
-
-// ----------------------------------------------------------------------------
-static int
 _py_proc__parse_maps_file(py_proc_t * self) {
   char      file_name[32];
   FILE    * fp        = NULL;
   char    * line      = NULL;
   size_t    len       = 0;
   int       maps_flag = 0;
+  char    * prev_path = NULL;
+
+  struct vm_map * map = NULL;
 
   sprintf(file_name, "/proc/%d/maps", self->pid);
   fp = fopen(file_name, "r");
@@ -377,97 +409,176 @@ _py_proc__parse_maps_file(py_proc_t * self) {
   sfree(self->bin_path);
   sfree(self->lib_path);
 
-  char prev_path[1024] = "\0";
+  self->map.elf.base = NULL;
+  self->map.elf.size = 0;
+
+  sprintf(file_name, "/proc/%d/exe", self->pid);
+  struct proc_desc * pd = calloc(1, sizeof(struct proc_desc));
+  if (readlink(file_name, pd->exe_path, sizeof(pd->exe_path)) == -1) {
+    log_e("Cannot readlink %s", file_name);
+    goto release;
+  }
+  log_d("Executable path: %s", pd->exe_path);
+
   while (getline(&line, &len, fp) != -1) {
     ssize_t lower, upper;
     char    pathname[1024];
+    char    perms[5];
 
-    int field_count = sscanf(line, ADDR_FMT "-" ADDR_FMT " %*s %*x %*x:%*x %*x %s\n",
+    int field_count = sscanf(line, ADDR_FMT "-" ADDR_FMT " %s %*x %*x:%*x %*x %s\n",
       &lower, &upper, // Map bounds
+      perms,          // Permissions
       pathname        // Binary path
     ) - 3; // We expect between 3 and 4 matches.
-    if (field_count >= 0) {
-      if (field_count == 0 || strstr(pathname, "[v") == NULL) {
-        // Skip meaningless addresses like [vsyscall] which would give
-        // ridiculous values.
-        if ((void *) lower < self->min_raddr) self->min_raddr = (void *) lower;
-        if ((void *) upper > self->max_raddr) self->max_raddr = (void *) upper;
+
+    if (field_count == 0 && isvalid(map) && !isvalid(map->bss_base) && strcmp(perms, "rw-p") == 0) {
+      // The BSS section is not mapped from a file and has rw permissions.
+      // We find that the map reported by proc fs is rounded to the next page
+      // boundary, so we need to adjust the values. We might slide into the data
+      // section, but that should be readable anyway.
+      size_t page_size = getpagesize();
+      map->bss_base = (void *) lower - page_size;
+      map->bss_size = upper - lower + page_size;
+      log_d("Inferred BSS for %s: %lx-%lx", map->path, lower, upper);
+    }
+
+    if (field_count <= 0)
+      continue;
+
+    if (field_count == 0 || strstr(pathname, "[v") == NULL) {
+      // Skip meaningless addresses like [vsyscall] which would give
+      // ridiculous values.
+      if ((void *) lower < self->min_raddr) self->min_raddr = (void *) lower;
+      if ((void *) upper > self->max_raddr) self->max_raddr = (void *) upper;
+    }
+
+    if ((maps_flag & HEAP_MAP) == 0 && strstr(line, "[heap]\n") != NULL) {
+      self->map.heap.base = (void *) lower;
+      self->map.heap.size = upper - lower;
+
+      maps_flag |= HEAP_MAP;
+
+      log_d("HEAP bounds " ADDR_FMT "-" ADDR_FMT, lower, upper);
+      continue;
+    }
+
+    if (pathname[0] == '[')
+      continue;
+
+    if (isvalid(prev_path) && strcmp(pathname, prev_path) == 0) { // Avoid analysing a binary multiple times
+      continue;
+    }
+    
+    sfree(prev_path);
+    prev_path = strndup(pathname, strlen(pathname));
+    if (!isvalid(prev_path)) {
+      log_ie("Cannot duplicate path name");
+      goto release;
+    }
+
+    // The first memory map of the executable
+    if (!isvalid(pd->maps[MAP_BIN].path) && strcmp(pd->exe_path, pathname) == 0) {
+      map = &(pd->maps[MAP_BIN]);
+      map->path = strndup(pathname, strlen(pathname));
+      if (!isvalid(map->path)) {
+        log_ie("Cannot duplicate path name");
+        goto release;
       }
+      map->file_size = _file_size(pathname);
+      map->base = (void *) lower;
+      map->size = upper - lower;
+      map->has_symbols = success(_py_proc__analyze_elf(self, pathname, (void *) lower));
+      if (map->has_symbols) {
+        map->bss_base = self->map.bss.base;
+        map->bss_size = self->map.bss.size;
+      }
+      log_d("Binary map: %s (symbols %d)", map->path, map->has_symbols);
+      continue;
+    }
 
-      if ((maps_flag & HEAP_MAP) == 0 && strstr(line, "[heap]\n") != NULL) {
-        self->map.heap.base = (void *) lower;
-        self->map.heap.size = upper - lower;
-
-        maps_flag |= HEAP_MAP;
-
-        log_d("HEAP bounds " ADDR_FMT "-" ADDR_FMT, lower, upper);
+    // The first memory map of the shared library (if any)
+    char * needle = strstr(pathname, "libpython");
+    if (!isvalid(pd->maps[MAP_LIBSYM].path) && isvalid(needle)) {
+      int has_symbols = success(_py_proc__analyze_elf(self, pathname, (void *) lower));
+      if (has_symbols) {
+        map = &(pd->maps[MAP_LIBSYM]);
+        map->path = strndup(pathname, strlen(pathname));
+        if (!isvalid(map->path)) {
+          log_ie("Cannot duplicate path name");
+          goto release;
+        }
+        map->file_size = _file_size(pathname);
+        map->base = (void *) lower;
+        map->size = upper - lower;
+        map->has_symbols = has_symbols;
+        if (map->has_symbols) {
+          map->bss_base = self->map.bss.base;
+          map->bss_size = self->map.bss.size;
+        }
+        log_d("Library map: %s (symbols %d)", map->path, map->has_symbols);
         continue;
       }
-
-      // if (strstr(line, "python") == NULL)
-      // NOTE: The python binary might have a name that doesn't contain python
-      //       but would still be valid. In case of future issues, this
-      //       should be changed so that the binary on the first line is
-      //       checked for, e.g., knownw symbols to determine whether it is a
-      //       valid binary that Austin can handle.
-        // continue;
-
-      // Check if it is an executable. Only bother if the size is above the
-      // MB threshold. Anything smaller is probably not a useful binary.
-      if (pathname[0] == '[')
-        continue;
-
-      if (strcmp(pathname, prev_path) == 0) // Avoid analysing a binary multiple times
-        continue;
-
-      strncpy(prev_path, pathname, sizeof(prev_path));
-
-      ssize_t file_size = _file_size(pathname);
-      if (_elf_is_executable(pathname)) {
-        if (self->bin_path != NULL || (file_size < (1 << 20)))
-          continue;
-
-        self->bin_path = strndup(pathname, strlen(pathname));
-
-        self->map.elf.base = (void *) lower;
-        self->map.elf.size = upper - lower;
-
-        if (fail(_py_proc__analyze_elf(self, self->bin_path))) {
-          log_d("Possibly invalid Python binary at %p: %s", self->map.elf.base, self->bin_path);
-          sfree(self->bin_path);
-          self->bin_path = NULL;
+      
+      // The first memory map of a binary that contains "pythonX.Y" in its name
+      if (!isvalid(pd->maps[MAP_LIBNEEDLE].path)) {
+        if (isvalid(needle)) {
+          unsigned int v;
+          if (sscanf(needle, "libpython%u.%u", &v, &v) == 2) {
+            map = &(pd->maps[MAP_LIBNEEDLE]);
+            map->path = strndup(pathname, strlen(pathname));
+            if (!isvalid(map->path)) {
+              log_ie("Cannot duplicate path name");
+              goto release;
+            }
+            map->file_size = _file_size(pathname);
+            map->base = (void *) lower;
+            map->size = upper - lower;
+            map->has_symbols = FALSE;
+            log_d("Library map: %s (needle)", map->path);
+            continue;
+          }
         }
-        else
-          log_d("Candidate binary: %s (size %d KB)", pathname, file_size >> 10);
-
-        continue;
-      } else {
-        if (self->bin_path != NULL || self->lib_path != NULL || (file_size < (1 << 20)))
-          continue;
-
-        self->lib_path = strndup(pathname, strlen(pathname));
-
-        self->map.elf.base = (void *) lower;
-        self->map.elf.size = upper - lower;
-
-        if (fail(_py_proc__analyze_elf(self, self->lib_path))) {
-          log_d("Possibly invalid Python library: %s", self->lib_path);
-          sfree(self->lib_path);
-          self->lib_path = NULL;
-        }
-        else
-          log_d("Candidate library: %s (size %d KB)", pathname, file_size >> 10);
       }
     }
   }
 
+  // If the library map is not valid, use the needle map
+  if (!isvalid(pd->maps[MAP_LIBSYM].path)) {
+    pd->maps[MAP_LIBSYM] = pd->maps[MAP_LIBNEEDLE];
+    pd->maps[MAP_LIBNEEDLE].path = NULL;
+  }
+
+  // Work out paths
+  self->bin_path = pd->maps[MAP_BIN].path;
+  self->lib_path = pd->maps[MAP_LIBSYM].path;
+
+  // Work out binary map
+  for (int i = 0; i < MAP_COUNT; i++) {
+    map = &(pd->maps[i]);
+    if (map->has_symbols) {
+      self->map.elf.base = map->base;
+      self->map.elf.size = map->size;
+      maps_flag |= BIN_MAP;
+      break;
+    }
+  }
+
+  // Work out BSS map
+  int map_index = isvalid(pd->maps[MAP_LIBSYM].path) ? MAP_LIBSYM : MAP_BIN;
+  self->map.bss.base = pd->maps[map_index].bss_base;
+  self->map.bss.size = pd->maps[map_index].bss_size;
+  log_d("BSS map %d from %s @ %p", map_index, pd->maps[map_index].path, self->map.bss.base);
+
+release:
+  sfree(pd->maps[MAP_LIBNEEDLE].path);
+  sfree(pd);
   sfree(line);
+  sfree(prev_path);
   fclose(fp);
 
-  return (
-    (self->bin_path == NULL && self->lib_path == NULL) ||
-    maps_flag != HEAP_MAP
-  );
+  log_d("VM maps parsing result: bin=%s lib=%s flags=%d", self->bin_path, self->lib_path, maps_flag);
+
+  return maps_flag != (BIN_MAP | HEAP_MAP);
 } /* _py_proc__parse_maps_file */
 
 

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -151,17 +151,17 @@ release:
 } /* _get_version_from_executable */
 
 static int
-_get_version_from_filename(char * filename, int * major, int * minor, int * patch) {
+_get_version_from_filename(char * filename, const char * needle, int * major, int * minor, int * patch) {
   #if defined PL_LINUX                                               /* LINUX */
   char         * base       = filename;
   char         * end        = base + strlen(base);
 
   while (base < end) {
-    base = strstr(base, "libpython");
+    base = strstr(base, needle);
     if (!isvalid(base)) {
       break;
     }
-    if (sscanf(base, "libpython%u.%u", major, minor) == 2) {
+    if (sscanf(base + strlen(needle), "%u.%u", major, minor) == 2) {
       SUCCESS;
     }
   }
@@ -257,6 +257,12 @@ release:
 #endif
 
 
+#if defined PL_LINUX
+#define LIB_NEEDLE "libpython"
+#else
+#define LIB_NEEDLE "python"
+#endif
+
 static int
 _py_proc__infer_python_version(py_proc_t * self) {
   if (self == NULL || (self->bin_path == NULL && self->lib_path == NULL))
@@ -287,7 +293,7 @@ _py_proc__infer_python_version(py_proc_t * self) {
   // Try to infer the Python version from the library file name.
   if (
     isvalid(self->lib_path)
-  &&success(_get_version_from_filename(self->lib_path, &major, &minor, &patch))
+  &&success(_get_version_from_filename(self->lib_path, LIB_NEEDLE, &major, &minor, &patch))
   ) goto from_filename;
 
   // On Linux, the actual executable is sometimes picked as a library. Hence we
@@ -304,6 +310,12 @@ _py_proc__infer_python_version(py_proc_t * self) {
     isvalid(self->bin_path)
   &&(success(_get_version_from_executable(self->bin_path, &major, &minor, &patch)))
   ) goto from_exe;
+
+  // Try to infer the Python version from the executable file name.
+  if (
+    isvalid(self->bin_path)
+  &&success(_get_version_from_filename(self->bin_path, "python", &major, &minor, &patch))
+  ) goto from_filename;
 
   #if defined PL_MACOS
   if (major == 0) {
@@ -489,45 +501,64 @@ _py_proc__scan_heap(py_proc_t * self) {
 // ----------------------------------------------------------------------------
 static int
 _py_proc__scan_bss(py_proc_t * self) {
-  if (fail(py_proc__memcpy(self, self->map.bss.base, self->map.bss.size, self->bss))) {
-    log_ie("Failed to copy BSS section");
-    FAIL;
-  }
-
-  log_d("Scanning the BSS section @ %p", self->map.bss.base);
-
-  void * upper_bound = self->bss + self->map.bss.size;
-  #ifdef CHECK_HEAP
-  // When the process uses the shared library we need to search in other maps
-  // other than the heap (at least on Linux). This could be optimised by
-  // creating a list of all the maps and checking that a value is valid address
-  // within any of these maps. However, this scan between min and max address
-  // should still be relatively quick so that the extra complexity of a list is
-  // not strictly required.
-  #endif
-  for (
-    register void ** raddr = (void **) self->bss;
-    (void *) raddr < upper_bound;
-    raddr++
-  ) {
-    if (
-      #ifdef CHECK_HEAP
-      (isvalid(self->lib_path)
-        ? _py_proc__is_raddr_within_max_range(self, *raddr)
-        : _py_proc__is_heap_raddr(self, *raddr)) &&
-      #endif
-      success(_py_proc__check_interp_state(self, *raddr))
-    ) {
-      log_d(
-        "Possible interpreter state referenced by BSS @ %p (offset %x)",
-        (void *) raddr - (void *) self->bss + (void *) self->map.bss.base,
-        (void *) raddr - (void *) self->bss
-      );
-      self->is_raddr = *raddr;
-      SUCCESS;
+  // Starting with Python 3.11, BSS scans fail because it seems that the
+  // interpreter state is stored in the data section. In this case, we shift our
+  // data queries into the data section. We then take steps of 64KB backwards
+  // and try to find the interpreter state. This is a bit of a hack for now, but
+  // it seems to work with decent performance. Note that if we fail the first
+  // scan, we then look for actual interpreter states rather than pointers to
+  // it. This make the search a little slower, since we now have to check every
+  // value in the range. However, the step size we chose seems to get us close
+  // enough in a few attempts.
+  int    shift = 0;
+  size_t step  = self->map.bss.size > 0x10000 ? 0x10000 : self->map.bss.size;
+  
+  V_DESC(self->py_v);
+  
+  while (!(shift && V_MAX(3, 10))) {
+    void * base = self->map.bss.base - (shift * step);
+    if (fail(py_proc__memcpy(self, base, self->map.bss.size, self->bss))) {
+      log_ie("Failed to copy BSS section");
+      FAIL;
     }
-  }
 
+    log_d("Scanning the BSS section @ %p (shift %d)", base, shift);
+
+    void * upper_bound = self->bss + (shift ? step : self->map.bss.size);
+    #ifdef CHECK_HEAP
+    // When the process uses the shared library we need to search in other maps
+    // other than the heap (at least on Linux). This could be optimised by
+    // creating a list of all the maps and checking that a value is valid address
+    // within any of these maps. However, this scan between min and max address
+    // should still be relatively quick so that the extra complexity of a list is
+    // not strictly required.
+    #endif
+    for (
+      register void ** raddr = (void **) self->bss;
+      (void *) raddr < upper_bound;
+      raddr++
+    ) {
+      if (
+        (!shift &&
+        #ifdef CHECK_HEAP
+        (isvalid(self->lib_path)
+          ? _py_proc__is_raddr_within_max_range(self, *raddr)
+          : _py_proc__is_heap_raddr(self, *raddr)) &&
+        #endif
+        success(_py_proc__check_interp_state(self, *raddr)))
+        ||(shift && success(_py_proc__check_interp_state(self, (void*) raddr - self->bss + base)))
+      ) {
+        log_d(
+          "Possible interpreter state referenced by BSS @ %p (offset %x)",
+          (void *) raddr - (void *) self->bss + (void *) base,
+          (void *) raddr - (void *) self->bss
+        );
+        self->is_raddr = shift ? (void*) raddr - self->bss + base : *raddr;
+        SUCCESS;
+      }
+    }
+    shift++;
+  }
   FAIL;
 }
 
@@ -729,7 +760,7 @@ _py_proc__wait_for_interp_state(py_proc_t * self) {
   log_w("BSS scan unsuccessful so we scan the heap directly ...");
 
   // TODO: Consider copying heap over and check for pointers
-  TIMER_SET(10)
+  TIMER_SET(100)
   TIMER_START
     switch (_py_proc__scan_heap(self)) {
     case 0:

--- a/test/utils.py
+++ b/test/utils.py
@@ -172,12 +172,17 @@ austin = Variant("austin")
 austinp = Variant("austinp")
 
 
-def run_async(command: list[str], *args: tuple[str]) -> Popen:
-    return Popen(command + list(args), stdout=PIPE, stderr=PIPE)
+def run_async(command: list[str], *args: tuple[str], env: dict | None = None) -> Popen:
+    return Popen(command + list(args), stdout=PIPE, stderr=PIPE, env=env)
 
 
-def run_python(version, *args: tuple[str], sleep_after: float | None = None) -> Popen:
-    result = run_async(python(version), *args)
+def run_python(
+    version,
+    *args: tuple[str],
+    env: dict | None = None,
+    sleep_after: float | None = None,
+) -> Popen:
+    result = run_async(python(version), *args, env=env)
 
     if sleep_after is not None:
         sleep(sleep_after)


### PR DESCRIPTION
### Description of the Change

This change improves the way the VM map of the tracee are parsed on Linux, which allows for better detection of executable  and Python library files. Furthermore, the BSS scan fallback is now more reliable since its location is inferred from the maps too when the binary files are not available from the FS (e.g. when targeting processes spawned from within a chroot jail). This means that we can allow for scenarios like those of #159.

Resolves #159.

### Alternate Designs

Since the section headers are not loaded into memory, we have no viable alternatives but to keep parsing the ELF file for the most accurate information.

### Regressions

There is a chance that some Python distributions on Linux that used to work might no longer work. In fact, we expect the opposite to happen, that is more Python distros and Python-based tools to be supported, and under more scenarios (e.g. sampling a process running in a Docker container from within the host environment).

### Verification Process

A test is added that tries to mimic the chroot jail scenario by creating a virtual environment, starting a Python process and then removing the virtual environment files from disk to cause Austin to fail to find them.