### PR TITLE
chore(win): enrich logs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -360,7 +360,7 @@ jobs:
       - name: Compile Austin
         run: |
           gcc.exe --version
-          gcc.exe -O3 -g -o src/austin.exe src/*.c -lpsapi -lntdll -Wall -Werror
+          gcc.exe -O3 -g -o src/austin.exe src/*.c -lpsapi -lntdll -Wall -Werror -DDEBUG
           src\austin.exe --help
 
       - uses: actions/upload-artifact@v3
@@ -411,7 +411,7 @@ jobs:
       - name: Run functional tests
         run: |
           venv\Scripts\Activate.ps1
-          python -m pytest --full-trace --pastebin=failed -svr a test\functional -k "not austinp" -n auto
+          python -m pytest --full-trace --pastebin=failed -svr a test\functional -k "not austinp"
         if: always()
 
       - name: Run integrity tests

--- a/src/logging.c
+++ b/src/logging.c
@@ -35,7 +35,7 @@
 
 #else
 #include <windows.h>
-#include <stdio.h>
+#include <time.h>
 
 #define LOG_EMERG   0  /* system is unusable */
 #define LOG_ALERT   1  /* action must be taken immediately */
@@ -61,14 +61,31 @@ _log_writer(int prio, const char * fmt, va_list ap) {
   vsyslog(prio, fmt, ap);
 
   #else
-  if (logfile == NULL) {
-    vfprintf(stderr, fmt, ap); fputc('\n', stderr);
-    fflush(stderr);
-  }
-  else {
-    vfprintf(logfile, fmt, ap); fputc('\n', logfile);
-    fflush(logfile);
-  }
+  time_t timer;
+  char buffer[32];
+  struct tm* tm_info;
+
+  timer = time(NULL);
+  tm_info = localtime(&timer);
+
+  strftime(buffer, 26, "%Y-%m-%d %H:%M:%S", tm_info);
+
+  FILE * stream = isvalid(logfile) ? logfile : stderr;
+
+  // Timestamp
+  fputs(buffer, stream);
+
+  // Process info
+  fprintf(stream, " " PROGRAM_NAME "[%ld]: ", GetCurrentProcessId());
+
+  // Log message
+  vfprintf(stream, fmt, ap);
+  
+  // Newline
+  fputc('\n', stream);
+
+  // Flush
+  fflush(stream);
 
   #endif
 }

--- a/test/utils.py
+++ b/test/utils.py
@@ -36,6 +36,7 @@ from subprocess import CompletedProcess
 from subprocess import Popen
 from subprocess import TimeoutExpired
 from subprocess import check_output
+from tempfile import gettempdir
 from test import PYTHON_VERSIONS
 from time import sleep
 from types import ModuleType
@@ -149,6 +150,20 @@ def collect_logs(variant: str, pid: int) -> List[str]:
                     ),
                     f" end of logs for {variant}[{pid}] ".center(80, "="),
                 ]
+
+        case "Windows":
+            with (Path(gettempdir()) / "austin.log").open() as logfile:
+                needles = (f"{variant}[{pid}]",)
+                return [
+                    f" logs for {variant}[{pid}] ".center(80, "="),
+                    *(
+                        line.strip()
+                        for line in logfile.readlines()
+                        if any(needle in line for needle in needles)
+                    ),
+                    f" end of logs for {variant}[{pid}] ".center(80, "="),
+                ]
+
         case _:
             return []
 


### PR DESCRIPTION
### Description of the Change

We add more details to the logs generated by Austin on Windows to include a timestamp and process information. This allows us to collect the data in tests for helping with investigations.

In order to easily get access to the data in CI we have to compromise with giving up on parallelising tests to allow each one of them to report any logs on failure.