### PR TITLE
ci(release): ensure correct macos target build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
           export VERSION=$(cat src/austin.h | sed -n -E "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
           echo "::set-output name=version::$VERSION"
 
-          gcc-12 -Wall -O3 -Os -o src/austin src/*.c
+          clang -Wall -O3 -Os -o src/austin src/*.c -target x86_64-apple-macos11
 
           pushd src
           zip -r austin-${VERSION}-mac64.zip austin


### PR DESCRIPTION
We make sure that macos binary are built with the expected target platform.

Fixes #242.