### PR TITLE
feat: add support for CPython 3.13

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -156,7 +156,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install \
             valgrind \
-            python3.{8..12} \
+            python3.{8..13} \
             python3.10-full python3.10-dev
 
           python3.10 -m venv .venv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -132,7 +132,7 @@ jobs:
       - name: Run functional Austin tests (with sudo)
         run: |
           ulimit -c unlimited
-          echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
+          sudo echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
           sudo -E env PATH="$PATH" .venv/bin/pytest --pastebin=failed -svr a test/functional -k "not austinp"
         if: always()
 
@@ -259,7 +259,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -385,7 +385,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -474,7 +474,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
-2024-xx-xx v3.6.1
+2024-xx-xx v3.7.0
+
+  Added support for CPython 3.13.
 
   Improve support for Python processes running in containers.
 

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ folder in either the SVG, PDF or PNG format
 
 # Compatibility
 
-Austin supports Python 3.8 through 3.12, and has been tested on the following
+Austin supports Python 3.8 through 3.13, and has been tested on the following
 platforms and architectures
 
 |             | <img src="art/tux.svg" /> | <img src="art/win.svg"/> | <img src="art/apple.svg"/> |

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.69])
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"AC_INIT([austin], [{version()}], [https://github.com/p403n1x87/austin/issues])")
 # ]]]
-AC_INIT([austin], [3.6.1], [https://github.com/p403n1x87/austin/issues])
+AC_INIT([austin], [3.7.0], [https://github.com/p403n1x87/austin/issues])
 # [[[end]]]
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/doc/cheatsheet.svg
+++ b/doc/cheatsheet.svg
@@ -6342,7 +6342,7 @@
          y="293.48233"
          x="49.886612"
          id="tspan9522"
-         sodipodi:role="line">3.8 | 3.9 | 3.10 | 3.11 | 3.12</tspan></text>
+         sodipodi:role="line">3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13</tspan></text>
     <text
        id="text9528"
        y="35.175755"
@@ -7272,7 +7272,7 @@
          y="6.5234571"
          x="206.75958"
          id="tspan867"
-         sodipodi:role="line">for version 3.6</tspan></text>
+         sodipodi:role="line">for version 3.7</tspan></text>
     <flowRoot
        xml:space="preserve"
        id="flowRoot1392"

--- a/scripts/build-wheel.py
+++ b/scripts/build-wheel.py
@@ -21,6 +21,7 @@ METADATA = {
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     "Project-URL": [
         "Homepage, https://github.com/P403n1x87/austin",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ base: core20
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"version: '{version()}+git'")
 # ]]]
-version: '3.6.1+git'
+version: '3.7.0+git'
 # [[[end]]]
 summary: A Python frame stack sampler for CPython
 description: |

--- a/src/austin.h
+++ b/src/austin.h
@@ -34,7 +34,7 @@
 from scripts.utils import get_current_version_from_changelog as version
 print(f'#define VERSION                         "{version()}"')
 ]]] */
-#define VERSION                         "3.6.1"
+#define VERSION                         "3.7.0"
 // [[[end]]]
 
 #endif

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -99,6 +99,11 @@ typedef struct {
   hash_table_t    * base_table;
   #endif
 
+  // Local buffers
+  _PyRuntimeState    * rs;
+  PyInterpreterState * is;
+  PyThreadState      * ts;
+
   // Platform-dependent fields
   proc_extra_info * extra;
 } py_proc_t;
@@ -207,6 +212,19 @@ py_proc__sample(py_proc_t *);
  * @return 0 on success.
  */
 #define py_proc__get_type(self, raddr, dt) (py_proc__memcpy(self, raddr, sizeof(dt), &dt))
+
+/**
+ * Make a local copy of a remote structure.
+ *
+ * @param self  the process object.
+ * @param type  the type of the structure.
+ * @param raddr the remote address of the structure.
+ * @param dest  the destination address.
+ *
+ * @return 0 on success.
+ */
+#define py_proc__copy_v(self, type, raddr, dest) (py_proc__memcpy(self, raddr, py_v->py_##type.size, dest))
+
 
 /**
  * Log the Python interpreter version

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -176,7 +176,7 @@ py_proc_list__sample(py_proc_list_t * self) {
   for (py_proc_item_t * item = self->first; item != NULL; /* item = item->next */) {
     log_t("Sampling process with PID %d", item->py_proc->pid);
     stopwatch_start();
-    if (fail(py_proc__sample(item->py_proc))) {
+    if (!isvalid(item->py_proc->py_v) || fail(py_proc__sample(item->py_proc))) {
       py_proc__wait(item->py_proc);
       py_proc_item_t * next = item->next;
       _py_proc_list__remove(self, item);

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -948,7 +948,13 @@ py_thread__emit_collapsed_stack(py_thread_t * self, int64_t interp_id, ctime_t t
   V_DESC(self->proc->py_v);
 
   if (isvalid(self->top_frame)) {
-    if (V_MIN(3, 11)) {
+    if (V_MIN(3, 13)) {
+      if (fail(_py_thread__unwind_iframe_stack(self, self->top_frame))) {
+        emit_invalid_frame();
+        error = TRUE;
+      }
+    }  
+    else if (V_MIN(3, 11)) {
       if (fail(_py_thread__unwind_cframe_stack(self))) {
         emit_invalid_frame();
         error = TRUE;

--- a/src/python/runtime.h
+++ b/src/python/runtime.h
@@ -156,4 +156,151 @@ typedef union {
   _PyRuntimeState3_12 v3_12;
 } _PyRuntimeState;
 
+// ----------------------------------------------------------------------------
+// Starting with CPython 3.13, we can retrieve the offsets from a dedicated
+// data structure
+
+#define _Py_Debug_Cookie "xdebugpy"
+
+typedef struct _Py_DebugOffsets3_13 {
+    char cookie[8];  // _Py_Debug_Cookie
+    uint64_t version;
+    uint64_t free_threaded;
+    // Runtime state offset;
+    struct _runtime_state {
+        uint64_t size;
+        uint64_t finalizing;
+        uint64_t interpreters_head;
+    } runtime_state;
+
+    // Interpreter state offset;
+    struct _interpreter_state {
+        uint64_t size;
+        uint64_t id;
+        uint64_t next;
+        uint64_t threads_head;
+        uint64_t gc;
+        uint64_t imports_modules;
+        uint64_t sysdict;
+        uint64_t builtins;
+        uint64_t ceval_gil;
+        uint64_t gil_runtime_state;
+        uint64_t gil_runtime_state_enabled;
+        uint64_t gil_runtime_state_locked;
+        uint64_t gil_runtime_state_holder;
+    } interpreter_state;
+
+    // Thread state offset;
+    struct _thread_state{
+        uint64_t size;
+        uint64_t prev;
+        uint64_t next;
+        uint64_t interp;
+        uint64_t current_frame;
+        uint64_t thread_id;
+        uint64_t native_thread_id;
+        uint64_t datastack_chunk;
+        uint64_t status;
+    } thread_state;
+
+    // InterpreterFrame offset;
+    struct _interpreter_frame {
+        uint64_t size;
+        uint64_t previous;
+        uint64_t executable;
+        uint64_t instr_ptr;
+        uint64_t localsplus;
+        uint64_t owner;
+    } interpreter_frame;
+
+    // Code object offset;
+    struct _code_object {
+        uint64_t size;
+        uint64_t filename;
+        uint64_t name;
+        uint64_t qualname;
+        uint64_t linetable;
+        uint64_t firstlineno;
+        uint64_t argcount;
+        uint64_t localsplusnames;
+        uint64_t localspluskinds;
+        uint64_t co_code_adaptive;
+    } code_object;
+
+    // PyObject offset;
+    struct _pyobject {
+        uint64_t size;
+        uint64_t ob_type;
+    } pyobject;
+
+    // PyTypeObject object offset;
+    struct _type_object {
+        uint64_t size;
+        uint64_t tp_name;
+        uint64_t tp_repr;
+        uint64_t tp_flags;
+    } type_object;
+
+    // PyTuple object offset;
+    struct _tuple_object {
+        uint64_t size;
+        uint64_t ob_item;
+        uint64_t ob_size;
+    } tuple_object;
+
+    // PyList object offset;
+    struct _list_object {
+        uint64_t size;
+        uint64_t ob_item;
+        uint64_t ob_size;
+    } list_object;
+
+    // PyDict object offset;
+    struct _dict_object {
+        uint64_t size;
+        uint64_t ma_keys;
+        uint64_t ma_values;
+    } dict_object;
+
+    // PyFloat object offset;
+    struct _float_object {
+        uint64_t size;
+        uint64_t ob_fval;
+    } float_object;
+
+    // PyLong object offset;
+    struct _long_object {
+        uint64_t size;
+        uint64_t lv_tag;
+        uint64_t ob_digit;
+    } long_object;
+
+    // PyBytes object offset;
+    struct _bytes_object {
+        uint64_t size;
+        uint64_t ob_size;
+        uint64_t ob_sval;
+    } bytes_object;
+
+    // Unicode object offset;
+    struct _unicode_object {
+        uint64_t size;
+        uint64_t state;
+        uint64_t length;
+        uint64_t asciiobject_size;
+    } unicode_object;
+
+    // GC runtime state offset;
+    struct _gc {
+        uint64_t size;
+        uint64_t collecting;
+    } gc;
+} _Py_DebugOffsets3_13;
+
+
+typedef union {
+  _Py_DebugOffsets3_13 v3_13;
+} _Py_DebugOffsets;
+
+
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -372,6 +372,10 @@ python_v python_v3_12 = {
   PY_IFRAME_312   (_PyInterpreterFrame3_12),
 };
 
+// ---- Python 3.13 -----------------------------------------------------------
+
+python_v python_v3_13;
+
 // ----------------------------------------------------------------------------
 static inline python_v *
 get_version_descriptor(int major, int minor, int patch) {
@@ -410,6 +414,9 @@ get_version_descriptor(int major, int minor, int patch) {
     // 3.12
     case 12: py_v = &python_v3_12; break;
 
+    // 3.13+
+    case 13: py_v = &python_v3_13; break;
+
     default: py_v = LATEST_VERSION;
       UNSUPPORTED_VERSION;
     }
@@ -421,6 +428,74 @@ get_version_descriptor(int major, int minor, int patch) {
 
   return py_v;
 }
+
+// ----------------------------------------------------------------------------
+
+#define V_ASSIGN(ver, dst, src) {py_v->py_##dst = py_d->v##ver.src;log_d("py_%s = %ld", #dst, py_v->py_##dst);}
+
+#define PY_CODE_313(v) { \
+  V_ASSIGN(v, code.size, code_object.size) \
+  V_ASSIGN(v, code.o_filename, code_object.filename) \
+  V_ASSIGN(v, code.o_name, code_object.name) \
+  V_ASSIGN(v, code.o_lnotab, code_object.linetable) \
+  V_ASSIGN(v, code.o_firstlineno, code_object.firstlineno) \
+  V_ASSIGN(v, code.o_code, code_object.co_code_adaptive) \
+  V_ASSIGN(v, code.o_qualname, code_object.qualname) \
+}
+
+#define PY_IFRAME_313(v) { \
+  V_ASSIGN(v, iframe.size, interpreter_frame.size) \
+  V_ASSIGN(v, iframe.o_previous, interpreter_frame.previous) \
+  V_ASSIGN(v, iframe.o_code, interpreter_frame.executable) \
+  V_ASSIGN(v, iframe.o_prev_instr, interpreter_frame.instr_ptr) \
+  V_ASSIGN(v, iframe.o_owner, interpreter_frame.owner) \
+}
+
+#define PY_THREAD_313(v) { \
+  V_ASSIGN(v, thread.size, thread_state.size) \
+  V_ASSIGN(v, thread.o_prev, thread_state.prev) \
+  V_ASSIGN(v, thread.o_next, thread_state.next) \
+  V_ASSIGN(v, thread.o_interp, thread_state.interp) \
+  V_ASSIGN(v, thread.o_frame, thread_state.current_frame) \
+  V_ASSIGN(v, thread.o_thread_id, thread_state.thread_id) \
+  V_ASSIGN(v, thread.o_native_thread_id, thread_state.native_thread_id) \
+  V_ASSIGN(v, thread.o_stack, thread_state.datastack_chunk) \
+  V_ASSIGN(v, thread.o_status, thread_state.status) \
+}
+
+#define PY_RUNTIME_313(v) { \
+  V_ASSIGN(v, runtime.size, runtime_state.size) \
+  V_ASSIGN(v, runtime.o_interp_head, runtime_state.interpreters_head) \
+}
+
+#define PY_IS_313(v) { \
+  V_ASSIGN(v, is.size, interpreter_state.size) \
+  V_ASSIGN(v, is.o_next, interpreter_state.next) \
+  V_ASSIGN(v, is.o_tstate_head, interpreter_state.threads_head) \
+  V_ASSIGN(v, is.o_id, interpreter_state.id) \
+  V_ASSIGN(v, is.o_gc, interpreter_state.gc) \
+  V_ASSIGN(v, is.o_gil_state, interpreter_state.ceval_gil) \
+}
+
+#define PY_GC_313(v) { \
+  V_ASSIGN(v, gc.size, gc.size) \
+  V_ASSIGN(v, gc.o_collecting, gc.collecting) \
+}
+
+// ----------------------------------------------------------------------------
+static void
+init_version_descriptor(python_v * py_v, _Py_DebugOffsets* py_d) {
+  switch (py_v->minor) {
+    case 13:
+      PY_CODE_313(3_13);
+      PY_IFRAME_313(3_13);
+      PY_THREAD_313(3_13);
+      PY_RUNTIME_313(3_13);
+      PY_IS_313(3_13);
+      PY_GC_313(3_13);
+  }
+}
+
 
 #endif  // PY_PROC_C
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,8 @@
 import os
 import platform
 
-PY3_LATEST = 12
+PY3_EARLIEST = 8
+PY3_LATEST = 13
 
 try:
     REQUESTED_PYTHON_VERSIONS = [
@@ -15,9 +16,9 @@ except Exception:
 match platform.system():
     case "Darwin":
         PYTHON_VERSIONS = REQUESTED_PYTHON_VERSIONS or [
-            (3, _) for _ in range(8, PY3_LATEST + 1)
+            (3, _) for _ in range(PY3_EARLIEST, PY3_LATEST + 1)
         ]
     case _:
         PYTHON_VERSIONS = REQUESTED_PYTHON_VERSIONS or [
-            (3, _) for _ in range(8, PY3_LATEST + 1)
+            (3, _) for _ in range(PY3_EARLIEST, PY3_LATEST + 1)
         ]


### PR DESCRIPTION
### Description of the Change

We add support for CPython 3.13. This new version introduces a data structure designed for easily exposing the required field offsets to out-of-process tools like Austin, via the ABI. We adapt the coding to allow integrating with this new structure.

We currently limit testing to the CPython 3.13 version with the GIL. No testing has currently been done with either the free-threaded version, nor with the new JIT.

### Alternate Designs

N.A.

### Regressions

There are slim chances that the current approach taken fails under certain circumstances. That is because the new approach would require allocating memory for the Python data structures at runtime, as they are no longer known at compile time. This has been done for some of the more critical structures, but for others we are still relying on the size of the same structures from previous versions. There are no guarantees that this would work.

### Verification Process

Existing test suite extended to Python 3.13.