### PR TITLE
refactor(linux): use the procfs helper

### DIFF
--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -24,6 +24,8 @@
 
 #if defined PL_LINUX
 #include <dirent.h>
+
+#include "linux/common.h"
 #elif defined PL_MACOS
 #include <libproc.h>
 #elif defined PL_WIN
@@ -205,9 +207,8 @@ py_proc_list__update(py_proc_list_t * self) {
 
   // Update PID table
   #if defined PL_LINUX                                               /* LINUX */
-  char stat_path[32];
-  char buffer[1024];
-  struct dirent *ent;
+  char            buffer[1024];
+  struct dirent * ent;
 
   cu_DIR * proc_dir = opendir("/proc");
   if (!isvalid(proc_dir)) {
@@ -222,9 +223,7 @@ py_proc_list__update(py_proc_list_t * self) {
     if ((*ent->d_name <= '0') || (*ent->d_name > '9')) continue;
 
     unsigned long pid = strtoul(ent->d_name, NULL, 10);
-    sprintf(stat_path, "/proc/%ld/stat", pid);
-
-    cu_FILE * stat_file = fopen(stat_path, "rb");
+    cu_FILE * stat_file = _procfs(pid, "stat");
     if (stat_file == NULL)
       continue;
 

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -513,8 +513,7 @@ py_thread__is_interrupted(py_thread_t * self) {
 
 int
 py_thread__save_kernel_stack(py_thread_t * self) {
-  char stack_path[48];
-  int  fd;
+  char  stack_path[48];
 
   if (!isvalid(_kstacks))
     FAIL;
@@ -522,17 +521,15 @@ py_thread__save_kernel_stack(py_thread_t * self) {
   sfree(_kstacks[self->tid]);
 
   sprintf(stack_path, "/proc/%d/task/" TID_FMT "/stack", self->proc->pid, self->tid);
-  fd = open(stack_path, O_RDONLY);
+  cu_fd fd = open(stack_path, O_RDONLY);
   if (fd == -1)
     FAIL;
 
   _kstacks[self->tid] = (char *) calloc(1, MAX_STACK_FILE_SIZE);
   if (read(fd, _kstacks[self->tid], MAX_STACK_FILE_SIZE) == -1) {
     log_e("stack: failed to read %s", stack_path);
-    close(fd);
     FAIL;
   };
-  close(fd);
 
   SUCCESS;
 }
@@ -808,10 +805,12 @@ py_thread__fill_from_raddr(py_thread_t * self, raddr_t * raddr, py_proc_t * proc
     }
     else if (
       likely(proc->extra->pthread_tid_offset)
-      && success(read_pthread_t(self->raddr.pref, (void *) self->tid
+      && success(read_pthread_t(self->proc, (void *) self->tid
     ))) {
       int o = proc->extra->pthread_tid_offset;
-      self->tid = o > 0 ? _pthread_buffer[o] : (pid_t) ((pid_t *) _pthread_buffer)[-o];
+      self->tid = o > 0
+        ? proc->extra->_pthread_buffer[o]
+        : (pid_t) ((pid_t *) proc->extra->_pthread_buffer)[-o];
       if (self->tid >= max_pid || self->tid == 0) {
         log_e("Invalid TID detected");
         self->tid = 0;


### PR DESCRIPTION
### Description of the Change

A previous change has introduced a helper to open PID-based files from procfs. This change makes use of the helper in other places too for code reuse.

### Alternate Designs

N.A.

### Regressions

None expected

### Verification Process

Existing test suite