### PR TITLE
Quash gcc-13 -Werror due to ent->d_name always being non-NULL

### DIFF
--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -219,7 +219,7 @@ py_proc_list__update(py_proc_list_t * self) {
   for (;;) {
     // This code is inspired by the ps util
     ent = readdir(proc_dir);
-    if (!ent || !ent->d_name) break;
+    if (!ent || !ent->d_name[0]) break;
     if ((*ent->d_name <= '0') || (*ent->d_name > '9')) continue;
 
     unsigned long pid = strtoul(ent->d_name, NULL, 10);


### PR DESCRIPTION
### Requirements for Adding, Changing, Fixing or Removing a Feature

Fill out the template below. Any pull request that does not include enough
information to be reviewed in a timely manner may be closed at the maintainers'
discretion.


### Description of the Change

`d_name` is an array member, not a pointer, so it's never NULL. It can be the empty string, in which case `d_name[0]` should be '\0'. This fixes the `-Werror` build failure when using gcc-13.

### Alternate Designs

Could simplify to `if (!ent) break;`.

### Regressions

build succeeds

### Verification Process

I compiled and ran.