### PR TITLE
ci: bump Ubuntu version

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 
@@ -27,7 +27,7 @@ jobs:
       - name: Compile Austin
         run: |
           autoreconf --install
-          ./configure --enable-debug-symbols true
+          ./configure --enable-debug-symbols=yes
           make
 
       - name: Install runtime dependencies

--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build-linux-archs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: ["armv7", "aarch64", "ppc64le"]
@@ -27,12 +27,12 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout sources
 
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2
         name: Build Austin on ${{ matrix.arch }}
         id: build-on-arch
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           dockerRunArgs:  --volume "${GITHUB_WORKSPACE}/artifacts:/artifacts"
           setup: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-manpage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Check docs
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
         run: git diff -I".* DO NOT MODIFY.*" -I"[.]TH AUSTIN.*" --exit-code src/austin.1
 
   cppcheck-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Static code analysis (Linux)
     env:
       cppcheck-version: 2.10.3
@@ -42,44 +42,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install build dependencies
+      - name: Install cppcheck
         run: |
           sudo apt-get update
-          sudo apt-get -y install libpcre3-dev
-
-      - name: Restore cppcheck build
-        id: cppcheck-build-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ${{ github.workspace }}/cppcheck
-          key: ${{ runner.os }}-cppcheck-${{ env.cppcheck-version }}
-
-      - name: Check out cppcheck
-        uses: actions/checkout@v3
-        with:
-          repository: danmar/cppcheck
-          ref: ${{ env.cppcheck-version }}
-          path: ${{ github.workspace }}/cppcheck
-
-      - name: Compile cppcheck
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libpcre3-dev
-          cd cppcheck
-          make MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
-          cd -
-
-      - name: Save cppcheck build
-        id: cppcheck-build-save
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ${{ github.workspace }}/cppcheck
-          key: ${{ runner.os }}-cppcheck-${{ env.cppcheck-version }}
+          sudo apt-get -y install cppcheck
 
       - name: Check source code
-        run: ${{ github.workspace }}/cppcheck/cppcheck -q -f --error-exitcode=1 --inline-suppr src
+        run: cppcheck -q -f --error-exitcode=1 --inline-suppr src
 
   cppcheck-macos:
     name: Static code analysis (macOS)
@@ -94,7 +63,7 @@ jobs:
         run: cppcheck -q -f --error-exitcode=1 --inline-suppr --check-level=exhaustive src
 
   codespell:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Codespell
     steps:
       - uses: actions/checkout@v3
@@ -110,7 +79,7 @@ jobs:
         run: codespell -I .github/workflows/wordlist.txt -S "src/python/*" src
 
   formatting-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Formatting (tests)
     steps:
       - uses: actions/checkout@v3
@@ -126,7 +95,7 @@ jobs:
         run: black --check --exclude=test/targets test/
 
   linting-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Linting (tests)
     steps:
       - uses: actions/checkout@v3
@@ -142,7 +111,7 @@ jobs:
         run: flake8 --config test/.flake8 test/
 
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Code coverage
     steps:
       - uses: actions/checkout@v3
@@ -190,7 +159,7 @@ jobs:
           verbose: true
 
   check-cog:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Check cog output
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -5,7 +5,7 @@ on:
       - 'v*-*'
 jobs:
   release-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     name: Release (Linux)

--- a/.github/workflows/pre_release_arch.yml
+++ b/.github/workflows/pre_release_arch.yml
@@ -5,7 +5,7 @@ on:
       - 'v*-*'
 jobs:
   release-linux-archs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch: ["armv7", "aarch64", "ppc64le"]
@@ -14,12 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout sources
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2
         name: Generate artifacts on ${{ matrix.arch }}
         id: run-tests-on-arch
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu20.04
+          distro: ubuntu24.04
           githubToken: ${{ github.token }}
           dockerRunArgs: --volume "${GITHUB_WORKSPACE}/artifacts:/artifacts"
           setup: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   release-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     name: Release (Linux)

--- a/.github/workflows/release_arch.yml
+++ b/.github/workflows/release_arch.yml
@@ -5,7 +5,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   release-linux-archs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch: ["armv7", "aarch64", "ppc64le"]
@@ -15,12 +15,12 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout sources
       
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2
         name: Run tests on ${{ matrix.arch }}
         id: run-tests-on-arch
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu20.04
+          distro: ubuntu24.04
           githubToken: ${{ github.token }}
           dockerRunArgs:  --volume "${GITHUB_WORKSPACE}/artifacts:/artifacts"
           setup: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04    
+    runs-on: ubuntu-24.04    
     name: Build Austin on Linux
     steps:
       - uses: actions/checkout@v3
@@ -36,18 +36,19 @@ jobs:
       - name: Compile Austin
         run: |
           autoreconf --install
-          ./configure --enable-debug-symbols true
+          ./configure --enable-debug-symbols=yes
           make
 
       - uses: actions/upload-artifact@v4
         with:
-          name: austin-binaries
+          name: austin-binaries-${{ runner.os }}
+          overwrite: true
           path: |
             src/austin
             src/austinp
 
   build-linux-musl:
-    runs-on: ubuntu-20.04    
+    runs-on: ubuntu-24.04    
     name: Build Austin on Linux (musl)
     steps:
       - uses: actions/checkout@v3
@@ -63,12 +64,13 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: austin-binaries
+          name: austin-binaries-${{ runner.os }}-musl
+          overwrite: true
           path: |
             src/austin.musl
 
   tests-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     needs: [build-linux, build-linux-musl]
 
@@ -86,7 +88,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binaries
+          name: austin-binaries-${{ runner.os }}
           path: src
 
       - run: chmod +x src/austin && chmod +x src/austinp
@@ -179,9 +181,9 @@ jobs:
         if: always()
 
   wheels-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
-    needs: build-linux
+    needs: [build-linux, build-linux-musl]
 
     name: Build Linux wheels
     steps:
@@ -189,7 +191,12 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binaries
+          name: austin-binaries-${{ runner.os }}
+          path: src
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: austin-binaries-${{ runner.os }}-musl
           path: src
 
       - run: chmod +x src/austin && chmod +x src/austinp
@@ -232,7 +239,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: austin-binary
+          name: austin-binary-${{ runner.os }}
+          overwrite: true
           path: |
             src/austin
 
@@ -270,7 +278,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binary
+          name: austin-binary-${{ runner.os }}
           path: src
 
       - run: chmod +x src/austin
@@ -332,7 +340,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binary
+          name: austin-binary-${{ runner.os }}
           path: src
 
       - run: chmod +x src/austin
@@ -373,7 +381,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: austin-binary
+          name: austin-binary-${{ runner.os }}
+          overwrite: true
           path: |
             src/austin.exe
 
@@ -396,7 +405,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binary
+          name: austin-binary-${{ runner.os }}
           path: src
 
       - name: Install Python
@@ -445,7 +454,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binary
+          name: austin-binary-${{ runner.os }}
           path: src
 
       - uses: actions/setup-python@v4
@@ -467,7 +476,7 @@ jobs:
             --files austin.exe:src/austin.exe
 
   validation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     needs: build-linux
 
@@ -501,7 +510,7 @@ jobs:
       - name: Compile Austin
         run: |
           autoreconf --install
-          ./configure --enable-debug-symbols true
+          ./configure --enable-debug-symbols=yes
           make
 
       - name: Install runtime dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  ubuntu:20.04
+FROM  ubuntu:24.04
 COPY  . /austin
 RUN   apt-get update && \
       apt-get install -y autoconf build-essential libunwind-dev binutils-dev libiberty-dev zlib1g-dev && \

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,10 @@ AM_INIT_AUTOMAKE
 AC_PROG_CC_C99
 AC_PROG_CPP
 
+# Host conditionals
+AC_CANONICAL_HOST
+AC_CANONICAL_TARGET
+
 # Use the C language and compiler for the following checks
 AC_LANG([C])
 
@@ -33,6 +37,12 @@ AC_CHECK_LIB(bfd, bfd_openr, [
     AC_DEFINE([HAVE_BFD], [1], ["Compile with BFD support"])
     AUSTINP_CFLAGS+=" -DHAVE_BFD"
     AUSTINP_LDADD+=" -l:libbfd.a -l:libz.a"
+    AC_CHECK_LIB(sframe, sframe_encode, [
+        AUSTINP_LDADD+=" -l:libsframe.a"
+    ])
+    AC_CHECK_LIB(zstd, ZSTD_compress, [
+        AUSTINP_LDADD+=" -l:libzstd.a"
+    ])
     echo "enabling symbol resolution support for austinp"
 ], [
     echo "austinp will be built without symbol resolution support: missing libbfd"
@@ -48,6 +58,12 @@ AC_CHECK_LIB(iberty, bfd_demangle, [
     -lbfd
 ])
 AUSTINP_LDADD+=" -ldl"
+
+case $target_cpu in
+    powerpc64le )
+        AUSTINP_CFLAGS+=" -Wno-error=stringop-overflow"
+        ;;
+esac
 
 AC_SUBST(AUSTINP_CFLAGS, [$AUSTINP_CFLAGS])
 AC_SUBST(AUSTINP_LDADD, [$AUSTINP_LDADD])


### PR DESCRIPTION
We migrate the CI jobs to more recent versions of Ubuntu. We also make the required changes to the autotools sources to ensure compilation of sources. All platforms but armv7 are covered by this change.