### PR TITLE
refactor: use proper lasti formula for 3.11 

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -179,8 +179,6 @@ _frame_from_code_raddr(py_proc_t * py_proc, void * code_raddr, int lasti, python
       return NULL;
     }
 
-    lasti >>= 1;
-
     for (size_t i = 0, bc = 0; i < len; i++) {
       bc += (lnotab[i] & 7) + 1;
       int code = (lnotab[i] >> 3) & 15;

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -314,7 +314,7 @@ _py_thread__push_iframe_from_addr(py_thread_t * self, PyInterpreterFrame * ifram
   stack_py_push(
     origin,
     code_raddr,
-    ((int)(V_FIELD_PTR(void *, iframe, py_iframe, o_prev_instr) - code_raddr)) - py_v->py_code.o_code
+    (((int)(V_FIELD_PTR(void *, iframe, py_iframe, o_prev_instr) - code_raddr)) - py_v->py_code.o_code) / sizeof(_Py_CODEUNIT)
   );
 
   #ifdef NATIVE


### PR DESCRIPTION
### Description of the Change

Use the more correct expression for computing the lasti index with Python 3.11.

### Alternate Designs

N. A.

### Regressions

None. We expect compiler optimisations to do a good job with divisions by powers of 2.

### Verification Process

Existing test suite