### PR TITLE
fix(macos): report permission error if not root

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,6 +229,7 @@ jobs:
             || (python${{ matrix.python-version }} -m pip install virtualenv && python${{ matrix.python-version }} -m virtualenv .venv)
           source .venv/bin/activate
           sudo -E pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -sr a
+          pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -sr a -k _darwin
           deactivate
 
   wheels-osx:

--- a/src/austin.c
+++ b/src/austin.c
@@ -219,6 +219,14 @@ int main(int argc, char ** argv) {
   py_proc_t * py_proc        = NULL;
   int         exec_arg       = parse_args(argc, argv);
 
+#if defined PL_MACOS
+  // On MacOS, we need to be root to use Austin.
+  if (geteuid() != 0) {
+    _msg(MPERM);
+    return EPROCPERM;
+  }
+#endif
+
   logger_init();
   if (!pargs.pipe)
     log_header();

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -70,3 +70,14 @@ def test_cli_permissions():
         result = austin("-i", "1ms", "-p", str(p.pid))
         assert result.returncode == 37, result.stderr
         assert "Insufficient permissions" in result.stderr, result.stderr
+
+
+@pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="Only Darwin requires sudo in all cases",
+)
+@no_sudo
+def test_cli_permissions_darwin():
+    result = austin("-i", "1ms", "python3.10", "-c", "from time import sleep; sleep(1)")
+    assert result.returncode == 37, result.stderr
+    assert "Insufficient permissions" in result.stderr, result.stderr


### PR DESCRIPTION
This change ensures that Austin reports the expected error code and message when running without the superuser privileges.

### Requirements for Adding, Changing, Fixing or Removing a Feature

Fill out the template below. Any pull request that does not include enough
information to be reviewed in a timely manner may be closed at the maintainers'
discretion.


### Description of the Change

<!--

Please give a brief but exhaustive description of the changes contained in the
PR.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version
was selected -->

### Regressions

<!-- What are the possible side-effects or negative impacts of the code change?
Would any user of austin be forced to adapt their scripts or code if they wanted
to upgrade to the new version? If so, please try to give an estimate of the
effort involved.
-->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
- How did you verify that the change has not introduced any memory leaks?

-->
