### PR TITLE
feat: support column-level location information

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,7 +79,7 @@ jobs:
         run: pip install black
 
       - name: Check source code spelling
-        run: black --check test/
+        run: black --check --exclude=test/targets test/
 
   linting-tests:
     runs-on: ubuntu-20.04

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 xxxx-xx-xx v3.5.0
 
+  Added support for fine-grained, column-level location information when
+  exporting samples in binary mode.
+
   Improved multiprocess support.
 
   Dropped the alternative output format.

--- a/README.md
+++ b/README.md
@@ -403,6 +403,16 @@ More details about the [MOJO] binary format can be found in the [Wiki].
 *Since Austin 3.4.0*.
 
 
+## Column-level Location Information
+
+Since Python 3.11, code objects carry finer-grained location information at the
+column level. When using the binary MOJO format, Austin can extract this extra
+location information when profiling code running with versions of the
+interpreter that expose this data.
+
+*Since Austin 3.5.0*.
+
+
 ## Memory and Full Metrics
 
 When profiling in memory mode with the `-m` or `--memory` switch, the metric

--- a/src/linux/addr2line.h
+++ b/src/linux/addr2line.h
@@ -224,8 +224,8 @@ get_native_frame(const char *file_name, bfd_vma addr, key_dt frame_key)
     syms = NULL;
 
     frame_t *frame = isvalid(filename) && isvalid(name)
-                         ? frame_new(frame_key, strdup(filename), strdup(name), line)
-                         : NULL;
+        ? frame_new(frame_key, strdup(filename), strdup(name), line, 0, 0, 0)
+        : NULL;
 
     bfd_close(abfd);
 

--- a/src/mojo.h
+++ b/src/mojo.h
@@ -29,7 +29,7 @@
 #include "cache.h"
 #include "platform.h"
 
-#define MOJO_VERSION 1
+#define MOJO_VERSION 2
 
 enum {
   MOJO_RESERVED,
@@ -124,12 +124,15 @@ static inline void mojo_integer(mojo_int_t integer, int sign) {
   mojo_integer(pid, 0);      \
   mojo_fstring(FORMAT_TID, tid);
 
-#define mojo_frame(frame)      \
-  mojo_event(MOJO_FRAME);      \
-  mojo_integer(frame->key, 0); \
-  mojo_ref(frame->filename);   \
-  mojo_ref(frame->scope);      \
-  mojo_integer(frame->line, 0);
+#define mojo_frame(frame)           \
+  mojo_event(MOJO_FRAME);           \
+  mojo_integer(frame->key, 0);      \
+  mojo_ref(frame->filename);        \
+  mojo_ref(frame->scope);           \
+  mojo_integer(frame->line, 0);     \
+  mojo_integer(frame->line_end, 0); \
+  mojo_integer(frame->column, 0);   \
+  mojo_integer(frame->column_end, 0);
 
 #define mojo_frame_ref(frame) \
   mojo_event(MOJO_FRAME_REF); \

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -683,7 +683,7 @@ _py_thread__unwind_native_frame_stack(py_thread_t * self) {
           }
         }
 
-        frame = frame_new(frame_key, filename, scope, offset);
+        frame = frame_new(frame_key, filename, scope, offset, 0, 0, 0);
         if (!isvalid(frame)) {
           log_ie("Failed to make native frame");
           FAIL;

--- a/test/.flake8
+++ b/test/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+exclude = targets/*

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-austin-python~=1.4
+austin-python~=1.5
 flaky
 pytest
 pytest-xdist

--- a/test/targets/column.py
+++ b/test/targets/column.py
@@ -1,0 +1,21 @@
+from time import sleep
+
+
+def lazy(n):
+    for _ in range(n):
+        sleep(0.1)
+        yield _
+
+
+def fib(n):
+    a, b = 0, 1
+    for _ in range(n):
+        yield a
+        a, b = b, a + b
+
+a = [
+    list(fib(_))
+    for _ in lazy(30)
+]
+
+print(a)

--- a/test/test_mojo.py
+++ b/test/test_mojo.py
@@ -1,0 +1,59 @@
+# This file is part of "austin" which is released under GPL.
+#
+# See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+# details.
+#
+# Austin is a Python frame stack sampler for CPython.
+#
+# Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from test.utils import allpythons
+from test.utils import austin
+from test.utils import python
+from test.utils import target
+
+from austin.format.mojo import MojoFile, MojoFrame
+from flaky import flaky
+
+
+@flaky
+@allpythons(min=(3, 11))
+def test_mojo_column_data(py, tmp_path: Path):
+    datafile = tmp_path / "test_mojo_column.austin"
+
+    result = austin(
+        "-i", "100", "-o", str(datafile), *python(py), target("column.py"), mojo=True
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+    def strip(f):
+        return (f.scope.string.value, f.line, f.line_end, f.column, f.column_end)
+
+    with datafile.open("rb") as f:
+        frames = {
+            strip(_)
+            for _ in MojoFile(f).parse()
+            if isinstance(_, MojoFrame)
+            and _.filename.string.value.endswith("column.py")
+        }
+
+        assert frames >= {
+            ("<module>", 16, 19, 5, 2),
+            ("<listcomp>", 16, 19, 5, 2),
+            ("lazy", 6, 6, 9, 19),
+            ("<listcomp>", 17, 17, 5, 17),
+        }


### PR DESCRIPTION
### Description of the Change

This change adds support for the extra column-level information exported by the location table of Python 3.11 code objects. The finer-grained location data is made available though the MOJO binary format only.

### Alternate Designs

N.A.

### Regressions

None expected.

### Verification Process

Added and extra test case to validate the presence of the extra column-level location data.