### PR TITLE
ci: improve wheel generation script

### DIFF
--- a/scripts/build-wheel.py
+++ b/scripts/build-wheel.py
@@ -82,7 +82,7 @@ def make_message(headers, payload=None):
 
 def write_austin_wheel(out_dir, *, version, platform, austin_bin_data):
     package_name = "austin-dist"
-    python = ".".join(("py2", "py3"))
+    python = "py3"
     dist_name = package_name.replace("-", "_")
     wheel_name = f"{dist_name}-{version}-{python}-none-{platform}.whl"
     dist_info = f"{dist_name}-{version}.dist-info"
@@ -104,7 +104,12 @@ def write_austin_wheel(out_dir, *, version, platform, austin_bin_data):
             "Version": version,
             **METADATA,
         },
-        Path("README.md").read_text("utf-8"),
+        Path("README.md")
+        .read_text("utf-8")
+        .replace(
+            'img src="art',
+            'img src="https://raw.githubusercontent.com/P403n1x87/austin/refs/heads/master/art',
+        ),
     )
     contents[f"{dist_info}/WHEEL"] = make_message(
         {


### PR DESCRIPTION
We improve the wheel script generator by removing the obsolete py2 target and by resolving the image addresses to the absolute raw ones so that images appear as expected in the PyPI page.