### PR TITLE
chore: clean up support for old versions of Python

### DIFF
--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -424,7 +424,7 @@ static inline int
 _py_thread__unwind_iframe_stack(py_thread_t * self, void * iframe_raddr) {
   int invalid = FALSE; 
   void * curr = iframe_raddr;
-  
+
   while (isvalid(curr)) {
     if (fail(_py_thread__push_iframe(self, &curr))) {
       log_d("Failed to retrieve iframe #%d", stack_pointer());
@@ -457,8 +457,6 @@ static inline int
 _py_thread__unwind_cframe_stack(py_thread_t * self) {
   PyCFrame cframe;
 
-  int invalid = FALSE;
-
   _py_thread__read_stack(self);
 
   stack_reset();
@@ -470,11 +468,7 @@ _py_thread__unwind_cframe_stack(py_thread_t * self) {
     FAIL;
   }
 
-  invalid = fail(_py_thread__unwind_iframe_stack(self, V_FIELD(void *, cframe, py_cframe, o_current_frame)));
-  if (invalid)
-    return invalid;
-
-  return invalid;
+  return fail(_py_thread__unwind_iframe_stack(self, V_FIELD(void *, cframe, py_cframe, o_current_frame)));
 }
 
 

--- a/src/python/string.h
+++ b/src/python/string.h
@@ -120,14 +120,4 @@ typedef struct {
     char ob_sval[1];
 } PyBytesObject;
 
-
-// ---- stringobject.h --------------------------------------------------------
-
-typedef struct {
-    PyObject_VAR_HEAD
-    long ob_shash;
-    int ob_sstate;
-    char ob_sval[1];
-} PyStringObject; /* From Python 2.7 */
-
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -141,16 +141,6 @@ typedef struct {
 
 
 typedef struct {
-  int version;
-} py_unicode_v;
-
-
-typedef struct {
-  int version;
-} py_bytes_v;
-
-
-typedef struct {
   ssize_t  size;
 
   offset_t o_interp_head;
@@ -278,14 +268,6 @@ typedef struct {
   offsetof(s, native_thread_id),        \
   offsetof(s, datastack_chunk),         \
   offsetof(s, _status)                  \
-}
-
-#define PY_UNICODE(n) {                 \
-  n                                     \
-}
-
-#define PY_BYTES(n) {                   \
-  n                                     \
 }
 
 #define PY_RUNTIME(s) {                 \


### PR DESCRIPTION
We remove some old code used for the support of older version of Python that is no longe required.