### PR TITLE
ci(benchmarks): run only the last release

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,15 +36,15 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r scripts/requirements-bm.txt
-          deactivate
 
       - name: Run benchmarks
+        env:
+          PYTHONPATH: "."
         run: |
           ulimit -c unlimited
-
+          echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
           source .venv/bin/activate
-          python scripts/benchmark.py --format markdown | tee comment.txt
-          deactivate
+          python scripts/benchmark.py --format markdown --last | tee comment.txt
 
       - name: Post results on PR
         uses: marocchino/sticky-pull-request-comment@v2

--- a/scripts/requirements-bm.txt
+++ b/scripts/requirements-bm.txt
@@ -1,2 +1,2 @@
 austin-python~=1.6
-scipy~=1.10.1
+scipy~=1.10


### PR DESCRIPTION
We speed up the benchmarks CI run by only running the latest release and dev. Any issues caught in this way can be analysed locally if needed.