### PR TITLE
ci(ubuntu): update before install

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,6 +11,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
 
       - name: Install Python 3.10

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install build dependencies
-        run: sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev help2man
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev help2man
 
       - name: Compile Austin
         run: |
@@ -36,7 +38,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install cppcheck
-        run: sudo apt-get -y install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install cppcheck
 
       - name: Check soure code
         run: cppcheck -q -f --error-exitcode=1 --inline-suppr src
@@ -103,6 +107,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
           sudo apt-get -y install \
             valgrind \
             python2.7 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
 
       - name: Compile Austin
@@ -43,6 +44,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install musl-tools
 
       - name: Compile Austin
@@ -81,6 +83,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install \
             valgrind \
             gdb
@@ -376,6 +379,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
 
       - name: Install Python


### PR DESCRIPTION
APT repository changes might require `apt-get update` to be called before `apt-get install`.