### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.pdf,*.svg,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ separated by only one underscore `_`. For instance method, the separator is a
 double underscore `__`.
 
 Private methods, i.e. those that are used only within the translation unit,
-must be `static` and prefixed with an underscore `_` so that they can be easly
+must be `static` and prefixed with an underscore `_` so that they can be easily
 recognised in the code.
 
 To summarise, here is an example of the above rules in place for an object of

--- a/ChangeLog
+++ b/ChangeLog
@@ -189,7 +189,7 @@
 
     - --memory, -m:
 
-        Switch to memory profling mode
+        Switch to memory profiling mode
 
     - --full, -f:
 


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

ATM it was only few typos, but the past was "darker":

```
❯ git log origin/master | grep typo | nl
     1	    Merge pull request #233 from P403n1x87/chore/fix-typos
     2	    chore: fix typos
     3	    chore: fix typos
     4	    fix: typo in logging.c
     5	    Some typos have also been fixed in various docstrings.
     6	    fix(utils): typo in resolve.py
     7	    docs: fix typo in manpage
     8	    * Fix typo in Austin TUI section title
```

with the CI future could remain bright ;)