### PR TITLE
fix: line end information for CPython < 3.11

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-xx-xx v3.6.1
+
+  Bugfix: fixed a bug with the MOJO binary format that caused the line end
+  position to wrongly be set to a non-zero value for CPython < 3.11, where line
+  end information is not actually available.
+
+
 2023-10-04 v3.6.0
 
   Added support for CPython 3.12

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.69])
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"AC_INIT([austin], [{version()}], [https://github.com/p403n1x87/austin/issues])")
 # ]]]
-AC_INIT([austin], [3.6.0], [https://github.com/p403n1x87/austin/issues])
+AC_INIT([austin], [3.6.1], [https://github.com/p403n1x87/austin/issues])
 # [[[end]]]
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ base: core20
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"version: '{version()}+git'")
 # ]]]
-version: '3.6.0+git'
+version: '3.6.1+git'
 # [[[end]]]
 summary: A Python frame stack sampler for CPython
 description: |

--- a/src/austin.h
+++ b/src/austin.h
@@ -34,7 +34,7 @@
 from scripts.utils import get_current_version_from_changelog as version
 print(f'#define VERSION                         "{version()}"')
 ]]] */
-#define VERSION                         "3.6.0"
+#define VERSION                         "3.6.1"
 // [[[end]]]
 
 #endif

--- a/src/frame.h
+++ b/src/frame.h
@@ -168,7 +168,7 @@ _frame_from_code_raddr(py_proc_t * py_proc, void * code_raddr, int lasti, python
   ssize_t len = 0;
 
   unsigned int lineno     = V_FIELD(unsigned int, code, py_code, o_firstlineno);
-  unsigned int line_end   = lineno;
+  unsigned int line_end   = 0;
   unsigned int column     = 0;
   unsigned int column_end = 0;
 


### PR DESCRIPTION
### Description of the Change

We fix the value of the line end exported in binary MOJO files for samples extracted from CPython < 3.11 and make sure that it is set to 0 to indicate that the information is not available.

### Regressions

Because no issues have been reported that relate to this fix, we assume that nobody was relying on the previous behaviour.

### Verification Process

Added a test case to validate that no incorrect location information is emitted from CPython versions prior to 3.11.