### PR TITLE
chore(linux): infer PID namespace PID

### DIFF
--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -96,6 +96,32 @@ struct proc_desc {
 
 
 // ----------------------------------------------------------------------------
+static FILE*
+_procfs(char * buffer, pid_t pid, char * file) {
+  FILE * fp;
+  
+  sprintf(buffer, "/proc/%d/%s", pid, file);
+  
+  fp = fopen(buffer, "r");
+  if (fp == NULL) {
+    switch (errno) {
+    case EACCES:  // Needs elevated privileges
+      set_error(EPROCPERM);
+      break;
+    case ENOENT:  // Invalid pid
+      set_error(EPROCNPID);
+      break;
+    default:
+      set_error(EPROCVM);
+    }
+    return NULL;
+  }
+
+  return fp;
+}
+
+
+// ----------------------------------------------------------------------------
 static void *
 wait_thread(void * py_proc) {
   waitpid(((py_proc_t *) py_proc)->pid, 0, 0);
@@ -709,6 +735,36 @@ _py_proc__init(py_proc_t * self) {
 } /* _py_proc__init */
 
 
+// ----------------------------------------------------------------------------
+pid_t
+_get_nspid(pid_t pid) {
+  char     path[32];
+  char   * line  = NULL;
+  size_t   len   = 0;
+  pid_t    nspid = 0;
+  pid_t    this  = 0;
+
+  FILE* status = _procfs(path, pid, "status");
+  if (!isvalid(status)) {
+    log_e("Cannot get namespace PID for %d", pid);
+    return 0;
+  }
+
+  while (getline(&line, &len, status) != -1) {
+    if (sscanf(line, "NSpid:\t%d\t%d", &this, &nspid) == 2 && this == pid) {
+      break;
+    }
+  }
+
+  fclose(status);
+  sfree(line);
+  
+  log_d("NS PID for %d: %d", pid, nspid);
+
+  return nspid;
+}
+
+
 // Support for CPU time on Linux. We need to retrieve the TID from the struct
 // pthread pointed to by the native thread ID stored by Python. We do not have
 // the definition of the structure, so we need to "guess" the offset of the tid
@@ -725,8 +781,15 @@ _infer_tid_field_offset(py_thread_t * py_thread) {
 
   log_d("pthread_t at %p", py_thread->tid);
 
+  // If the target process is in a different PID namespace, we need to get its
+  // other PID to be able to determine the offset of the TID field.
+  pid_t nspid = _get_nspid(py_thread->raddr.pref);
+
   for (register int i = 0; i < PTHREAD_BUFFER_ITEMS; i++) {
-    if (py_thread->raddr.pref == _pthread_buffer[i]) {
+    if (
+      py_thread->raddr.pref == _pthread_buffer[i]
+      || (nspid && nspid == _pthread_buffer[i])
+    ) {
       log_d("TID field offset: %d", i);
       py_thread->proc->extra->pthread_tid_offset = i;
       SUCCESS;
@@ -735,7 +798,10 @@ _infer_tid_field_offset(py_thread_t * py_thread) {
 
   // Fall-back to smaller steps if we failed
   for (register int i = 0; i < PTHREAD_BUFFER_ITEMS * (sizeof(uintptr_t) / sizeof(pid_t)); i++) {
-    if (py_thread->raddr.pref == (pid_t) ((pid_t *) _pthread_buffer)[i]) {
+    if (
+      py_thread->raddr.pref == (pid_t) ((pid_t *) _pthread_buffer)[i]
+      || (nspid && nspid == (pid_t) ((pid_t *) _pthread_buffer)[i])
+    ) {
       log_d("TID field offset (from fall-back): %d", i);
       py_thread->proc->extra->pthread_tid_offset = -i;
       SUCCESS;

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -433,12 +433,16 @@ _py_proc__check_interp_state(py_proc_t * self, void * raddr) {
   // Try to determine the TID by reading the remote struct pthread structure.
   // We can then use this information to parse the appropriate procfs file and
   // determine the native thread's running state.
+  void * initial_thread_addr = thread.raddr.addr;
   while (isvalid(thread.raddr.addr)) {
     if (success(_infer_tid_field_offset(&thread)))
       SUCCESS;
     if (is_fatal(austin_errno))
       FAIL;
+    
     py_thread__next(&thread);
+    if (thread.raddr.addr == initial_thread_addr)
+      break;
   }
   log_d("tid field offset not ready");
   FAIL;

--- a/test/utils.py
+++ b/test/utils.py
@@ -180,9 +180,10 @@ def run_python(
     version,
     *args: tuple[str],
     env: dict | None = None,
+    prefix: list[str] = [],
     sleep_after: float | None = None,
 ) -> Popen:
-    result = run_async(python(version), *args, env=env)
+    result = run_async(prefix + python(version), *args, env=env)
 
     if sleep_after is not None:
         sleep(sleep_after)


### PR DESCRIPTION
### Description of the Change

This change allows Austin to infer the PID of a process running in a different PID namespace (e.g. containers) so that the pthread TID field offset can be computed reliably in this case. Previously, the inference would fail and cause an infinite loop.

Resolves #159.

### Alternate Designs

To the best of our knowledge, `/proc/<pid>/status` is the only procfs file that can provide the necessary information to find other PIDs a process is known by.

### Regressions

None expected. This is an enhancement.

### Verification Process

Existing test suite.