### PR TITLE
ci: run certain workflows when necessary

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,11 @@ name: Benchmarks
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/benchmarks.yml
+      - scripts/benchmark.py
+      - scripts/requirements-bm.txt
+      - src/**
 
 jobs:
   benchmarks:

--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -6,6 +6,14 @@ on:
       - master
       - devel
   pull_request:
+    paths:
+      - .github/workflows/build_arch.yml
+      - scripts/build_arch.sh
+      - scripts/build-wheel.py
+      - scripts/requirements-bw.txt
+      - src/**
+      - configure.ac
+      - Makefile.am
 
 jobs:
   build-linux-archs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,16 @@ on:
       - master
       - devel
   pull_request:
+    paths:
+      - .github/workflows/tests.yml
+      - scripts/build-wheel.py
+      - scripts/requirements-bw.txt
+      - scripts/requirements-val.txt
+      - scripts/validation.py
+      - src/**
+      - test/**
+      - configure.ac
+      - Makefile.am
 
 concurrency: 
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
We add path filtering to some GitHub workflows so that they are triggered when necessary.