### PR TITLE
fix: propagate signals to spawned process

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,9 @@
   Bugfix: ensure that threads are resumed by austinp when an error occurs during
   the sampling process.
 
+  Bugfix: propagate the termination signal to the child process when launching a
+  command with Austin to prevent it from running indefinitely in the background.
+
 
 2023-02-21 v3.5.0
 

--- a/src/austin.c
+++ b/src/austin.c
@@ -117,8 +117,11 @@ do_single_process(py_proc_t * py_proc) {
       // Propagate the signal to the parent if we spawned it.
       py_proc__signal(py_proc, interrupt < 0 ? -interrupt : SIGTERM);
 
+
+    #if defined PL_UNIX
     // If we spawned the process, we need to wait for it to terminate.
     py_proc__wait(py_proc);
+    #endif
   }
 
   py_proc__destroy(py_proc);
@@ -220,7 +223,9 @@ do_child_processes(py_proc_t * py_proc) {
 
     // If we spawned the child processes, we need to wait for them to terminate.
     py_proc_list__update(list);
+    #if defined PL_UNIX
     py_proc_list__wait(list);
+    #endif
   }
 } /* do_child_processes */
 

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -218,6 +218,16 @@ py_proc__log_version(py_proc_t *, int);
 
 
 /**
+ * Send a signal to the process.
+ *
+ * @param py_proc_t * the process object.
+ * @param int         the signal to send to the process.
+ */
+void
+py_proc__signal(py_proc_t *, int);
+
+
+/**
  * Terminate the process.
  *
  * @param py_proc_t * the process object.


### PR DESCRIPTION
### Description of the Change

When Austin is given a command to launch, we make sure that any termination signal that Austin receives is propagated to the spawned process to prevent it from running potentially indefinitely in the background.

### Regressions

We don't expect any tools based on Austin to rely on the previous behaviour, so we do not expect any regressions.

### Verification Process

This bug was caught with the austin-python test suite.