### PR TITLE
chore: remove VM bounds tracking logic

### DIFF
--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -372,9 +372,6 @@ _py_proc__parse_maps_file(py_proc_t * self) {
   crc32_t file_hash = fhash(fp);
   long modified_time = fmtime_ns(fp);
 
-  self->min_raddr = (void *) -1;
-  self->max_raddr = NULL;
-
   sfree(self->bin_path);
   sfree(self->lib_path);
 
@@ -432,13 +429,6 @@ _py_proc__parse_maps_file(py_proc_t * self) {
       self->map.runtime.base = (void *) lower - page_size;
       self->map.runtime.size = upper - lower + page_size;
       log_d("PyRuntime section inferred from VM maps for %s: %lx-%lx", map->path, lower, upper);
-    }
-
-    if (field_count == 0 || strstr(pathname, "[v") == NULL) {
-      // Skip meaningless addresses like [vsyscall] which would give
-      // ridiculous values.
-      if ((void *) lower < self->min_raddr) self->min_raddr = (void *) lower;
-      if ((void *) upper > self->max_raddr) self->max_raddr = (void *) upper;
     }
 
     if (pathname[0] == '[')

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -481,9 +481,6 @@ _py_proc__get_maps(py_proc_t * self) {
     FAIL;
   }
 
-  self->min_raddr = (void *) -1;
-  self->max_raddr = NULL;
-
   sfree(self->bin_path);
   sfree(self->lib_path);
 
@@ -521,12 +518,6 @@ _py_proc__get_maps(py_proc_t * self) {
     &count,
     &object_name
   ) == KERN_SUCCESS) {
-    if ((void *) address < self->min_raddr)
-      self->min_raddr = (void *) address;
-
-    if ((void *) address + size > self->max_raddr)
-      self->max_raddr = (void *) address + size;
-
     int path_len = proc_regionfilename(self->pid, address, path, MAXPATHLEN);
 
     if (isvalid(prev_path) && strcmp(path, prev_path) == 0) { // Avoid analysing a binary multiple times

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -676,9 +676,6 @@ _py_proc__run(py_proc_t * self) {
   if (!(isvalid(self->bin_path) || isvalid(self->lib_path)))
     log_w("No Python binary files detected");
 
-  if (self->min_raddr > self->max_raddr)
-    log_w("Invalid remote VM maximal bounds.");
-
   if (
     self->symbols[DYNSYM_RUNTIME] == NULL &&
     self->gc_state_raddr          == NULL
@@ -688,7 +685,6 @@ _py_proc__run(py_proc_t * self) {
   #ifdef DEBUG
   if (self->bin_path != NULL) log_d("Python binary:  %s", self->bin_path);
   if (self->lib_path != NULL) log_d("Python library: %s", self->lib_path);
-  log_d("Maximal VM address space: %p-%p", self->min_raddr, self->max_raddr);
   #endif
 
   self->timestamp = gettime();
@@ -713,7 +709,6 @@ py_proc_new(int child) {
     return NULL;
 
   py_proc->child = child;
-  py_proc->min_raddr = (void *) -1;
   py_proc->gc_state_raddr = NULL;
 
   _prehash_symbols();

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -65,8 +65,6 @@ typedef struct {
   char          * lib_path;
 
   proc_vm_map_t   map;
-  void          * min_raddr;
-  void          * max_raddr;
 
   int             sym_loaded;
   python_v      * py_v;

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -219,9 +219,6 @@ _py_proc__get_modules(py_proc_t * self) {
   MODULEENTRY32 module;
   module.dwSize = sizeof(module);
 
-  self->min_raddr = (void *) -1;
-  self->max_raddr = NULL;
-
   sfree(self->bin_path);
   sfree(self->lib_path);
 
@@ -249,12 +246,6 @@ _py_proc__get_modules(py_proc_t * self) {
     FAIL;
   }
   do {
-    if ((void *) module.modBaseAddr < self->min_raddr)
-      self->min_raddr = module.modBaseAddr;
-
-    if ((void *) module.modBaseAddr + module.modBaseSize > self->max_raddr)
-      self->max_raddr = module.modBaseAddr + module.modBaseSize;
-
     if (isvalid(prev_path) && strcmp(module.szExePath, prev_path) == 0) { // Avoid analysing a binary multiple times
       continue;
     }


### PR DESCRIPTION
### Description of the Change

With the removal of the heap scanning logic, we no longer need to keep track of VM bounds so we remove the relevant code.
