### PR TITLE
tests: run uwsgi tests in virtual environment

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,4 +9,3 @@ pycparser
 # Support tests
 psutil
 requests
-uwsgi; sys_platform != 'win32'

--- a/test/support/requirements-uwsgi.txt
+++ b/test/support/requirements-uwsgi.txt
@@ -1,0 +1,1 @@
+uwsgi; sys_platform != 'win32'

--- a/test/support/test_uwsgi.py
+++ b/test/support/test_uwsgi.py
@@ -1,12 +1,17 @@
+import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
 from subprocess import PIPE
 from subprocess import Popen
+from subprocess import check_output
+from tempfile import TemporaryDirectory
+from test.utils import allpythons
 from test.utils import austin
 from test.utils import compress
 from test.utils import has_pattern
 from test.utils import requires_sudo
+from test.utils import run_python
 from test.utils import threads
 from threading import Thread
 from time import sleep
@@ -24,7 +29,7 @@ UWSGI = Path(__file__).parent / "uwsgi"
 
 
 @contextmanager
-def uwsgi(app="app.py", port=9090, args=[]):
+def uwsgi(app="app.py", port=9090, args=[], env=None):
     with Popen(
         [
             "uwsgi",
@@ -36,6 +41,7 @@ def uwsgi(app="app.py", port=9090, args=[]):
         ],
         stdout=PIPE,
         stderr=PIPE,
+        env=env or os.environ,
     ) as uw:
         sleep(0.5)
 
@@ -55,35 +61,60 @@ def uwsgi(app="app.py", port=9090, args=[]):
                     proc.wait()
 
 
+@contextmanager
+def venv(py, reqs):
+    with TemporaryDirectory() as tmp_path:
+        venv_path = Path(tmp_path) / ".venv"
+        p = run_python(py, "-m", "venv", str(venv_path))
+        p.wait(120)
+        assert 0 == p.returncode, "Virtual environment was created successfully"
+
+        env = os.environ.copy()
+        env["LD_LIBRARY_PATH"] = str(venv_path / "lib")
+        env["PATH"] = str(venv_path / "bin") + os.pathsep + env["PATH"]
+
+        check_output(
+            ["python", "-m", "pip", "install", "-r", reqs, "--use-pep517"], env=env
+        )
+
+        yield env
+
+
 @requires_sudo
-def test_uwsgi():
+@allpythons()
+def test_uwsgi(py):
     request_thread = Thread(target=get, args=("http://localhost:9090",))
 
-    with uwsgi() as uw:
-        request_thread.start()
+    with venv(py, reqs=Path(__file__).parent / "requirements-uwsgi.txt") as env:
+        with uwsgi(env=env) as uw:
+            request_thread.start()
 
-        result = austin("-x", "2", "-Cp", str(uw.pid))
-        assert has_pattern(result.stdout, "app.py:application:5"), compress(
-            result.stdout
-        )
+            result = austin("-x", "2", "-Cp", str(uw.pid))
+            assert has_pattern(result.stdout, "app.py:application:5"), compress(
+                result.stdout
+            )
 
-    request_thread.join()
+        request_thread.join()
 
 
 @requires_sudo
-def test_uwsgi_multiprocess():
+@allpythons()
+def test_uwsgi_multiprocess(py):
     request_thread = Thread(target=get, args=("http://localhost:9091",))
 
-    with uwsgi(port=9091, args=["--processes", "2", "--threads", "2"]) as uw:
-        request_thread.start()
+    with venv(py, reqs=Path(__file__).parent / "requirements-uwsgi.txt") as env:
+        with uwsgi(
+            port=9091, args=["--processes", "2", "--threads", "2"], env=env
+        ) as uw:
+            request_thread.start()
 
-        result = austin("-x", "2", "-Cp", str(uw.pid))
-        assert has_pattern(result.stdout, "app.py:application:5"), compress(
-            result.stdout
-        )
+            result = austin("-x", "2", "-Cp", str(uw.pid))
+            assert has_pattern(result.stdout, "app.py:application:5"), compress(
+                result.stdout
+            )
 
-        ts = threads(result.stdout)
-        assert len(ts) >= 4, ts
-        assert len({p for p, _ in ts}) >= 2, ts
+            ts = threads(result.stdout)
+            assert len(ts) >= 4, ts
+            assert len({p for p, _ in ts}) >= 2, ts
 
-    request_thread.join()
+        request_thread.join()


### PR DESCRIPTION
### Description of the Change

We run the uwsgi tests in separated virtual environment to ensure that we install it using the interpreter that Austin is being tested against. Currently, we install the dependency in the environment used to run pytest, which means that we test uwsgi with the same Python version in every job.

### Regressions

We make the uwsgi tests run as expected, so there is always the chance of new CI findings.