### PR TITLE
ci: bump GitHub action versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ jobs:
   benchmarks:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
     name: Build on ${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout sources
 
       - uses: uraimo/run-on-arch-action@v2.0.5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Check manpage
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |
@@ -38,7 +38,7 @@ jobs:
       cppcheck-version: 2.10.3
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-cppcheck-${{ env.cppcheck-version }}
 
       - name: Check out cppcheck
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: danmar/cppcheck
           ref: ${{ env.cppcheck-version }}
@@ -83,7 +83,7 @@ jobs:
     name: Static code analysis (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Install cppcheck
         run: brew install cppcheck
@@ -95,9 +95,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: Codespell
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "3.9"
 
@@ -111,9 +111,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: Formatting (tests)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "3.10"
 
@@ -127,9 +127,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: Linting (tests)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "3.10"
 
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Code coverage
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Check cog output
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install cog
         run: pip install cogapp

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Push to Docker Hub
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     name: Release (Linux)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Austin
 
       - name: Generate artifacts
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
     name: Release (Windows)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Austin
         with:
           fetch-depth: 0
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
     name: Release (macOS)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Austin
 
       - name: Generate artifacts

--- a/.github/workflows/pre_release_arch.yml
+++ b/.github/workflows/pre_release_arch.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     name: Build on ${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout sources
       - uses: uraimo/run-on-arch-action@v2.0.5
         name: Generate artifacts on ${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     name: Release (Linux)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Austin
 
       - name: Install Python 3.10
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
     name: Release (Windows)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Austin
         with:
           fetch-depth: 0
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
     name: Release (macOS)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Austin
 
       - name: Install Python 3.10

--- a/.github/workflows/release_arch.yml
+++ b/.github/workflows/release_arch.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     name: Build on ${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout sources
       
       - uses: uraimo/run-on-arch-action@v2.0.5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04    
     name: Build Austin on Linux
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-20.04    
     name: Build Austin on Linux (musl)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |
@@ -72,7 +72,7 @@ jobs:
     
     name: Tests on Linux with Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -127,7 +127,7 @@ jobs:
 
     name: Build Linux wheels
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -167,7 +167,7 @@ jobs:
 
     name: Build Austin on macOS (gcc)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Compile Austin
         run: gcc-11 -Wall -Werror -O3 -g src/*.c -o src/austin
@@ -183,7 +183,7 @@ jobs:
 
     name: Build Austin on macOS (clang)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Install automake
         run: brew install automake
@@ -208,7 +208,7 @@ jobs:
 
     name: Tests on macOS with Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -253,7 +253,7 @@ jobs:
 
     name: Build macOS wheels
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -288,7 +288,7 @@ jobs:
 
     name: Build Austin on Windows
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Compile Austin
         run: |
@@ -317,7 +317,7 @@ jobs:
     
     name: Tests on Windows with Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -329,7 +329,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}-dev
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python 3.10
         with:
           python-version: '3.10'
@@ -355,14 +355,14 @@ jobs:
 
     name: Build Windows wheels
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
           name: austin-binary
           path: src
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python 3.10
         with:
           python-version: '3.10'
@@ -395,7 +395,7 @@ jobs:
 
     name: Data validation with Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
We bump the checkout action version from 2 to 3, and setup-python from 2 to 4 (the latest at the time this change is being made) to resolve the node12 deprecation warnings.