### PR TITLE
fix: version detection on Python 3.11

### DIFF
--- a/src/python/symbols.h
+++ b/src/python/symbols.h
@@ -39,17 +39,17 @@ enum {
 #ifdef PY_PROC_C
 
 #ifdef PL_MACOS
-  #define SYM_PREFIX "__"
-#else
   #define SYM_PREFIX "_"
+#else
+  #define SYM_PREFIX ""
 #endif
 
 
 static const char * _dynsym_array[] = {
-  SYM_PREFIX "PyThreadState_Current",
-  SYM_PREFIX "PyRuntime",
+  SYM_PREFIX "_PyThreadState_Current",
+  SYM_PREFIX "_PyRuntime",
   "interp_head",
-  "Py_Version",
+  SYM_PREFIX "Py_Version",
 };
 
 static long _dynsym_hash_array[DYNSYM_COUNT] = {0};

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from subprocess import check_output
+
 from test.utils import allpythons
 from test.utils import austin
 from test.utils import compress
@@ -115,3 +117,18 @@ def test_pipe_wall_time_multiprocess_output(py, tmp_path):
         d = int(meta["duration"])
 
         assert 0 < 0.8 * d < a < 2.2 * d
+
+
+@allpythons(min=(3, 11))
+def test_python_version(py):
+    result = austin("-Pi", "1s", *python(py), target())
+    assert result.returncode == 0
+
+    meta = metadata(result.stdout)
+
+    reported_version = ".".join((str(_) for _ in meta["python"]))
+    actual_version = (
+        check_output([*python(py), "-V"]).decode().strip().partition(" ")[-1]
+    )
+
+    assert reported_version == actual_version, meta


### PR DESCRIPTION
### Description of the Change

The wrong symbol name was being used on OSX, preventing the inference of the Python version from symbols.

### Regressions

None expected

### Verification Process

Added a new test case to check that we get the correct full version from symbols.