### PR TITLE
refactor: general coding improvements

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -173,8 +173,8 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r test/requirements.txt
-          .venv/bin/pytest --pastebin=failed --no-flaky-report -sr fE -n auto || true
-          sudo -E env PATH="$PATH" .venv/bin/pytest --pastebin=failed --no-flaky-report -sr fE -n auto || true
+          .venv/bin/pytest --pastebin=failed -sr fE -n auto || true
+          sudo -E env PATH="$PATH" .venv/bin/pytest --pastebin=failed -sr fE -n auto || true
           deactivate
 
       - name: Generate Cobertura report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,8 +109,8 @@ jobs:
         run: |
           ulimit -c unlimited
           source .venv/bin/activate
-          sudo -E env PATH="$PATH" .venv/bin/pytest --pastebin=failed --no-flaky-report -svr a
-          .venv/bin/pytest --pastebin=failed --no-flaky-report -svr a
+          sudo -E env PATH="$PATH" .venv/bin/pytest --pastebin=failed -svr a
+          .venv/bin/pytest --pastebin=failed -svr a
           deactivate
 
   wheels-linux:
@@ -235,8 +235,8 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          sudo -E pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -svr a
-          pytest --ignore=test/cunit --pastebin=failed --no-flaky-report -svr a -k _darwin
+          sudo -E pytest --ignore=test/cunit --pastebin=failed -svr a
+          pytest --ignore=test/cunit --pastebin=failed -svr a -k _darwin
           deactivate
 
   wheels-osx:
@@ -338,7 +338,7 @@ jobs:
       - name: Run tests
         run: |
           venv\Scripts\Activate.ps1
-          python -m pytest --ignore=test\cunit --pastebin=failed --no-flaky-report -svr a
+          python -m pytest --ignore=test\cunit --pastebin=failed -svr a
           deactivate
 
   wheels-win:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,8 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install \
             valgrind \
-            gdb
+            gdb \
+            systemd-coredump
 
       - name: Install Python
         uses: actions/setup-python@v4
@@ -105,11 +106,17 @@ jobs:
           pip install -r test/requirements.txt
           deactivate
 
-      - name: Run tests
+      - name: Run tests (with sudo)
         run: |
           ulimit -c unlimited
           source .venv/bin/activate
           sudo -E env PATH="$PATH" .venv/bin/pytest --pastebin=failed -svr a
+          deactivate
+
+      - name: Run tests (without sudo)
+        run: |
+          ulimit -c unlimited
+          source .venv/bin/activate
           .venv/bin/pytest --pastebin=failed -svr a
           deactivate
 
@@ -338,7 +345,7 @@ jobs:
       - name: Run tests
         run: |
           venv\Scripts\Activate.ps1
-          python -m pytest --ignore=test\cunit --pastebin=failed -svr a
+          python -m pytest --full-trace --ignore=test\cunit --pastebin=failed -svr a
           deactivate
 
   wheels-win:

--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,10 @@ AM_CONDITIONAL([COVERAGE], [test x$coverage = xtrue])
 AC_ARG_ENABLE([debug-symbols], [
   --enable-debug-symbols    Include debug symbols], [
 case "${enableval}" in
-    yes) debugsymbols=true ;;
+    yes)
+        debugsymbols=true
+        AUSTINP_LDADD+=" -lm"
+        ;;
     no)  debugsymbols=false ;;
     *) AC_MSG_ERROR([bad value ${enableval} for --enable-debug-symbols]) ;;
 esac], [debugsymbols=false])

--- a/scripts/cog.sh
+++ b/scripts/cog.sh
@@ -11,4 +11,5 @@ cog -P $args \
     README.md \
     src/austin.h \
     src/argparse.c \
+    src/linux/py_proc.h \
     snap/snapcraft.yaml

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,7 +25,8 @@ OPT_FLAGS = -O3
 STRIP_FLAGS = -Os -s
 
 if DEBUG_SYMBOLS
-DEBUG_OPTS = -g
+DEBUG_OPTS = -g -DDEBUG
+austin_LDADD = -lm
 undefine STRIP_FLAGS
 endif
 
@@ -62,5 +63,5 @@ bin_PROGRAMS += austinp
 
 austinp_SOURCES = $(austin_SOURCES)
 austinp_CFLAGS = $(austin_CFLAGS) @AUSTINP_CFLAGS@
-austinp_LDADD = @AUSTINP_LDADD@
+austinp_LDADD = $(austin_LDADD) @AUSTINP_LDADD@
 endif

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -45,7 +45,7 @@
 #else
 #define DEFAULT_SAMPLING_INTERVAL    100
 #endif
-#define DEFAULT_INIT_TIMEOUT_MS      500  // 0.5 seconds
+#define DEFAULT_INIT_TIMEOUT_MS     1000  // 1 seconds
 #define DEFAULT_HEAP_SIZE              0
 
 const char SAMPLE_FORMAT_NORMAL[]      = ";%s:%s:%d";

--- a/src/austin.c
+++ b/src/austin.c
@@ -138,7 +138,7 @@ do_child_processes(py_proc_t * py_proc) {
     // enough so we can try to attach to child processes straight away.
     // TODO: In the future, we might want to consider adding the option to wait
     // for child processes, as they might be spawned only much later.
-    pargs.timeout = 1;
+    pargs.timeout = 100000;  // 0.1s
 
     // Store the PID before it gets deleted by the update.
     pid_t ppid = py_proc->pid;
@@ -215,8 +215,13 @@ do_child_processes(py_proc_t * py_proc) {
 static inline int
 handle_error() {
   int retval = 0;
+  
   log_d("Last error: %d :: %s", austin_errno, get_last_error());
-  if (is_fatal(austin_errno)) {
+  
+  if (interrupt == SIGTERM) {
+    retval = SIGTERM;
+  }
+  else {
     retval = austin_errno;
 
     switch(retval) {
@@ -254,9 +259,6 @@ handle_error() {
       _msg(MERROR);
     }
   }
-
-  if (interrupt == SIGTERM)
-    retval = SIGTERM;
 
   return retval;
 } /* handle_error */

--- a/src/austin.c
+++ b/src/austin.c
@@ -211,6 +211,56 @@ do_child_processes(py_proc_t * py_proc) {
 } /* do_child_processes */
 
 
+// ----------------------------------------------------------------------------
+static inline int
+handle_error() {
+  int retval = 0;
+  log_d("Last error: %d :: %s", austin_errno, get_last_error());
+  if (is_fatal(austin_errno)) {
+    retval = austin_errno;
+
+    switch(retval) {
+    case EPROCISTIMEOUT:
+      _msg(MTIMEOUT, pargs.attach_pid == 0 ? "run" : "attach to");
+      break;
+    #if defined PL_UNIX
+    case EPROCPERM:
+      _msg(MPERM);
+      break;
+    #endif
+    case EPROCFORK:
+      _msg(MFORK);
+      break;
+    case EPROCATTACH:
+      _msg(MATTACH);
+      break;
+    case EPROCNPID:
+      _msg(MNOPROC);
+      break;
+    case EPROC:
+      _msg(MNOPYTHON);
+      break;
+    case EPROCNOCHILDREN:
+      _msg(MNOCHILDREN);
+      break;
+    case ENOVERSION:
+      _msg(MNOVERSION);
+      break;
+    case EMEMCOPY:
+      // Ignore. At this point we expect remote memory reads to fail.
+      retval = EOK;
+      break;
+    default:
+      _msg(MERROR);
+    }
+  }
+
+  if (interrupt == SIGTERM)
+    retval = SIGTERM;
+
+  return retval;
+} /* handle_error */
+
 // ---- MAIN ------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
@@ -268,6 +318,8 @@ int main(int argc, char ** argv) {
     ) {
       log_ie("Cannot start the process");
       py_proc__terminate(py_proc);
+
+      retval = handle_error();
       goto finally;
     }
   } else {
@@ -276,12 +328,11 @@ int main(int argc, char ** argv) {
       && !pargs.children
     ) {
       log_ie("Cannot attach the process");
+
+      retval = handle_error();
       goto finally;
     }
   }
-
-  if (austin_errno == EPROCPERM)
-    goto finally;
 
   // Redirect output to STDOUT if not output file was given.
   if (pargs.output_file != stdout)
@@ -331,11 +382,10 @@ int main(int argc, char ** argv) {
   // destroying it. Hence once they return we need to invalidate it.
   py_proc = NULL;
 
-  if (austin_errno == EPROCNOCHILDREN)
+  if (austin_errno == EPROCNOCHILDREN) {
+    retval = handle_error();
     goto finally;
-
-  if (austin_errno == EPROCNPID)
-    austin_errno = EOK;
+  }
 
   if (pargs.where)
     goto finally;
@@ -353,49 +403,6 @@ int main(int argc, char ** argv) {
 finally:
   py_thread_free();
   py_proc__destroy(py_proc);
-
-  log_d("Last error: %d :: %s", austin_errno, get_last_error());
-  if (is_fatal(austin_errno)) {
-    retval = austin_errno;
-
-    switch(retval) {
-    case EPROCISTIMEOUT:
-      _msg(MTIMEOUT, pargs.attach_pid == 0 ? "run" : "attach to");
-      break;
-    #if defined PL_UNIX
-    case EPROCPERM:
-      _msg(MPERM);
-      break;
-    #endif
-    case EPROCFORK:
-      _msg(MFORK);
-      break;
-    case EPROCATTACH:
-      _msg(MATTACH);
-      break;
-    case EPROCNPID:
-      _msg(MNOPROC);
-      break;
-    case EPROC:
-      _msg(MNOPYTHON);
-      break;
-    case EPROCNOCHILDREN:
-      _msg(MNOCHILDREN);
-      break;
-    case ENOVERSION:
-      _msg(MNOVERSION);
-      break;
-    case EMEMCOPY:
-      // Ignore. At this point we expect remote memory reads to fail.
-      retval = EOK;
-      break;
-    default:
-      _msg(MERROR);
-    }
-  }
-
-  if (interrupt == SIGTERM)
-    retval = SIGTERM;
 
   log_footer();
 

--- a/src/austin.h
+++ b/src/austin.h
@@ -23,6 +23,8 @@
 #ifndef AUSTIN_H
 #define AUSTIN_H
 
+#include "platform.h"
+
 #ifdef NATIVE
 #define PROGRAM_NAME                    "austinp"
 #else

--- a/src/error.c
+++ b/src/error.c
@@ -39,7 +39,7 @@ const char * _error_msg_tab[MAXERROR] = {
   "Cannot determine Python version",
   "Cannot redirect STDOUT to " NULL_DEVICE,
   "No command nor valid PID",
-  NULL,
+  "Binary has no symbols",
   NULL,
 
   // PyCodeObject

--- a/src/error.c
+++ b/src/error.c
@@ -66,7 +66,7 @@ const char * _error_msg_tab[MAXERROR] = {
   "Failed to create thread object",
   "Failed to get top frame for thread",
   "Invalid thread",
-  NULL,
+  "No next thread",
   NULL,
   NULL,
   NULL,
@@ -88,7 +88,7 @@ const int _fatal_error_tab[MAXERROR] = {
   // generic error messages
   0,
   1,
-  0,
+  1,
   1,
   0,
   1,
@@ -126,7 +126,7 @@ const int _fatal_error_tab[MAXERROR] = {
   0,
 
   // py_proc_t
-  1,
+  0,
   1,
   1,
   1,

--- a/src/error.h
+++ b/src/error.h
@@ -35,6 +35,7 @@
 #define ENOVERSION            3
 #define ENULLDEV              4
 #define ECMDLINE              5
+#define ESYM                  6
 
 // PyCodeObject
 #define ECODE                 ((1 << 3) + 0)

--- a/src/error.h
+++ b/src/error.h
@@ -56,6 +56,7 @@
 #define ETHREAD               ((3 << 3) + 0)
 #define ETHREADNOFRAME        ((3 << 3) + 1)
 #define ETHREADINV            ((3 << 3) + 2)
+#define ETHREADNONEXT         ((3 << 3) + 3)
 
 // py_proc_t
 #define EPROC                 ((4 << 3) + 0)

--- a/src/hints.h
+++ b/src/hints.h
@@ -29,8 +29,6 @@
 #define TRUE                           1
 #define FALSE                          0
 
-#define NOVERSION                      0
-
 #define success(x)                      (!(x))
 #define fail(x)                         (x)
 #define sfree(x)                        {if ((x) != NULL) {free(x); x = NULL;}}

--- a/src/linux/analyze_elf.h
+++ b/src/linux/analyze_elf.h
@@ -1,0 +1,90 @@
+// ----------------------------------------------------------------------------
+static Elf64_Addr
+_get_base_64(Elf64_Ehdr * ehdr, void * elf_map)
+{
+  for (int i = 0; i < ehdr->e_phnum; ++i) {
+    Elf64_Phdr * phdr = (Elf64_Phdr *) (elf_map + ehdr->e_phoff + i * ehdr->e_phentsize);
+    if (phdr->p_type == PT_LOAD)
+      return phdr->p_vaddr - phdr->p_vaddr % phdr->p_align;
+  }
+  return UINT64_MAX;
+} /* _get_base_64 */
+
+static int
+_py_proc__analyze_elf64(py_proc_t * self, void * elf_map, void * elf_base) {
+  register int symbols = 0;
+
+  Elf64_Ehdr * ehdr = elf_map;
+
+  // Section header must be read from binary as it is not loaded into memory
+  Elf64_Xword   sht_size      = ehdr->e_shnum * ehdr->e_shentsize;
+  Elf64_Off     elf_map_size  = ehdr->e_shoff + sht_size;
+  Elf64_Shdr  * p_shdr;
+
+  Elf64_Shdr  * p_shstrtab   = elf_map + ELF_SH_OFF(ehdr, ehdr->e_shstrndx);
+  char        * sh_name_base = elf_map + p_shstrtab->sh_offset;
+  Elf64_Shdr  * p_dynsym     = NULL;
+  Elf64_Addr    base         = _get_base_64(ehdr, elf_map);
+
+  void         * bss_base    = NULL;
+  size_t         bss_size    = 0;
+
+  if (base != UINT64_MAX) {
+    log_d("Base @ %p", base);
+
+    for (Elf64_Off sh_off = ehdr->e_shoff; \
+      sh_off < elf_map_size; \
+      sh_off += ehdr->e_shentsize \
+    ) {
+      p_shdr = (Elf64_Shdr *) (elf_map + sh_off);
+
+      if (
+        p_shdr->sh_type == SHT_DYNSYM && \
+        strcmp(sh_name_base + p_shdr->sh_name, ".dynsym") == 0
+      ) {
+        p_dynsym = p_shdr;
+      }
+      else if (strcmp(sh_name_base + p_shdr->sh_name, ".bss") == 0) {
+        bss_base = elf_base + (p_shdr->sh_addr - base);
+        bss_size = p_shdr->sh_size;
+      }
+      else if (strcmp(sh_name_base + p_shdr->sh_name, ".PyRuntime") == 0) {
+        self->map.runtime.base = elf_base + (p_shdr->sh_addr - base);
+        self->map.runtime.size = p_shdr->sh_size;
+      }
+    }
+
+    if (p_dynsym != NULL) {
+      if (p_dynsym->sh_offset != 0) {
+        Elf64_Shdr * p_strtabsh = (Elf64_Shdr *) (elf_map + ELF_SH_OFF(ehdr, p_dynsym->sh_link));
+
+        // Search for dynamic symbols
+        for (Elf64_Off tab_off = p_dynsym->sh_offset; \
+          tab_off < p_dynsym->sh_offset + p_dynsym->sh_size; \
+          tab_off += p_dynsym->sh_entsize
+        ) {
+          Elf64_Sym * sym      = (Elf64_Sym *) (elf_map + tab_off);
+          char      * sym_name = (char *) (elf_map + p_strtabsh->sh_offset + sym->st_name);
+          void      * value    = elf_base + (sym->st_value - base);
+          if ((symbols += _py_proc__check_sym(self, sym_name, value)) >= DYNSYM_COUNT) {
+            // We have found all the symbols. No need to look further
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (symbols < DYNSYM_MANDATORY) {
+    log_e("ELF binary has not all the mandatory Python symbols");
+    set_error(ESYM);
+    FAIL;
+  }
+
+  // Communicate BSS data back to the caller
+  self->map.bss.base = bss_base;
+  self->map.bss.size = bss_size;
+  log_d("BSS @ %p (size %x, offset %x)", self->map.bss.base, self->map.bss.size, self->map.bss.base - elf_base);
+
+  SUCCESS;
+} /* _py_proc__analyze_elf64 */

--- a/src/linux/futils.h
+++ b/src/linux/futils.h
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/stat.h>
+
+#define BUF_SIZE 1024
+
+typedef uint32_t crc32_t;
+
+// ----------------------------------------------------------------------------
+static inline crc32_t
+crc32(const uint8_t *data, size_t length)
+{
+    crc32_t crc = 0xFFFFFFFF;
+    for (size_t i = 0; i < length; i++)
+    {
+        crc ^= data[i];
+        for (size_t j = 0; j < 8; j++)
+        {
+            crc = (crc >> 1) ^ (0xEDB88320 & (-(int32_t)(crc & 1))); // cppcheck-suppress [integerOverflow]
+        }
+    }
+    return ~crc;
+}
+
+// ----------------------------------------------------------------------------
+static inline crc32_t
+fhash(FILE *fp)
+{
+
+    uint8_t buf[BUF_SIZE];
+    size_t bytes_read;
+    crc32_t crc = 0xFFFFFFFF;
+
+    // Save the current position
+    long int current_offset = ftell(fp);
+
+    // Move to the beginning of the file
+    fseek(fp, 0, SEEK_SET);
+
+    while ((bytes_read = fread(buf, 1, BUF_SIZE, fp)) != 0)
+    {
+        crc = crc32(buf, bytes_read);
+    }
+
+    // Restore the position
+    fseek(fp, current_offset, SEEK_SET);
+
+    return ~crc;
+}
+
+// ----------------------------------------------------------------------------
+static inline long
+fmtime_ns(FILE *fp)
+{
+    struct stat st;
+    if (fstat(fileno(fp), &st) != 0)
+    {
+        return -1;
+    }
+    return st.st_mtim.tv_nsec;
+}

--- a/src/logging.c
+++ b/src/logging.c
@@ -22,6 +22,7 @@
 
 #define _DEFAULT_SOURCE
 
+#include "austin.h"
 #include "events.h"
 #include "mem.h"
 #include "platform.h"
@@ -84,7 +85,7 @@ logger_init(void) {
   if (!logging) return;
   #ifdef PL_UNIX
   setlogmask (LOG_UPTO (LOG_DEBUG));
-  openlog ("austin", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);
+  openlog (PROGRAM_NAME, LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);
 
   #else
   if (logfile == NULL) {

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -156,7 +156,13 @@ _py_proc__analyze_macho64(py_proc_t * self, void * base, void * map) {
             self->map.bss.base = base + sec[j].addr;
             self->map.bss.size = sec[j].size;
             bin_attrs |= B_BSS;
-            break;
+            continue;
+          }
+          // This section was added in Python 3.11
+          if (strcmp(sec[j].sectname, "PyRuntime") == 0) {
+            self->map.runtime.base = base + sec[j].addr;
+            self->map.runtime.size = sec[j].size;
+            continue;
           }
         }
         cmd_cnt++;
@@ -257,7 +263,13 @@ _py_proc__analyze_macho32(py_proc_t * self, void * base, void * map) {
             self->map.bss.base = base + sec[j].addr;
             self->map.bss.size = sec[j].size;
             bin_attrs |= B_BSS;
-            break;
+            continue;
+          }
+          // This section was added in Python 3.11
+          if (strcmp(sec[j].sectname, "PyRuntime") == 0) {
+            self->map.runtime.base = base + sec[j].addr;
+            self->map.runtime.size = sec[j].size;
+            continue;
           }
         }
         cmd_cnt++;

--- a/src/mem.h
+++ b/src/mem.h
@@ -174,8 +174,12 @@ copy_memory(proc_ref_t proc_ref, void * addr, ssize_t len, void * buf) {
     // the PID that was used must have been valid. Therefore this call can only
     // fail if the process no longer exists. However, if the return value is
     // MACH_SEND_INVALID_DEST, we probably tried an invalid memory area.
-    if (kr != MACH_SEND_INVALID_DEST)
+    if (kr != MACH_SEND_INVALID_DEST) {
       set_error(EPROCNPID);
+    }
+    else {
+      set_error(EMEMCOPY);
+    }
     FAIL;
   }
 

--- a/src/mem.h
+++ b/src/mem.h
@@ -52,8 +52,6 @@
 #include "error.h"
 #include "logging.h"
 
-#define OUT_OF_BOUND                  -1
-
 
 /**
  * Copy a data structure from the given remote address structure.
@@ -174,11 +172,15 @@ copy_memory(proc_ref_t proc_ref, void * addr, ssize_t len, void * buf) {
     // the PID that was used must have been valid. Therefore this call can only
     // fail if the process no longer exists. However, if the return value is
     // MACH_SEND_INVALID_DEST, we probably tried an invalid memory area.
-    if (kr != MACH_SEND_INVALID_DEST) {
-      set_error(EPROCNPID);
-    }
-    else {
-      set_error(EMEMCOPY);
+    switch(kr) {
+      case KERN_PROTECTION_FAILURE:
+        set_error(EPROCPERM);
+        break;
+      case KERN_INVALID_ARGUMENT:
+        set_error(EPROCNPID);
+        break;
+      default:
+        set_error(EMEMCOPY);
     }
     FAIL;
   }

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -51,6 +51,7 @@ typedef struct {
   proc_vm_map_block_t exe;
   proc_vm_map_block_t dynsym;
   proc_vm_map_block_t rodata;
+  proc_vm_map_block_t runtime; // Added in Python 3.11
 } proc_vm_map_t;
 
 typedef struct _proc_extra_info proc_extra_info;  // Forward declaration.

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -48,8 +48,7 @@ typedef struct {
 
 typedef struct {
   proc_vm_map_block_t bss;
-  proc_vm_map_block_t heap;
-  proc_vm_map_block_t elf;
+  proc_vm_map_block_t exe;
   proc_vm_map_block_t dynsym;
   proc_vm_map_block_t rodata;
 } proc_vm_map_t;
@@ -67,8 +66,6 @@ typedef struct {
   proc_vm_map_t   map;
   void          * min_raddr;
   void          * max_raddr;
-
-  void          * bss;  // local copy of the remote bss section
 
   int             sym_loaded;
   python_v      * py_v;

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -178,6 +178,7 @@ _py_thread__resolve_py_stack(py_thread_t * self) {
         log_ie("Failed to get frame from code object");
         // Truncate the stack to the point where we have successfully resolved.
         _stack->pointer = i;
+        set_error(ETHREAD);
         FAIL;
       }
       lru_cache__store(cache, frame_key, frame);
@@ -196,8 +197,10 @@ _py_thread__resolve_py_stack(py_thread_t * self) {
 // ----------------------------------------------------------------------------
 static inline int
 _py_thread__push_frame_from_addr(py_thread_t * self, PyFrameObject * frame_obj, void ** prev) {
-  if (!isvalid(self))
+  if (!isvalid(self)) {
+    set_error(ETHREAD);
     FAIL;
+  }
   
   V_DESC(self->proc->py_v);
   
@@ -206,6 +209,7 @@ _py_thread__push_frame_from_addr(py_thread_t * self, PyFrameObject * frame_obj, 
   *prev = V_FIELD_PTR(void *, frame_obj, py_frame, o_back);
   if (unlikely(origin == *prev)) {
     log_d("Frame points to itself!");
+    set_error(ETHREAD);
     FAIL;
   }
 
@@ -308,6 +312,7 @@ _py_thread__push_iframe_from_addr(py_thread_t * self, PyInterpreterFrame * ifram
   *prev = V_FIELD_PTR(void *, iframe, py_iframe, o_previous);
   if (unlikely(origin == *prev)) {
     log_d("Interpreter frame points to itself!");
+    set_error(ETHREAD);
     FAIL;
   }
 
@@ -469,8 +474,10 @@ py_thread__set_idle(py_thread_t * self) {
   unsigned char bit   = 1 << (self->tid & 7);
   size_t        index = self->tid >> 3;
 
-  if (index > (max_pid >> 3))
+  if (index > (max_pid >> 3)) {
+    set_error(ETHREAD);
     FAIL;
+  }
 
   if (_py_thread__is_idle(self)) {
     _tids_idle[index] |= bit;
@@ -515,19 +522,24 @@ int
 py_thread__save_kernel_stack(py_thread_t * self) {
   char  stack_path[48];
 
-  if (!isvalid(_kstacks))
+  if (!isvalid(_kstacks)) {
+    set_error(ETHREAD);
     FAIL;
+  }
 
   sfree(_kstacks[self->tid]);
 
   sprintf(stack_path, "/proc/%d/task/" TID_FMT "/stack", self->proc->pid, self->tid);
   cu_fd fd = open(stack_path, O_RDONLY);
-  if (fd == -1)
+  if (fd == -1) {
+    set_error(ETHREAD);
     FAIL;
+  }
 
   _kstacks[self->tid] = (char *) calloc(1, MAX_STACK_FILE_SIZE);
   if (read(fd, _kstacks[self->tid], MAX_STACK_FILE_SIZE) == -1) {
     log_e("stack: failed to read %s", stack_path);
+    set_error(ETHREAD);
     FAIL;
   };
 
@@ -595,20 +607,25 @@ _py_thread__unwind_native_frame_stack(py_thread_t * self) {
     _tids[self->tid] = _UPT_create(self->tid);
     if (!isvalid(_tids[self->tid])) {
       log_e("libunwind: failed to re-create context for thread %d", self->tid);
+      set_error(ETHREAD);
       FAIL;
     }
     if (!isvalid(context)) {
       log_e("libunwind: unexpected invalid context");
+      set_error(ETHREAD);
       FAIL;
     }
   }
 
-  if (fail(wait_unw_init_remote(&cursor, self->proc->unwind.as, context)))
+  if (fail(wait_unw_init_remote(&cursor, self->proc->unwind.as, context))) {
+    set_error(ETHREAD);
     FAIL;
+  }
 
   do {
     if (unw_get_reg(&cursor, UNW_REG_IP, &pc)) {
       log_e("libunwind: cannot read program counter\n");
+      set_error(ETHREAD);
       FAIL;
     }
 
@@ -686,6 +703,7 @@ _py_thread__unwind_native_frame_stack(py_thread_t * self) {
         frame = frame_new(frame_key, filename, scope, offset, 0, 0, 0);
         if (!isvalid(frame)) {
           log_ie("Failed to make native frame");
+          set_error(ETHREAD);
           FAIL;
         }
       }
@@ -710,6 +728,7 @@ _py_thread__seize(py_thread_t * self) {
   if (!isvalid(_tids[self->tid])) {
     if (fail(wait_ptrace(PTRACE_SEIZE, self->tid, 0, 0))) {
       log_e("ptrace: cannot seize thread %d: %d\n", self->tid, errno);
+      set_error(ETHREAD);
       FAIL;
     }
     else {
@@ -718,6 +737,7 @@ _py_thread__seize(py_thread_t * self) {
     _tids[self->tid] = _UPT_create(self->tid);
     if (!isvalid(_tids[self->tid])) {
       log_e("libunwind: failed to create context for thread %d", self->tid);
+      set_error(ETHREAD);
       FAIL;
     }
   }
@@ -733,8 +753,10 @@ _py_thread__seize(py_thread_t * self) {
 // ----------------------------------------------------------------------------
 int
 py_thread__fill_from_raddr(py_thread_t * self, raddr_t * raddr, py_proc_t * proc) {
-  if (!isvalid(self))
+  if (!isvalid(self)) {
+    set_error(ETHREAD);
     FAIL;
+  }
 
   V_DESC(proc->py_v);
 
@@ -791,6 +813,7 @@ py_thread__fill_from_raddr(py_thread_t * self, raddr_t * raddr, py_proc_t * proc
     // If we fail to get a valid Thread ID, we resort to the PyThreadState
     // remote address
     log_e("Failed to retrieve OS thread information");
+    set_error(ETHREAD);
     FAIL;
   }
   #if defined PL_LINUX
@@ -833,8 +856,10 @@ py_thread__fill_from_raddr(py_thread_t * self, raddr_t * raddr, py_proc_t * proc
 // ----------------------------------------------------------------------------
 int
 py_thread__next(py_thread_t * self) {
-  if (self->invalid || !isvalid(self->next_raddr.addr))
+  if (self->invalid || !isvalid(self->next_raddr.addr)) {
+    set_error(ETHREAD);
     FAIL;
+  }
 
   return py_thread__fill_from_raddr(self, &(self->next_raddr), self->proc);
 }
@@ -1022,8 +1047,11 @@ py_thread_allocate(void) {
   if (isvalid(_stack))
     SUCCESS;
 
-  if (fail(stack_allocate(MAX_STACK_SIZE)))
+  if (fail(stack_allocate(MAX_STACK_SIZE))) {
+    log_e("Failed to allocate stack");
+    set_error(ETHREAD);
     FAIL;
+  }
 
   #if defined PL_WIN
   // On Windows we need to fetch process and thread information to detect idle
@@ -1031,8 +1059,10 @@ py_thread_allocate(void) {
   // needed we grow it at runtime.
   _pi_buffer_size = (1 << 16) * sizeof(void *);
   _pi_buffer      = calloc(1, _pi_buffer_size);
-  if (!isvalid(_pi_buffer))
+  if (!isvalid(_pi_buffer)) {
+    set_error(ETHREAD);
     FAIL;
+  }
   #endif
 
   max_pid = pid_max() + 1;
@@ -1064,10 +1094,12 @@ failed:
   sfree(_tids_idle);
   sfree(_tids_int);
   sfree(_kstacks);
+  
+  set_error(ETHREAD);
   FAIL;
 
 ok:
-  #endif
+  #endif /* NATIVE */
 
   SUCCESS;
 }

--- a/src/timer.h
+++ b/src/timer.h
@@ -41,6 +41,6 @@ yield() {
 }
 
 
-#define TIMER_START(d) {ctime_t _e=(gettime()+d);while(gettime()<=_e){
-#define TIMER_END      yield();}_s:}
+#define TIMER_START(d) {__label__ _s;ctime_t _e=(gettime()+d);while(gettime()<=_e){
+#define TIMER_END      yield();}_s:;}
 #define TIMER_STOP     goto _s;

--- a/src/timer.h
+++ b/src/timer.h
@@ -5,7 +5,7 @@
 //
 // Austin is a Python frame stack sampler for CPython.
 //
-// Copyright (c) 2022 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
 // All rights reserved.
 //
 // This program is free software: you can redistribute it and/or modify
@@ -20,52 +20,27 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef PY_SYMBOLS_H
-#define PY_SYMBOLS_H
+#pragma once
 
-#include "../platform.h"
-#include "../py_string.h"
+#include "stats.h"
 
-#define DYNSYM_MANDATORY 1
-
-enum {
-  // Mandatory symbols
-  DYNSYM_RUNTIME,
-  // Optional symbols
-  DYNSYM_HEX_VERSION,
-  // Count
-  DYNSYM_COUNT
-};
-
-
-#ifdef PY_PROC_C
-
-#ifdef PL_MACOS
-  #define SYM_PREFIX "_"
+#if defined PL_UNIX
+#include <sched.h>
 #else
-  #define SYM_PREFIX ""
+#include <windows.h>
 #endif
 
 
-static const char * _dynsym_array[] = {
-  SYM_PREFIX "_PyRuntime",
-  SYM_PREFIX "Py_Version",
-};
-
-static long _dynsym_hash_array[DYNSYM_COUNT] = {0};
-
-#define symcmp(name, i) ((string__hash(name) != _dynsym_hash_array[i] || strcmp(name, _dynsym_array[i])))
-
 static inline void
-_prehash_symbols(void) {
-  if (_dynsym_hash_array[0] == 0) {
-    for (register int i = 0; i < DYNSYM_COUNT; i++) {
-      _dynsym_hash_array[i] = string__hash((char *) _dynsym_array[i]);
-    }
-  }
+yield() {
+#if defined PL_UNIX
+    sched_yield();
+#else
+    Sleep(0);
+#endif
 }
 
-#endif  // PY_PROC_C
 
-
-#endif  // PY_SYMBOLS_H
+#define TIMER_START(d) {ctime_t _e=(gettime()+d);while(gettime()<=_e){
+#define TIMER_END      yield();}_s:}
+#define TIMER_STOP     goto _s;

--- a/src/timing.h
+++ b/src/timing.h
@@ -39,7 +39,6 @@ ctime_t _sample_timestamp;
 static inline void
 stopwatch_start(void) {
   _sample_timestamp = gettime();
-  austin_errno = EOK;
 } /* timer_start */
 
 

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -122,7 +122,12 @@ _py_proc__analyze_pe(py_proc_t * self, char * path, void * base) {
     }
   }
 
-  return !self->sym_loaded;
+  if (!self->sym_loaded) {
+    set_error(EPROC);
+    FAIL;
+  }
+
+  SUCCESS;
 }
 
 
@@ -348,8 +353,8 @@ _py_proc__get_modules(py_proc_t * self) {
   for (int i = 0; i < MAP_COUNT; i++) {
     map = &(pd->maps[i]);
     if (map->has_symbols) {
-      self->map.elf.base = map->base;
-      self->map.elf.size = map->size;
+      self->map.exe.base = map->base;
+      self->map.exe.size = map->size;
       break;
     }
   }
@@ -362,7 +367,12 @@ _py_proc__get_modules(py_proc_t * self) {
   log_d("BSS map %d from %s @ %p", map_index, pd->maps[map_index].path, self->map.bss.base);
   log_d("VM maps parsing result: bin=%s lib=%s symbols=%d", self->bin_path, self->lib_path, self->sym_loaded);
 
-  return !self->sym_loaded;
+  if (!self->sym_loaded) {
+    set_error(EPROC);
+    FAIL;
+  }
+
+  SUCCESS;
 }
 
 

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -98,7 +98,10 @@ _py_proc__analyze_pe(py_proc_t * self, char * path, void * base) {
     if (strcmp(".data", (const char *) s_hdr[i].Name) == 0) {
       self->map.bss.base = base + s_hdr[i].VirtualAddress;
       self->map.bss.size = s_hdr[i].Misc.VirtualSize;
-      break;
+    }
+    else if (strcmp("PyRuntime", (const char *) s_hdr[i].Name) == 0) {
+      self->map.runtime.base = base + s_hdr[i].VirtualAddress;
+      self->map.runtime.size = s_hdr[i].Misc.VirtualSize;
     }
   }
 

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -28,11 +28,6 @@ ROOT = TEST.parent
 SRC = ROOT / "src"
 
 
-# Remove any existing shared objects
-for so in SRC.glob("*.so"):
-    so.unlink(missing_ok=True)
-
-
 restrict_re = re.compile(r"__restrict \w+")
 
 _header_head = r"""

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -28,6 +28,11 @@ ROOT = TEST.parent
 SRC = ROOT / "src"
 
 
+# Remove any existing shared objects
+for so in SRC.glob("*.so"):
+    so.unlink(missing_ok=True)
+
+
 restrict_re = re.compile(r"__restrict \w+")
 
 _header_head = r"""

--- a/test/cunit/test_error.py
+++ b/test/cunit/test_error.py
@@ -30,7 +30,7 @@ def test_error_unknown():
         (0, False),
         (1, True),
         (8, False),
-        (32, True),
+        (32, False),
         (1000, False),
     ],
 )

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,5 @@
 austin-python~=1.5
+flaky
 pytest
 pytest-xdist
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,4 @@
 austin-python~=1.5
-flaky
 pytest
 pytest-xdist
 

--- a/test/targets/target34.py
+++ b/test/targets/target34.py
@@ -27,7 +27,7 @@ import threading
 
 def keep_cpu_busy():
     a = []
-    for i in range(6000000):
+    for i in range(10_000_000):
         a.append(i)
         if i % 1000000 == 0:
             print("Unwanted output " + str(i))

--- a/test/test_accuracy.py
+++ b/test/test_accuracy.py
@@ -29,10 +29,8 @@ from test.utils import samples
 from test.utils import target
 
 import pytest
-from flaky import flaky
 
 
-@flaky
 @pytest.mark.parametrize("heap", [tuple(), ("-h", "0"), ("-h", "64")])
 @allpythons()
 def test_accuracy_fast_recursive(py, heap):

--- a/test/test_attach.py
+++ b/test/test_attach.py
@@ -24,7 +24,7 @@ import os
 import platform
 from collections import Counter
 from shutil import rmtree
-from test.utils import allpythons as _allpythons
+from test.utils import allpythons
 from test.utils import austin
 from test.utils import austinp
 from test.utils import compress
@@ -40,20 +40,8 @@ from test.utils import variants
 from time import sleep
 
 import pytest
-from flaky import flaky
 
 
-def allpythons():
-    # Attach tests fail on Windows for Python < 3.7 and on MacOS for Python < 3
-    match platform.system():
-        case "Windows":
-            return _allpythons(min=(3, 7))
-        case "Darwin":
-            return _allpythons(min=(3,))
-    return _allpythons()
-
-
-@flaky(max_runs=6)
 @requires_sudo
 @pytest.mark.parametrize("heap", [tuple(), ("-h", "0"), ("-h", "64")])
 @pytest.mark.parametrize(
@@ -85,7 +73,6 @@ def test_attach_wall_time(austin, py, mode, mode_meta, heap):
         assert a <= d
 
 
-@flaky
 @requires_sudo
 @pytest.mark.parametrize("exposure", [1, 2])
 @allpythons()
@@ -121,7 +108,6 @@ def test_where(py, mojo):
         assert "<module>" in result.stdout
 
 
-@flaky
 @requires_sudo
 @pytest.mark.xfail(platform.system() == "Windows", reason="Does not pass in Windows CI")
 @allpythons()
@@ -165,7 +151,7 @@ def test_where_kernel(py):
 @pytest.mark.parametrize("prefix", [[], ["unshare", "-p", "-f", "-r"]])
 @pytest.mark.skipif(platform.system() != "Linux", reason="Linux only")
 @requires_sudo
-@_allpythons(min=(3,))
+@allpythons()
 def test_attach_container_like(py, tmp_path, prefix):
     """Test in container-like conditions.
 
@@ -203,4 +189,4 @@ def test_attach_container_like(py, tmp_path, prefix):
         a = sum_metric(result.stdout)
         d = int(meta["duration"])
 
-        assert a <= d
+        assert abs(a - d) <= (a + d) * 0.1

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -21,12 +21,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import platform
+import sys
+
+import pytest
+
 from test.utils import austin
 from test.utils import no_sudo
 from test.utils import run_python
 from test.utils import target
-
-import pytest
 
 
 def test_cli_no_arguments():
@@ -39,9 +41,10 @@ def test_cli_no_arguments():
 def test_cli_no_python():
     result = austin(
         "-C",
-        "powershell" if platform.system() == "Windows" else "bash",
+        "src\\austin.exe" if platform.system() == "Windows" else "src/austin",
+        sys.executable,
         "-c",
-        "sleep 1",
+        "from time import sleep;sleep(2)",
     )
     assert result.returncode == 39
     assert "not a Python" in result.stderr or "Cannot launch" in result.stderr

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -40,14 +40,24 @@ def test_cli_no_arguments():
 
 def test_cli_no_python():
     result = austin(
-        "-C",
-        "src\\austin.exe" if platform.system() == "Windows" else "src/austin",
+        "cmd.exe" if platform.system() == "Windows" else "src/austin",
         sys.executable,
         "-c",
         "from time import sleep;sleep(2)",
     )
-    assert result.returncode == 39
+    assert result.returncode == 32
     assert "not a Python" in result.stderr or "Cannot launch" in result.stderr
+
+
+def test_cli_short_lived():
+    result = austin(
+        "src\\austin.exe" if platform.system() == "Windows" else "src/austin",
+        sys.executable,
+        "-c",
+        "print('Hello World')",
+    )
+    assert result.returncode == 33
+    assert "too quickly" in result.stderr
 
 
 def test_cli_invalid_command():

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -22,13 +22,12 @@
 
 import platform
 import sys
-
-import pytest
-
 from test.utils import austin
 from test.utils import no_sudo
 from test.utils import run_python
 from test.utils import target
+
+import pytest
 
 
 def test_cli_no_arguments():
@@ -44,6 +43,7 @@ def test_cli_no_python():
         sys.executable,
         "-c",
         "from time import sleep;sleep(2)",
+        expect_fail=True,
     )
     assert result.returncode == 32
     assert "not a Python" in result.stderr or "Cannot launch" in result.stderr
@@ -55,20 +55,21 @@ def test_cli_short_lived():
         sys.executable,
         "-c",
         "print('Hello World')",
+        expect_fail=True,
     )
     assert result.returncode == 33
     assert "too quickly" in result.stderr
 
 
 def test_cli_invalid_command():
-    result = austin("snafubar")
+    result = austin("snafubar", expect_fail=True)
     assert "[GCC" in result.stderr
     assert result.returncode == 33
     assert "Cannot launch" in (result.stderr or result.stdout)
 
 
 def test_cli_invalid_pid():
-    result = austin("-p", "9999999")
+    result = austin("-p", "9999999", expect_fail=True)
 
     assert result.returncode == 36
     assert "Cannot attach" in result.stderr
@@ -80,7 +81,7 @@ def test_cli_invalid_pid():
 @no_sudo
 def test_cli_permissions():
     with run_python("3", target("sleepy.py")) as p:
-        result = austin("-i", "1ms", "-p", str(p.pid))
+        result = austin("-i", "1ms", "-p", str(p.pid), expect_fail=True)
         assert result.returncode == 37, result.stderr
         assert "Insufficient permissions" in result.stderr, result.stderr
 
@@ -91,6 +92,13 @@ def test_cli_permissions():
 )
 @no_sudo
 def test_cli_permissions_darwin():
-    result = austin("-i", "1ms", "python3.10", "-c", "from time import sleep; sleep(1)")
+    result = austin(
+        "-i",
+        "1ms",
+        "python3.10",
+        "-c",
+        "from time import sleep; sleep(1)",
+        expect_fail=True,
+    )
     assert result.returncode == 37, result.stderr
     assert "Insufficient permissions" in result.stderr, result.stderr

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -40,10 +40,8 @@ from test.utils import threads
 from test.utils import variants
 
 import pytest
-from flaky import flaky
 
 
-@flaky(max_runs=10)
 @pytest.mark.parametrize("heap", [tuple(), ("-h", "0"), ("-h", "64")])
 @allpythons()
 @variants
@@ -76,7 +74,6 @@ def test_fork_wall_time(austin, py, heap, mojo):
         assert [_ for _ in ms if "python" in _], ms
 
 
-@flaky
 @pytest.mark.parametrize("heap", [tuple(), ("-h", "0"), ("-h", "64")])
 @allpythons()
 @variants
@@ -100,7 +97,6 @@ def test_fork_cpu_time_cpu_bound(py, heap, austin, mojo):
     assert 0 < a < 2.1 * d
 
 
-@flaky(max_runs=6)
 @allpythons()
 @variants
 def test_fork_cpu_time_idle(py, austin):
@@ -117,7 +113,6 @@ def test_fork_cpu_time_idle(py, austin):
     assert a < 1.1 * d
 
 
-@flaky
 @allpythons()
 @mojo
 def test_fork_memory(py, mojo):
@@ -168,9 +163,8 @@ def test_fork_output(py, tmp_path: Path, mojo):
 
 # Support for multiprocess is attach-like and seems to suffer from the same
 # issues as attach tests on Windows.
-@flaky
 @pytest.mark.xfail(platform.system() == "Windows", reason="Does not pass in Windows CI")
-@allpythons(min=(3, 7) if platform.system() == "Windows" else None)
+@allpythons()
 @mojo
 def test_fork_multiprocess(py, mojo):
     result = austin("-Ci", "1ms", *python(py), target("target_mp.py"), mojo=mojo)
@@ -187,7 +181,6 @@ def test_fork_multiprocess(py, mojo):
     assert has_pattern(result.stdout, "target_mp.py:fact:31 "), compress(result.stdout)
 
 
-@flaky
 @allpythons()
 @mojo
 def test_fork_full_metrics(py, mojo):
@@ -213,7 +206,6 @@ def test_fork_full_metrics(py, mojo):
     assert alloc * dealloc
 
 
-@flaky
 @pytest.mark.parametrize("exposure", [1, 2])
 @allpythons()
 def test_fork_exposure(py, exposure):

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -20,7 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import platform
 from test.utils import allpythons
 from test.utils import austin
 from test.utils import has_pattern
@@ -30,13 +29,9 @@ from test.utils import python
 from test.utils import samples
 from test.utils import target
 
-from flaky import flaky
-import pytest
 
-
-@allpythons(min=(3, 7))
+@allpythons()
 @mojo
-@flaky
 def test_gc_off(py, mojo):
     result = austin("-i", "1ms", *python(py), target("target_gc.py"), mojo=mojo)
     assert result.returncode == 0
@@ -44,13 +39,8 @@ def test_gc_off(py, mojo):
     assert not has_pattern(":GC:", result.stdout)
 
 
-@pytest.mark.xfail(
-    platform.system() != "Linux",
-    reason="GC sampling seems to work reliably only on Linux",
-)
-@allpythons(min=(3, 7))
+@allpythons()
 @mojo
-@flaky
 def test_gc_on(py, mojo):
     result = austin("-gi", "1ms", *python(py), target("target_gc.py"), mojo=mojo)
     assert result.returncode == 0
@@ -62,9 +52,8 @@ def test_gc_on(py, mojo):
     assert len(gcs) > 10
 
 
-@allpythons(min=(3, 7))
+@allpythons()
 @mojo
-@flaky
 def test_gc_disabled(py, monkeypatch, mojo):
     monkeypatch.setenv("GC_DISABLED", "1")
 

--- a/test/test_mojo.py
+++ b/test/test_mojo.py
@@ -27,10 +27,8 @@ from test.utils import python
 from test.utils import target
 
 from austin.format.mojo import MojoFile, MojoFrame
-from flaky import flaky
 
 
-@flaky
 @allpythons(min=(3, 11))
 def test_mojo_column_data(py, tmp_path: Path):
     datafile = tmp_path / "test_mojo_column.austin"

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -35,10 +35,7 @@ from test.utils import sum_metric
 from test.utils import target
 from test.utils import threads
 
-from flaky import flaky
 
-
-@flaky
 @allpythons()
 def test_pipe_wall_time(py):
     interval = 1
@@ -78,7 +75,6 @@ def test_pipe_cpu_time(py):
     assert meta["interval"] == "1000", meta
 
 
-@flaky(max_runs=3)
 @allpythons()
 def test_pipe_wall_time_multiprocess(py):
     result = austin("-CPi", "1ms", *python(py), target())
@@ -93,7 +89,6 @@ def test_pipe_wall_time_multiprocess(py):
     assert ".".join((str(_) for _ in meta["python"])).startswith(py), meta
 
 
-@flaky
 @allpythons()
 def test_pipe_wall_time_multiprocess_output(py, tmp_path):
     datafile = tmp_path / "test_pipe.austin"

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -44,8 +44,6 @@ def valgrind(python_args: list[str], mode: str):
                 str(austin.path),
                 f"-{mode}i",
                 "1ms",
-                "-t",
-                "1s",
                 "-o",
                 "/dev/null",
                 *python_args,

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -67,7 +67,7 @@ def test_valgrind_fork(py, mode):
 @pytest.mark.parametrize("mode", ["", "s", "C", "Cs"])
 @allpythons()
 def test_valgrind_attach(py, mode):
-    with run_python(py, target("sleepy.py")) as p:
+    with run_python(py, target("sleepy.py"), "2") as p:
         result = valgrind(["-p", str(p.pid)], mode)
         assert result.returncode == 0, "\n".join((result.stdout, result.stderr))
         p.kill()


### PR DESCRIPTION

### Description of the Change

After dropping support for CPython < 3.8, we make further simplifications to the coding, and also improve the logic in some places, specifically the process initialisation. More in detail:

1. drop the tracking of symbols that are no longer exported by the CPython binaries in later versions
2. rationalise the error propagation for a more robust error handling and propagation logic.
3. improve the initialisation process by including the interpreter resolution step as part of the start-up loop
4. handle the `PyRuntime` section introduced in recent CPython versions.

Improvement 3 translates into a much less flaky CI, to the point where we are able to essentially remove the `@flaky` decorator from almost all tests. We still observe some residual flakiness, but we will address that in follow-up changes. We expect that improvement 4 will help Austin handle stripped binaries.

### Alternate Designs

Not considered

### Regressions

This is a considerable refactor that still makes the existing CI scenarios pass, so no regressions are expected. However, the change in this PR is substantial enough to raise the risk level.

### Verification Process

Existing test suite.