### PR TITLE
refactor: introduce event handlers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,9 @@ austin_SOURCES = \
   austin.c       \
   cache.c        \
   error.c        \
+  events.c       \
   logging.c      \
+  stack.c        \
   stats.c        \
   platform.c     \
   py_proc_list.c \

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -48,24 +48,6 @@
 #define DEFAULT_INIT_TIMEOUT_MS 1000 // 1 second
 #define DEFAULT_HEAP_SIZE       0
 
-const char SAMPLE_FORMAT_NORMAL[] = ";%s:%s:%d";
-const char SAMPLE_FORMAT_WHERE[]  = "    \033[33;1m%2$s\033[0m (\033[36;1m%1$s\033[0m:\033[32;1m%3$d\033[0m)\n";
-#ifdef NATIVE
-const char SAMPLE_FORMAT_WHERE_NATIVE[]
-    = "    \033[38;5;246m%2$s\033[0m (\033[38;5;248;1m%1$s\033[0m:\033[38;5;246m%3$d\033[0m)\n";
-const char SAMPLE_FORMAT_KERNEL[]       = ";kernel:%s:0";
-const char SAMPLE_FORMAT_WHERE_KERNEL[] = "    \033[38;5;159m%s\033[0m 🐧\n";
-#endif
-#if defined PL_WIN
-const char HEAD_FORMAT_DEFAULT[] = "P%I64d;T%I64x:%I64x";
-const char HEAD_FORMAT_WHERE[]
-    = "\n\n%4$s%5$s Process \033[35;1m%1$I64d\033[0m 🧵 Thread \033[34;1m%2$I64d:%3$I64d\033[0m\n\n";
-#else
-const char HEAD_FORMAT_DEFAULT[] = "P%d;T%ld:%ld";
-const char HEAD_FORMAT_WHERE[]
-    = "\n\n%4$s%5$s Process \033[35;1m%1$d\033[0m 🧵 Thread \033[34;1m%2$ld:%3$ld\033[0m\n\n";
-#endif
-
 // Globals for command line arguments
 parsed_args_t pargs = {
     /* t_sampling_interval */ DEFAULT_SAMPLING_INTERVAL,
@@ -73,8 +55,6 @@ parsed_args_t pargs = {
     /* attach_pid          */ 0,
     /* where               */ 0,
     /* sleepless           */ 0,
-    /* format              */ (char*)SAMPLE_FORMAT_NORMAL,
-    /* head_format         */ (char*)HEAD_FORMAT_DEFAULT,
     /* full                */ 0,
     /* memory              */ 0,
     /* binary              */ 0,
@@ -86,8 +66,6 @@ parsed_args_t pargs = {
     /* gc                  */ 0,
     /* heap                */ DEFAULT_HEAP_SIZE,
 #ifdef NATIVE
-    /* native_format       */ (char*)SAMPLE_FORMAT_NORMAL,
-    /* kernel_format       */ (char*)SAMPLE_FORMAT_KERNEL,
     /* kernel              */ 0,
 #endif
 };
@@ -372,12 +350,6 @@ parse_opt(int key, char* arg, struct argp_state* state) {
         pargs.attach_pid = (pid_t)l_pid;
         pargs.where      = TRUE;
 
-        pargs.head_format = (char*)HEAD_FORMAT_WHERE;
-        pargs.format      = (char*)SAMPLE_FORMAT_WHERE;
-#ifdef NATIVE
-        pargs.native_format = (char*)SAMPLE_FORMAT_WHERE_NATIVE;
-        pargs.kernel_format = (char*)SAMPLE_FORMAT_WHERE_KERNEL;
-#endif
         break;
 
 #ifdef NATIVE
@@ -666,8 +638,6 @@ cb(const char opt, const char* arg) {
         }
         pargs.where = TRUE;
 
-        pargs.head_format = (char*)HEAD_FORMAT_WHERE;
-        pargs.format      = (char*)SAMPLE_FORMAT_WHERE;
         break;
 
     case 'o':

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -31,27 +31,23 @@
 #include "stats.h"
 
 typedef struct {
-    ctime_t t_sampling_interval;
-    ctime_t timeout;
-    pid_t   attach_pid;
-    int     where;
-    int     sleepless;
-    char*   format;
-    char*   head_format;
-    int     full;
-    int     memory;
-    int     binary;
-    FILE*   output_file;
-    char*   output_filename;
-    int     children;
-    ctime_t exposure;
-    int     pipe;
-    int     gc;
-    size_t  heap;
+    microseconds_t t_sampling_interval;
+    ctime_t        timeout;
+    pid_t          attach_pid;
+    int            where;
+    int            sleepless;
+    int            full;
+    int            memory;
+    int            binary;
+    FILE*          output_file;
+    char*          output_filename;
+    int            children;
+    ctime_t        exposure;
+    int            pipe;
+    int            gc;
+    size_t         heap;
 #ifdef NATIVE
-    char* native_format;
-    char* kernel_format;
-    int   kernel;
+    int kernel;
 #endif
 } parsed_args_t;
 

--- a/src/austin.c
+++ b/src/austin.c
@@ -308,9 +308,9 @@ main(int argc, char** argv) {
     }
 
     if (!isvalid(handler)) {
-        log_e("Failed to create event handler");
+        log_e("Failed to create event handler"); // GCOV_EXCL_START
         retval = -1;
-        goto release;
+        goto release; // GCOV_EXCL_STOP
     }
     event_handler_install(handler);
 

--- a/src/austin.c
+++ b/src/austin.c
@@ -298,6 +298,22 @@ main(int argc, char** argv) {
         goto finally;
     }
 
+    event_handler_t* handler = NULL;
+    if (pargs.where) {
+        handler = where_event_handler_new();
+    } else if (pargs.binary) {
+        handler = mojo_event_handler_new();
+    } else {
+        handler = collapsed_stack_event_handler_new();
+    }
+
+    if (!isvalid(handler)) {
+        log_e("Failed to create event handler");
+        retval = -1;
+        goto release;
+    }
+    event_handler_install(handler);
+
     py_proc = py_proc_new(FALSE);
     if (!isvalid(py_proc)) {
         log_ie("Cannot create process");
@@ -311,10 +327,6 @@ main(int argc, char** argv) {
 
     // Initialise sampling metrics.
     stats_reset();
-
-    if (pargs.binary) {
-        mojo_header();
-    }
 
     if (pargs.attach_pid == 0) {
         if ((fail(py_proc__start(py_proc, argv[exec_arg], (char**)&argv[exec_arg])) && !pargs.children)
@@ -344,7 +356,7 @@ main(int argc, char** argv) {
         // We use the exposure branch to emulate sampling once
         pargs.exposure            = 1;
     } else
-        log_i("Sampling interval: %lu μs", pargs.t_sampling_interval);
+        log_i("Sampling interval: " MICROSECONDS_FMT " μs", pargs.t_sampling_interval);
 
     if (pargs.heap)
         log_i("Maximum frame heap size: %d MB", pargs.heap >> 20);
@@ -383,19 +395,12 @@ main(int argc, char** argv) {
         goto finally;
     }
 
-    if (pargs.where)
-        goto finally;
-
-    // Log sampling metrics
-    NL;
-
-    emit_metadata("duration", MICROSECONDS_FMT, stats_duration());
+    event_handler__emit_metadata("duration", MICROSECONDS_FMT, stats_duration());
     if (pargs.gc) {
-        emit_metadata("gc", MICROSECONDS_FMT, _gc_time);
+        event_handler__emit_metadata("gc", MICROSECONDS_FMT, _gc_time);
     }
 
     stats_log_metrics();
-    NL;
 
 finally:
     py_thread_free();
@@ -410,6 +415,8 @@ release:
     }
 
     logger_close();
+
+    event_handler_free();
 
     if (interrupt < 0)
         // Interrupted  by signal

--- a/src/events.c
+++ b/src/events.c
@@ -1,0 +1,407 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018-2025 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#define EVENTS_C
+
+#include "events.h"
+#include "argparse.h"
+#include "frame.h"
+#include "mojo.h"
+#include "platform.h"
+#include "stack.h"
+
+typedef struct {
+    event_handler_spec_t spec;        // Pointer to the event handler
+    sample_t             sample_data; // Sample data
+} base_event_handler_t;
+
+static inline void
+base_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sample) {
+    self->sample_data = *sample;
+}
+
+// ----------------------------------------------------------------------------
+// Collapsed stack event handler
+
+#if defined PL_WIN
+const char* COLLAPSED_HEAD_FORMAT = "P%I64d;T%I64x:%I64x";
+#else
+const char* COLLAPSED_HEAD_FORMAT = "P%d;T%ld:%ld";
+#endif
+
+static inline void
+collapsed_stack_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sample) {
+    base_event_handler__handle_stack_begin(self, sample);
+
+    fprintfp(pargs.output_file, COLLAPSED_HEAD_FORMAT, sample->pid, sample->iid, sample->tid);
+}
+
+static inline void
+collapsed_stack_event_handler__handle_metadata(base_event_handler_t* self, char* key, char* value, va_list args) {
+    fputs(META_HEAD, pargs.output_file);
+    fputs(key, pargs.output_file);
+    fputs(META_SEP, pargs.output_file);
+    vfprintf(pargs.output_file, value, args);
+    NL;
+}
+
+const char* SAMPLE_FORMAT = ";%s:%s:%d";
+#ifdef NATIVE
+const char* SAMPLE_FORMAT_KERNEL = ";kernel:%s:0";
+#endif
+
+static inline void
+collapsed_stack_frame_ref(const char* format, frame_t* frame) {
+    cached_string_t* scope = frame->scope;
+    fprintfp(
+        pargs.output_file, format, frame->filename->value, scope == UNKNOWN_SCOPE ? "<unknown>" : scope->value,
+        frame->line
+    );
+}
+
+#ifdef NATIVE
+static inline void
+collapsed_stack_kernel_frame_ref(const char* format, char* scope) {
+    fprintfp(pargs.output_file, format, scope);
+}
+#endif
+
+void
+collapsed_stack_event_handler__handle_stack_end(base_event_handler_t* self) {
+#ifdef NATIVE
+    int has_cframes = FALSE;
+    if (stack_top() == CFRAME_MAGIC) {
+        has_cframes = TRUE;
+        (void)stack_pop();
+    }
+
+    while (!stack_native_is_empty()) {
+        frame_t* native_frame = stack_native_pop();
+        if (!isvalid(native_frame)) {
+            log_e("Invalid native frame");
+            break;
+        }
+        cached_string_t* scope = native_frame->scope;
+
+        int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
+        if (!stack_is_empty() && is_frame_eval) {
+            // TODO: if the py stack is empty we have a mismatch.
+            frame_t* frame = stack_pop();
+            if (has_cframes) {
+                while (frame != CFRAME_MAGIC) {
+                    collapsed_stack_frame_ref(SAMPLE_FORMAT, frame);
+
+                    if (stack_is_empty())
+                        break;
+
+                    frame = stack_pop();
+                }
+            } else {
+                collapsed_stack_frame_ref(SAMPLE_FORMAT, frame);
+            }
+        } else {
+            collapsed_stack_frame_ref(SAMPLE_FORMAT, native_frame);
+        }
+    }
+    if (!stack_is_empty()) {
+        log_d("Stack mismatch: left with %d Python frames after interleaving", stack_pointer());
+        set_error(ETHREADINV);
+#ifdef DEBUG
+        fprintf(pargs.output_file, ";:%ld FRAMES LEFT:", stack_pointer());
+#endif
+    }
+    while (!stack_kernel_is_empty()) {
+        char* scope = stack_kernel_pop();
+        collapsed_stack_kernel_frame_ref(SAMPLE_FORMAT_KERNEL, scope);
+        free(scope);
+    }
+
+#else
+    while (!stack_is_empty()) {
+        frame_t* frame = stack_pop();
+        collapsed_stack_frame_ref(SAMPLE_FORMAT, frame);
+    }
+#endif
+
+    if (self->sample_data.gc_state == GC_STATE_COLLECTING) {
+        fprintf(pargs.output_file, ":GC:");
+    }
+
+    // Finish off sample with the metric(s)
+    sample_t* sample = &self->sample_data;
+    if (pargs.full) {
+        fprintf(
+            pargs.output_file, " " TIME_METRIC METRIC_SEP IDLE_METRIC METRIC_SEP MEM_METRIC "\n", sample->time,
+            sample->is_idle, sample->memory
+        );
+    } else {
+        if (pargs.memory) {
+            fprintf(pargs.output_file, " " MEM_METRIC "\n", sample->memory);
+        } else {
+            fprintf(pargs.output_file, " " TIME_METRIC "\n", sample->time);
+        }
+    }
+}
+
+event_handler_t*
+collapsed_stack_event_handler_new(void) {
+    event_handler_t* handler = (event_handler_t*)calloc(1, sizeof(base_event_handler_t));
+    if (!isvalid(handler)) {
+        log_e("Failed to allocate memory for event handler");
+        return NULL;
+    }
+
+    handler->spec.emit_stack_begin = (event_handler_stack_begin_t)collapsed_stack_event_handler__handle_stack_begin;
+    handler->spec.emit_metadata    = (event_handler_metadata_t)collapsed_stack_event_handler__handle_metadata;
+    handler->spec.emit_stack_end   = (event_handler_stack_end_t)collapsed_stack_event_handler__handle_stack_end;
+
+    return handler;
+}
+
+// ----------------------------------------------------------------------------
+// MOJO (binary mode) stack event handler
+
+static inline void
+mojo_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sample) {
+    base_event_handler__handle_stack_begin(self, sample);
+
+    mojo_event(MOJO_STACK);
+    mojo_integer(sample->pid, 0);
+    mojo_integer(sample->iid, 0);
+    fprintf(pargs.output_file, FORMAT_TID, sample->tid);
+    fputc('\0', pargs.output_file);
+}
+
+static inline void
+mojo_event_handler__handle_metadata(base_event_handler_t* self, char* key, char* value, va_list args) {
+    mojo_event(MOJO_METADATA);
+    mojo_string(key);
+    vfprintf(pargs.output_file, value, args);
+    fputc('\0', pargs.output_file);
+}
+
+static inline void
+mojo_event_handler__handle_new_string(base_event_handler_t* self, cached_string_t* string) {
+    mojo_event(MOJO_STRING);
+    mojo_ref(string->key);
+    mojo_string(string->value);
+}
+
+static inline void
+mojo_event_handler__handle_new_frame(base_event_handler_t* self, frame_t* frame) {
+    mojo_event(MOJO_FRAME);
+    mojo_integer(frame->key, 0);
+    mojo_ref(frame->filename->key);
+    mojo_ref(frame->scope->key);
+    mojo_integer(frame->line, 0);
+    mojo_integer(frame->line_end, 0);
+    mojo_integer(frame->column, 0);
+    mojo_integer(frame->column_end, 0);
+}
+
+static inline void
+mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
+#ifdef NATIVE
+    int has_cframes = FALSE;
+    if (stack_top() == CFRAME_MAGIC) {
+        has_cframes = TRUE;
+        (void)stack_pop();
+    }
+
+    while (!stack_native_is_empty()) {
+        frame_t* native_frame = stack_native_pop();
+        if (!isvalid(native_frame)) {
+            log_e("Invalid native frame");
+            break;
+        }
+        cached_string_t* scope = native_frame->scope;
+        int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
+        if (!stack_is_empty() && is_frame_eval) {
+            // TODO: if the py stack is empty we have a mismatch.
+            frame_t* frame = stack_pop();
+            if (has_cframes) {
+                while (frame != CFRAME_MAGIC) {
+                    mojo_frame_ref(frame);
+
+                    if (stack_is_empty())
+                        break;
+
+                    frame = stack_pop();
+                }
+            } else {
+                mojo_frame_ref(frame);
+            }
+        } else {
+            mojo_frame_ref(native_frame);
+        }
+    }
+    if (!stack_is_empty()) {
+        log_d("Stack mismatch: left with %d Python frames after interleaving", stack_pointer());
+        set_error(ETHREADINV);
+    }
+    while (!stack_kernel_is_empty()) {
+        char* scope = stack_kernel_pop();
+        mojo_frame_kernel(scope);
+        free(scope);
+    }
+
+#else
+    while (!stack_is_empty()) {
+        frame_t* frame = stack_pop();
+        mojo_frame_ref(frame);
+    }
+#endif
+
+    if (self->sample_data.gc_state == GC_STATE_COLLECTING) {
+        mojo_event(MOJO_GC);
+    }
+
+    // Finish off sample with the metric(s)
+    sample_t* sample = &self->sample_data;
+    if (pargs.full) {
+        mojo_metric_time(sample->time);
+        if (sample->is_idle) {
+            mojo_event(MOJO_IDLE);
+        }
+        mojo_metric_memory(sample->memory);
+    } else {
+        if (pargs.memory) {
+            mojo_metric_memory(sample->memory);
+        } else {
+            mojo_metric_time(sample->time);
+        }
+    }
+}
+
+event_handler_t*
+mojo_event_handler_new(void) {
+    event_handler_t* handler = (event_handler_t*)calloc(1, sizeof(base_event_handler_t));
+    if (!isvalid(handler)) {
+        log_e("Failed to allocate memory for event handler");
+        return NULL;
+    }
+
+    handler->spec.emit_stack_begin = (event_handler_stack_begin_t)mojo_event_handler__handle_stack_begin;
+    handler->spec.emit_metadata    = (event_handler_metadata_t)mojo_event_handler__handle_metadata;
+    handler->spec.emit_new_string  = (event_handler_new_string_t)mojo_event_handler__handle_new_string;
+    handler->spec.emit_new_frame   = (event_handler_new_frame_t)mojo_event_handler__handle_new_frame;
+    handler->spec.emit_stack_end   = (event_handler_stack_end_t)mojo_event_handler__handle_stack_end;
+
+    mojo_header();
+
+    return handler;
+}
+
+// ----------------------------------------------------------------------------
+// Where event handler
+
+const char* WHERE_SAMPLE_FORMAT = "    \033[33;1m%2$s\033[0m (\033[36;1m%1$s\033[0m:\033[32;1m%3$d\033[0m)\n";
+#ifdef NATIVE
+const char* WHERE_SAMPLE_FORMAT_NATIVE
+    = "    \033[38;5;246m%2$s\033[0m (\033[38;5;248;1m%1$s\033[0m:\033[38;5;246m%3$d\033[0m)\n";
+const char* WHERE_SAMPLE_FORMAT_KERNEL = "    \033[38;5;159m%s\033[0m 🐧\n";
+#endif
+#if defined PL_WIN
+const char* WHERE_HEAD_FORMAT
+    = "\n\n%4$s Process \033[35;1m%1$I64d\033[0m 🧵 Thread \033[34;1m%2$I64d:%3$I64d\033[0m\n\n";
+#else
+const char* WHERE_HEAD_FORMAT = "\n\n%4$s Process \033[35;1m%1$d\033[0m 🧵 Thread \033[34;1m%2$ld:%3$ld\033[0m\n\n";
+#endif
+
+static inline void
+where_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sample) {
+    fprintfp(
+        pargs.output_file, WHERE_HEAD_FORMAT, sample->pid, sample->iid, sample->tid, sample->is_idle ? "💤" : "🚀"
+    );
+}
+
+void
+where_event_handler__handle_stack_end(base_event_handler_t* self) {
+#ifdef NATIVE
+    int has_cframes = FALSE;
+    if (stack_top() == CFRAME_MAGIC) {
+        has_cframes = TRUE;
+        (void)stack_pop();
+    }
+
+    while (!stack_native_is_empty()) {
+        frame_t* native_frame = stack_native_pop();
+        if (!isvalid(native_frame)) {
+            log_e("Invalid native frame");
+            break;
+        }
+        cached_string_t* scope = native_frame->scope;
+        if (!isvalid(scope)) {
+            scope = UNKNOWN_SCOPE;
+        }
+
+        int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
+        if (!stack_is_empty() && is_frame_eval) {
+            // TODO: if the py stack is empty we have a mismatch.
+            frame_t* frame = stack_pop();
+            if (has_cframes) {
+                while (frame != CFRAME_MAGIC) {
+                    collapsed_stack_frame_ref(WHERE_SAMPLE_FORMAT, frame);
+
+                    if (stack_is_empty())
+                        break;
+
+                    frame = stack_pop();
+                }
+            } else {
+                collapsed_stack_frame_ref(WHERE_SAMPLE_FORMAT, frame);
+            }
+        } else {
+            collapsed_stack_frame_ref(WHERE_SAMPLE_FORMAT_NATIVE, native_frame);
+        }
+    }
+    if (!stack_is_empty()) {
+        log_d("Stack mismatch: left with %d Python frames after interleaving", stack_pointer());
+        set_error(ETHREADINV);
+    }
+    while (!stack_kernel_is_empty()) {
+        char* scope = stack_kernel_pop();
+        collapsed_stack_kernel_frame_ref(WHERE_SAMPLE_FORMAT_KERNEL, scope);
+        free(scope);
+    }
+
+#else
+    while (!stack_is_empty()) {
+        frame_t* frame = stack_pop();
+        collapsed_stack_frame_ref(WHERE_SAMPLE_FORMAT, frame);
+    }
+#endif
+}
+
+event_handler_t*
+where_event_handler_new(void) {
+    event_handler_t* handler = (event_handler_t*)calloc(1, sizeof(base_event_handler_t));
+    if (!isvalid(handler)) {
+        log_e("Failed to allocate memory for event handler");
+        return NULL;
+    }
+
+    handler->spec.emit_stack_begin = (event_handler_stack_begin_t)where_event_handler__handle_stack_begin;
+    handler->spec.emit_stack_end   = (event_handler_stack_end_t)where_event_handler__handle_stack_end;
+
+    return handler;
+}

--- a/src/events.c
+++ b/src/events.c
@@ -98,7 +98,7 @@ collapsed_stack_event_handler__handle_stack_end(base_event_handler_t* self) {
         frame_t* native_frame = stack_native_pop();
         if (!isvalid(native_frame)) {
             log_e("Invalid native frame");
-            break;
+            break; // GCOV_EXCL_LINE
         }
         cached_string_t* scope = native_frame->scope;
 
@@ -166,8 +166,8 @@ event_handler_t*
 collapsed_stack_event_handler_new(void) {
     event_handler_t* handler = (event_handler_t*)calloc(1, sizeof(base_event_handler_t));
     if (!isvalid(handler)) {
-        log_e("Failed to allocate memory for event handler");
-        return NULL;
+        log_e("Failed to allocate memory for event handler"); // GCOV_EXCL_START
+        return NULL;                                          // GCOV_EXCL_STOP
     }
 
     handler->spec.emit_stack_begin = (event_handler_stack_begin_t)collapsed_stack_event_handler__handle_stack_begin;
@@ -230,8 +230,8 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
     while (!stack_native_is_empty()) {
         frame_t* native_frame = stack_native_pop();
         if (!isvalid(native_frame)) {
-            log_e("Invalid native frame");
-            break;
+            log_e("Invalid native frame"); // GCOV_EXCL_START
+            break;                         // GCOV_EXCL_STOP
         }
         cached_string_t* scope = native_frame->scope;
         int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
@@ -296,8 +296,8 @@ event_handler_t*
 mojo_event_handler_new(void) {
     event_handler_t* handler = (event_handler_t*)calloc(1, sizeof(base_event_handler_t));
     if (!isvalid(handler)) {
-        log_e("Failed to allocate memory for event handler");
-        return NULL;
+        log_e("Failed to allocate memory for event handler"); // GCOV_EXCL_START
+        return NULL;                                          // GCOV_EXCL_STOP
     }
 
     handler->spec.emit_stack_begin = (event_handler_stack_begin_t)mojo_event_handler__handle_stack_begin;
@@ -346,12 +346,12 @@ where_event_handler__handle_stack_end(base_event_handler_t* self) {
     while (!stack_native_is_empty()) {
         frame_t* native_frame = stack_native_pop();
         if (!isvalid(native_frame)) {
-            log_e("Invalid native frame");
-            break;
+            log_e("Invalid native frame"); // GCOV_EXCL_START
+            break;                         // GCOV_EXCL_STOP
         }
         cached_string_t* scope = native_frame->scope;
         if (!isvalid(scope)) {
-            scope = UNKNOWN_SCOPE;
+            scope = UNKNOWN_SCOPE; // GCOV_EXCL_LINE
         }
 
         int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
@@ -396,8 +396,8 @@ event_handler_t*
 where_event_handler_new(void) {
     event_handler_t* handler = (event_handler_t*)calloc(1, sizeof(base_event_handler_t));
     if (!isvalid(handler)) {
-        log_e("Failed to allocate memory for event handler");
-        return NULL;
+        log_e("Failed to allocate memory for event handler"); // GCOV_EXCL_START
+        return NULL;                                          // GCOV_EXCL_STOP
     }
 
     handler->spec.emit_stack_begin = (event_handler_stack_begin_t)where_event_handler__handle_stack_begin;

--- a/src/events.h
+++ b/src/events.h
@@ -92,7 +92,7 @@ extern
 static inline void
 event_handler__emit_stack_begin(sample_t* sample) {
     if (!isvalid(event_handler))
-        return;
+        return; // GCOV_EXCL_LINE
 
     event_handler_stack_begin_t handler = event_handler->spec.emit_stack_begin;
     if (isvalid(handler))
@@ -102,7 +102,7 @@ event_handler__emit_stack_begin(sample_t* sample) {
 static inline void
 event_handler__emit_metadata(char* key, char* value, ...) {
     if (!isvalid(event_handler))
-        return;
+        return; // GCOV_EXCL_LINE
 
     va_list args;
     va_start(args, value);
@@ -117,7 +117,7 @@ event_handler__emit_metadata(char* key, char* value, ...) {
 static inline void
 event_handler__emit_new_string(cached_string_t* cached_string) {
     if (!isvalid(event_handler))
-        return;
+        return; // GCOV_EXCL_LINE
 
     event_handler_new_string_t handler = event_handler->spec.emit_new_string;
     if (isvalid(handler))
@@ -127,7 +127,7 @@ event_handler__emit_new_string(cached_string_t* cached_string) {
 static inline void
 event_handler__emit_new_frame(void* frame) {
     if (!isvalid(event_handler))
-        return;
+        return; // GCOV_EXCL_LINE
 
     event_handler_new_frame_t handler = event_handler->spec.emit_new_frame;
     if (isvalid(handler))
@@ -137,7 +137,7 @@ event_handler__emit_new_frame(void* frame) {
 static inline void
 event_handler__emit_stack_end(void) {
     if (!isvalid(event_handler))
-        return;
+        return; // GCOV_EXCL_LINE
 
     event_handler_stack_end_t handler = event_handler->spec.emit_stack_end;
     if (isvalid(handler))

--- a/src/events.h
+++ b/src/events.h
@@ -20,9 +20,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef EVENTS_H
-#define EVENTS_H
+#pragma once
 
+#include <stdarg.h>
 #include <stdio.h>
 
 #include "argparse.h"
@@ -30,6 +30,7 @@
 #include "logging.h"
 #include "mojo.h"
 #include "platform.h"
+#include "py_string.h"
 
 #if defined PL_WIN
 #define fprintfp _fprintf_p
@@ -42,114 +43,128 @@
 #else
 #define MEM_METRIC "%zd"
 #endif
-#define TIME_METRIC "%lu"
+#define TIME_METRIC MICROSECONDS_FMT
 #define IDLE_METRIC "%d"
 #define METRIC_SEP  ","
 
-#define emit_metadata(label, ...)              \
-    {                                          \
-        if (pargs.binary) {                    \
-            mojo_metadata(label, __VA_ARGS__); \
-        } else {                               \
-            meta(label, __VA_ARGS__);          \
-        }                                      \
+typedef enum {
+    GC_STATE_INACTIVE,
+    GC_STATE_COLLECTING,
+    GC_STATE_UNKNOWN,
+} gc_state_t;
+
+typedef struct {
+    pid_t          pid;      // Process ID
+    int64_t        iid;      // Interpreter ID
+    uintptr_t      tid;      // Thread ID
+    microseconds_t time;     // Time of the sample
+    ssize_t        memory;   // Memory usage
+    gc_state_t     gc_state; // GC state
+    int            is_idle;  // Is the thread idle?
+} sample_t;
+
+struct _eh;
+
+typedef void (*event_handler_metadata_t)(struct _eh*, char* key, char* value, va_list args);
+typedef void (*event_handler_stack_begin_t)(struct _eh*, sample_t* sample);
+typedef void (*event_handler_new_string_t)(struct _eh*, cached_string_t* string);
+typedef void (*event_handler_new_frame_t)(struct _eh*, void* frame);
+typedef void (*event_handler_stack_end_t)(struct _eh*);
+
+typedef struct _ehs {
+    event_handler_metadata_t    emit_metadata;
+    event_handler_stack_begin_t emit_stack_begin;
+    event_handler_new_string_t  emit_new_string;
+    event_handler_new_frame_t   emit_new_frame;
+    event_handler_stack_end_t   emit_stack_end;
+} event_handler_spec_t;
+
+typedef struct _eh {
+    event_handler_spec_t spec; // Pointer to the event handler
+    // custom event handler data
+} event_handler_t;
+
+#ifndef EVENTS_C
+extern
+#endif
+    event_handler_t* event_handler; // Global event handler
+
+static inline void
+event_handler__emit_stack_begin(sample_t* sample) {
+    if (!isvalid(event_handler))
+        return;
+
+    event_handler_stack_begin_t handler = event_handler->spec.emit_stack_begin;
+    if (isvalid(handler))
+        handler(event_handler, sample);
+}
+
+static inline void
+event_handler__emit_metadata(char* key, char* value, ...) {
+    if (!isvalid(event_handler))
+        return;
+
+    va_list args;
+    va_start(args, value);
+
+    event_handler_metadata_t handler = event_handler->spec.emit_metadata;
+    if (isvalid(handler))
+        handler(event_handler, key, value, args);
+
+    va_end(args);
+}
+
+static inline void
+event_handler__emit_new_string(cached_string_t* cached_string) {
+    if (!isvalid(event_handler))
+        return;
+
+    event_handler_new_string_t handler = event_handler->spec.emit_new_string;
+    if (isvalid(handler))
+        handler(event_handler, cached_string);
+}
+
+static inline void
+event_handler__emit_new_frame(void* frame) {
+    if (!isvalid(event_handler))
+        return;
+
+    event_handler_new_frame_t handler = event_handler->spec.emit_new_frame;
+    if (isvalid(handler))
+        handler(event_handler, frame);
+}
+
+static inline void
+event_handler__emit_stack_end(void) {
+    if (!isvalid(event_handler))
+        return;
+
+    event_handler_stack_end_t handler = event_handler->spec.emit_stack_end;
+    if (isvalid(handler))
+        handler(event_handler);
+}
+
+static inline void
+event_handler_install(event_handler_t* handler) {
+    if (isvalid(event_handler))
+        free(event_handler);
+
+    event_handler = handler;
+}
+
+static inline void
+event_handler_free(void) {
+    if (isvalid(event_handler)) {
+        free(event_handler);
+        event_handler = NULL;
     }
+}
 
-#define emit_invalid_frame()                          \
-    {                                                 \
-        if (pargs.binary) {                           \
-            mojo_event(MOJO_FRAME_INVALID);           \
-        } else {                                      \
-            fprintf(pargs.output_file, ";:INVALID:"); \
-        }                                             \
-    }
+event_handler_t*
+collapsed_stack_event_handler_new(void);
 
-#define emit_gc()                                \
-    {                                            \
-        if (pargs.binary) {                      \
-            mojo_event(MOJO_GC);                 \
-        } else {                                 \
-            fprintf(pargs.output_file, ";:GC:"); \
-        }                                        \
-    }
+event_handler_t*
+mojo_event_handler_new(void);
 
-#define emit_stack(format, pid, iid, tid, ...)                               \
-    {                                                                        \
-        if (pargs.binary) {                                                  \
-            mojo_stack(pid, iid, tid);                                       \
-        } else {                                                             \
-            fprintfp(pargs.output_file, format, pid, iid, tid, __VA_ARGS__); \
-        }                                                                    \
-    }
-
-#define emit_frame_ref(format, frame)                                                   \
-    {                                                                                   \
-        if (pargs.binary) {                                                             \
-            mojo_frame_ref(frame);                                                      \
-        } else {                                                                        \
-            fprintfp(                                                                   \
-                pargs.output_file, format, frame->filename,                             \
-                frame->scope == UNKNOWN_SCOPE ? "<unknown>" : frame->scope, frame->line \
-            );                                                                          \
-        }                                                                               \
-    }
-
-#define emit_time_metric(value)                                      \
-    {                                                                \
-        if (pargs.binary) {                                          \
-            mojo_metric_time(value);                                 \
-        } else {                                                     \
-            fprintf(pargs.output_file, " " TIME_METRIC "\n", value); \
-        }                                                            \
-    }
-
-#define emit_memory_metric(value)                                   \
-    {                                                               \
-        if (pargs.binary) {                                         \
-            mojo_metric_memory(value);                              \
-        } else {                                                    \
-            fprintf(pargs.output_file, " " MEM_METRIC "\n", value); \
-        }                                                           \
-    }
-
-#define emit_full_metrics(time, idle, memory)                                                                     \
-    {                                                                                                             \
-        if (pargs.binary) {                                                                                       \
-            mojo_metric_time(time);                                                                               \
-            if (idle) {                                                                                           \
-                mojo_event(MOJO_IDLE);                                                                            \
-            }                                                                                                     \
-            mojo_metric_memory(memory);                                                                           \
-        } else {                                                                                                  \
-            fprintf(                                                                                              \
-                pargs.output_file, " " TIME_METRIC METRIC_SEP IDLE_METRIC METRIC_SEP MEM_METRIC "\n", time, idle, \
-                memory                                                                                            \
-            );                                                                                                    \
-        }                                                                                                         \
-    }
-
-#ifdef NATIVE
-
-#define emit_kernel_frame(format, scope)                \
-    {                                                   \
-        if (pargs.binary) {                             \
-            mojo_frame_kernel(scope);                   \
-        } else {                                        \
-            fprintfp(pargs.output_file, format, scope); \
-        }                                               \
-    }
-
-#endif // NATIVE
-
-#ifdef DEBUG
-
-#define emit_frames_left(n)                                      \
-    {                                                            \
-        if (!pargs.binary) {                                     \
-            fprintf(pargs.output_file, ";:%zd FRAMES LEFT:", n); \
-        }                                                        \
-    }
-
-#endif // DEBUG
-
-#endif // EVENTS_H
+event_handler_t*
+where_event_handler_new(void);

--- a/src/events.h
+++ b/src/events.h
@@ -100,16 +100,16 @@ event_handler__emit_stack_begin(sample_t* sample) {
 }
 
 static inline void
-event_handler__emit_metadata(char* key, char* value, ...) {
+event_handler__emit_metadata(char* key, char* fmt, ...) {
     if (!isvalid(event_handler))
         return; // GCOV_EXCL_LINE
 
     va_list args;
-    va_start(args, value);
+    va_start(args, fmt);
 
     event_handler_metadata_t handler = event_handler->spec.emit_metadata;
     if (isvalid(handler))
-        handler(event_handler, key, value, args);
+        handler(event_handler, key, fmt, args);
 
     va_end(args);
 }

--- a/src/frame.h
+++ b/src/frame.h
@@ -23,16 +23,17 @@
 #pragma once
 
 #include "cache.h"
+#include "events.h"
 #include "resources.h"
 
 typedef struct {
-    key_dt       key;
-    char*        filename;
-    char*        scope;
-    unsigned int line;
-    unsigned int line_end;
-    unsigned int column;
-    unsigned int column_end;
+    key_dt           key;
+    cached_string_t* filename;
+    cached_string_t* scope;
+    unsigned int     line;
+    unsigned int     line_end;
+    unsigned int     column;
+    unsigned int     column_end;
 } frame_t;
 
 typedef struct {
@@ -44,8 +45,8 @@ typedef struct {
 // ----------------------------------------------------------------------------
 static inline frame_t*
 frame_new(
-    key_dt key, char* filename, char* scope, unsigned int line, unsigned int line_end, unsigned int column,
-    unsigned int column_end
+    key_dt key, cached_string_t* filename, cached_string_t* scope, unsigned int line, unsigned int line_end,
+    unsigned int column, unsigned int column_end
 ) {
     frame_t* frame = (frame_t*)malloc(sizeof(frame_t));
     if (!isvalid(frame)) {
@@ -114,38 +115,40 @@ _frame_from_code_raddr(py_proc_t* py_proc, void* code_raddr, int lasti, python_v
 
     lru_cache_t* cache = py_proc->string_cache;
 
-    key_dt string_key = py_string_key(code, o_filename);
-    char*  filename   = (char*)lru_cache__maybe_hit(cache, string_key);
+    key_dt           string_key = py_string_key(code, o_filename);
+    cached_string_t* filename   = (cached_string_t*)lru_cache__maybe_hit(cache, string_key);
     if (!isvalid(filename)) {
-        filename = _code__get_filename(&code, pref, py_v);
-        if (!isvalid(filename)) {
+        char* filename_value = _code__get_filename(&code, pref, py_v);
+        if (!isvalid(filename_value)) {
             log_ie("Cannot get file name from PyCodeObject");
             return NULL;
         }
-        lru_cache__store(cache, string_key, filename);
-        if (pargs.binary) {
-            mojo_string_event(string_key, filename);
+        filename = cached_string_new(string_key, filename_value);
+        if (!isvalid(filename)) {
+            log_ie("Cannot create cached string for file name");
+            return NULL;
         }
-    }
-    if (pargs.binary) {
-        filename = (char*)string_key;
+        lru_cache__store(cache, string_key, filename);
+
+        event_handler__emit_new_string(filename);
     }
 
-    string_key  = V_MIN(3, 11) ? py_string_key(code, o_qualname) : py_string_key(code, o_name);
-    char* scope = (char*)lru_cache__maybe_hit(cache, string_key);
+    string_key             = V_MIN(3, 11) ? py_string_key(code, o_qualname) : py_string_key(code, o_name);
+    cached_string_t* scope = (cached_string_t*)lru_cache__maybe_hit(cache, string_key);
     if (!isvalid(scope)) {
-        scope = V_MIN(3, 11) ? _code__get_qualname(&code, pref, py_v) : _code__get_name(&code, pref, py_v);
-        if (!isvalid(scope)) {
+        char* scope_value = V_MIN(3, 11) ? _code__get_qualname(&code, pref, py_v) : _code__get_name(&code, pref, py_v);
+        if (!isvalid(scope_value)) {
             log_ie("Cannot get scope name from PyCodeObject");
             return NULL;
         }
-        lru_cache__store(cache, string_key, scope);
-        if (pargs.binary) {
-            mojo_string_event(string_key, scope);
+        scope = cached_string_new(string_key, scope_value);
+        if (!isvalid(scope)) {
+            log_ie("Cannot create cached string for scope name");
+            return NULL;
         }
-    }
-    if (pargs.binary) {
-        scope = (char*)string_key;
+        lru_cache__store(cache, string_key, scope);
+
+        event_handler__emit_new_string(scope);
     }
 
     ssize_t len = 0;

--- a/src/frame.h
+++ b/src/frame.h
@@ -24,6 +24,7 @@
 
 #include "cache.h"
 #include "events.h"
+#include "py_string.h"
 #include "resources.h"
 
 typedef struct {

--- a/src/hints.h
+++ b/src/hints.h
@@ -49,6 +49,4 @@
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #endif
 
-#define UNKNOWN_SCOPE ((char*)1)
-
 #endif

--- a/src/linux/addr2line.h
+++ b/src/linux/addr2line.h
@@ -35,6 +35,7 @@
 #endif
 
 #include "../logging.h"
+#include "../py_string.h"
 #include "../stack.h"
 
 static asymbol** syms; /* Symbol table.  */
@@ -207,9 +208,11 @@ get_native_frame(const char* file_name, bfd_vma addr, key_dt frame_key) {
     free(syms);
     syms = NULL;
 
-    frame_t* frame = isvalid(filename) && isvalid(name)
-                       ? frame_new(frame_key, strdup(filename), strdup(name), line, 0, 0, 0)
-                       : NULL;
+    frame_t* frame = isvalid(filename) && isvalid(name) ? frame_new(
+                                                              frame_key, cached_string_new(0, (char*)filename),
+                                                              cached_string_new(0, (char*)name), line, 0, 0, 0
+                                                          )
+                                                        : NULL;
 
     bfd_close(abfd);
 

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -591,7 +591,9 @@ _py_proc__get_vm_maps(py_proc_t* self) {
         } else {
             // We print the maps instead so that we can resolve them later and use
             // the CPU more efficiently to collect samples.
-            emit_metadata("map", "%zx-%zx %s", (addr_t)m->address, ((addr_t)m->address) + m->size, m->pathname);
+            event_handler__emit_metadata(
+                "map", "%zx-%zx %s", (addr_t)m->address, ((addr_t)m->address) + m->size, m->pathname
+            );
         }
     }
 

--- a/src/linux/py_thread.h
+++ b/src/linux/py_thread.h
@@ -34,8 +34,14 @@
 #include "../resources.h"
 
 // ----------------------------------------------------------------------------
-static int
-_py_thread__is_idle(py_thread_t* self) {
+int
+py_thread__is_idle(py_thread_t* self) {
+#ifdef NATIVE
+    size_t index  = self->tid >> 3;
+    int    offset = self->tid & 7;
+
+    return _tids_idle[index] & (1 << offset);
+#else
     char file_name[64];
     char buffer[2048] = "";
 
@@ -63,4 +69,5 @@ _py_thread__is_idle(py_thread_t* self) {
         p++;
 
     return (*p != 'R');
+#endif
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -211,23 +211,23 @@ logger_close(void) {
 
 void
 log_meta_header(void) {
-    emit_metadata("austin", VERSION);
-    emit_metadata("interval", "%lu", pargs.t_sampling_interval);
+    event_handler__emit_metadata("austin", VERSION);
+    event_handler__emit_metadata("interval", MICROSECONDS_FMT, pargs.t_sampling_interval);
 
     if (pargs.full) {
-        emit_metadata("mode", "full");
+        event_handler__emit_metadata("mode", "full");
     } else if (pargs.memory) {
-        emit_metadata("mode", "memory");
+        event_handler__emit_metadata("mode", "memory");
     } else if (pargs.sleepless) {
-        emit_metadata("mode", "cpu");
+        event_handler__emit_metadata("mode", "cpu");
     } else {
-        emit_metadata("mode", "wall");
+        event_handler__emit_metadata("mode", "wall");
     }
 
     if (pargs.memory || pargs.full) {
-        emit_metadata("memory", MEM_VALUE, get_total_memory());
+        event_handler__emit_metadata("memory", MEM_VALUE, get_total_memory());
     }
     if (pargs.children) {
-        emit_metadata("multiprocess", "on");
+        event_handler__emit_metadata("multiprocess", "on");
     }
 }

--- a/src/mac/py_thread.h
+++ b/src/mac/py_thread.h
@@ -20,7 +20,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifdef PY_THREAD_C
+#pragma once
 
 #include <libproc.h>
 
@@ -71,8 +71,8 @@ _infer_thread_id_offset(py_thread_t* py_thread) {
 }
 
 // ----------------------------------------------------------------------------
-static int
-_py_thread__is_idle(py_thread_t* self) {
+int
+py_thread__is_idle(py_thread_t* self) {
     if (unlikely(_silly_offset == 0)) {
         _infer_thread_id_offset(self);
     }
@@ -89,5 +89,3 @@ _py_thread__is_idle(py_thread_t* self) {
 
     return ti.pth_run_state != TH_STATE_RUNNING;
 }
-
-#endif

--- a/src/mojo.h
+++ b/src/mojo.h
@@ -72,10 +72,6 @@ typedef unsigned long long mojo_int_t;
     fputs(string, pargs.output_file); \
     fputc('\0', pargs.output_file);
 
-#define mojo_fstring(...)                    \
-    fprintf(pargs.output_file, __VA_ARGS__); \
-    fputc('\0', pargs.output_file);
-
 static inline void
 mojo_integer(mojo_int_t integer, int sign) {
     unsigned char byte = integer & 0x3f;
@@ -112,27 +108,6 @@ mojo_integer(mojo_int_t integer, int sign) {
         mojo_integer(MOJO_VERSION, 0);   \
         fflush(pargs.output_file);       \
     }
-
-#define mojo_metadata(label, ...) \
-    mojo_event(MOJO_METADATA);    \
-    mojo_string(label);           \
-    mojo_fstring(__VA_ARGS__);
-
-#define mojo_stack(pid, iid, tid)  \
-    mojo_event(MOJO_STACK);        \
-    mojo_integer(pid, 0);          \
-    mojo_integer(iid, 0);          \
-    mojo_fstring(FORMAT_TID, tid);
-
-#define mojo_frame(frame)               \
-    mojo_event(MOJO_FRAME);             \
-    mojo_integer(frame->key, 0);        \
-    mojo_ref(frame->filename);          \
-    mojo_ref(frame->scope);             \
-    mojo_integer(frame->line, 0);       \
-    mojo_integer(frame->line_end, 0);   \
-    mojo_integer(frame->column, 0);     \
-    mojo_integer(frame->column_end, 0);
 
 #define mojo_frame_ref(frame)    \
     mojo_event(MOJO_FRAME_REF);  \

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -744,7 +744,7 @@ py_proc_new(int child) {
     py_proc->frame_cache->name = "frame cache";
 #endif
 
-    py_proc->string_cache = lru_cache_new(MAX_STRING_CACHE_SIZE, (void (*)(value_t))free);
+    py_proc->string_cache = lru_cache_new(MAX_STRING_CACHE_SIZE, (void (*)(value_t))cached_string_destroy);
     if (!isvalid(py_proc->string_cache)) {
         log_e("Failed to allocate string cache");
         goto error;
@@ -1034,16 +1034,16 @@ _py_proc__get_memory_delta(py_proc_t* self) {
 
 // ----------------------------------------------------------------------------
 int
-py_proc__is_gc_collecting(py_proc_t* self) {
+py_proc__get_gc_state(py_proc_t* self) {
     if (!isvalid(self->gc_state_raddr))
-        return FALSE;
+        return GC_STATE_UNKNOWN;
 
     V_DESC(self->py_v);
 
     GCRuntimeState gc_state;
     if (fail(py_proc__get_type(self, self->gc_state_raddr, gc_state))) {
         log_d("Failed to get GC runtime state");
-        return -1;
+        return GC_STATE_UNKNOWN;
     }
 
     return V_FIELD(int, gc_state, py_gc, o_collecting);
@@ -1168,6 +1168,9 @@ _py_proc__sample_interpreter(py_proc_t* self, PyInterpreterState* is, microsecon
 
     int64_t interp_id = V_FIELD_PTR(int64_t, is, py_is, o_id);
     do {
+        if (py_thread.invalid)
+            continue;
+
         if (pargs.memory) {
             mem_delta = 0;
             if (V_MAX(3, 11) && self->symbols[DYNSYM_RUNTIME] != NULL && current_thread == (void*)-1) {
@@ -1180,12 +1183,52 @@ _py_proc__sample_interpreter(py_proc_t* self, PyInterpreterState* is, microsecon
                 mem_delta = _py_proc__get_memory_delta(self);
                 log_t("Thread %lx holds the GIL", py_thread.tid);
             }
+            if (!pargs.full && mem_delta == 0)
+                continue;
         }
 
-        // In this call, the 64bit time_delta may be truncated to 32bit. That
-        // is ok most of the time as we expect the delta to express less than
-        // an hour.
-        py_thread__emit_collapsed_stack(&py_thread, interp_id, time_delta, mem_delta);
+        if (mem_delta == 0 && time_delta == 0)
+            continue;
+
+        int is_idle = FALSE;
+        if (pargs.full || pargs.sleepless || unlikely(pargs.where)) {
+            is_idle = py_thread__is_idle(&py_thread);
+            if (!pargs.full && is_idle && pargs.sleepless) {
+                continue;
+            }
+        }
+
+        gc_state_t gc = GC_STATE_UNKNOWN;
+        if (pargs.gc) {
+            gc = py_proc__get_gc_state(self);
+            if (gc == GC_STATE_COLLECTING) {
+                stats_gc_time(time_delta);
+            }
+        }
+
+        sample_t sample = {
+            .pid      = self->pid,
+            .tid      = py_thread.tid,
+            .iid      = interp_id,
+            .time     = time_delta,
+            .memory   = mem_delta,
+            .is_idle  = is_idle,
+            .gc_state = gc,
+        };
+        event_handler__emit_stack_begin(&sample);
+
+        py_thread__unwind(&py_thread);
+
+#ifdef NATIVE
+        if (V_MIN(3, 11) && V_MAX(3, 12)) {
+            // We expect a CFrame to sit at the top of the stack
+            if (!stack_is_empty() && stack_top() != CFRAME_MAGIC) {
+                log_e("Invalid resolved Python stack");
+            }
+        }
+#endif
+
+        event_handler__emit_stack_end();
     } while (success(py_thread__next(&py_thread)));
 
     if (austin_errno != ETHREADNONEXT) {
@@ -1257,12 +1300,12 @@ py_proc__log_version(py_proc_t* self, int parent) {
     if (pargs.pipe) {
         if (patch == 0xFF) {
             if (parent) {
-                emit_metadata("python", "%d.%d.?", major, minor);
+                event_handler__emit_metadata("python", "%d.%d.?", major, minor);
             } else
                 log_m("# python: %d.%d.?", major, minor);
         } else {
             if (parent) {
-                emit_metadata("python", "%d.%d.%d", major, minor, patch);
+                event_handler__emit_metadata("python", "%d.%d.%d", major, minor, patch);
             } else
                 log_m("# python: %d.%d.%d", major, minor, patch);
         }

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1036,14 +1036,14 @@ _py_proc__get_memory_delta(py_proc_t* self) {
 int
 py_proc__get_gc_state(py_proc_t* self) {
     if (!isvalid(self->gc_state_raddr))
-        return GC_STATE_UNKNOWN;
+        return GC_STATE_UNKNOWN; // GCOV_EXCL_LINE
 
     V_DESC(self->py_v);
 
     GCRuntimeState gc_state;
     if (fail(py_proc__get_type(self, self->gc_state_raddr, gc_state))) {
         log_d("Failed to get GC runtime state");
-        return GC_STATE_UNKNOWN;
+        return GC_STATE_UNKNOWN; // GCOV_EXCL_LINE
     }
 
     return V_FIELD(int, gc_state, py_gc, o_collecting);

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cache.h"
 #include "hints.h"
 #include "logging.h"
 #include "mem.h"
@@ -36,6 +37,35 @@
 #define MAGIC_TINY                7
 #define MAGIC_BIG                 1000003
 #define p_ascii_data(raddr, size) (raddr + size)
+
+#define UNKNOWN_SCOPE ((cached_string_t*)1)
+
+// ----------------------------------------------------------------------------
+typedef struct _string {
+    key_dt key;
+    char*  value;
+} cached_string_t;
+
+static inline cached_string_t*
+cached_string_new(key_dt key, char* value) {
+    cached_string_t* cached_string = (cached_string_t*)malloc(sizeof(cached_string_t));
+    if (!isvalid(cached_string)) {
+        return NULL;
+    }
+
+    cached_string->key   = key;
+    cached_string->value = value;
+
+    return cached_string;
+}
+
+static inline void
+cached_string_destroy(cached_string_t* cached_string) {
+    if (isvalid(cached_string)) {
+        sfree(cached_string->value);
+        sfree(cached_string);
+    }
+}
 
 // ----------------------------------------------------------------------------
 static inline long

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -50,7 +50,7 @@ static inline cached_string_t*
 cached_string_new(key_dt key, char* value) {
     cached_string_t* cached_string = (cached_string_t*)malloc(sizeof(cached_string_t));
     if (!isvalid(cached_string)) {
-        return NULL;
+        return NULL; // GCOV_EXCL_LINE
     }
 
     cached_string->key   = key;

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -613,9 +613,9 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                         if (unw_get_proc_name(&cursor, _native_buf, MAXLEN, &offset) == 0) {
                             scope = cached_string_new(scope_key, strdup(_native_buf));
                             if (!isvalid(scope)) {
-                                log_ie("Failed to create scope string");
+                                log_ie("Failed to create scope string"); // GCOV_EXCL_START
                                 set_error(ETHREAD);
-                                FAIL;
+                                FAIL; // GCOV_EXCL_STOP
                             }
                             lru_cache__store(string_cache, scope_key, (value_t)scope);
                             event_handler__emit_new_string(scope);
@@ -630,9 +630,9 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                 if (isvalid(range)) { // For now this is only relevant in `where` mode
                     filename = cached_string_new((key_dt)pc, range->name);
                     if (!isvalid(filename)) {
-                        log_ie("Failed to create filename string");
+                        log_ie("Failed to create filename string"); // GCOV_EXCL_START
                         set_error(ETHREAD);
-                        FAIL;
+                        FAIL; // GCOV_EXCL_STOP
                     }
                 } else {
                     // The program counter carries information about the file name *and*
@@ -647,9 +647,9 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                         sprintf(_native_buf, "native@%" PRIxPTR, pc);
                         filename = cached_string_new(filename_key, strdup(_native_buf));
                         if (!isvalid(filename)) {
-                            log_ie("Failed to create filename string");
+                            log_ie("Failed to create filename string"); // GCOV_EXCL_START
                             set_error(ETHREAD);
-                            FAIL;
+                            FAIL; // GCOV_EXCL_STOP
                         }
                         lru_cache__store(string_cache, filename_key, (value_t)filename);
                         event_handler__emit_new_string(filename);

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -44,8 +44,23 @@
 #include "heap.h"
 #include "py_thread.h"
 
+// ---- PRIVATE ---------------------------------------------------------------
+
+#define NULL_HEAP ((_heap_t){NULL, 0})
+
+static _heap_t _frames      = NULL_HEAP;
+static _heap_t _frames_heap = NULL_HEAP;
+
+static size_t max_pid = 0;
+#ifdef NATIVE
+static void**         _tids      = NULL;
+static unsigned char* _tids_idle = NULL;
+static unsigned char* _tids_int  = NULL;
+static char**         _kstacks   = NULL;
+#endif
+
 // ----------------------------------------------------------------------------
-// -- Platform-dependent implementations of _py_thread__is_idle
+// -- Platform-dependent implementations of py_thread__is_idle
 // ----------------------------------------------------------------------------
 
 #if defined(PL_LINUX)
@@ -63,21 +78,6 @@
 
 #include "mac/py_thread.h"
 
-#endif
-
-// ---- PRIVATE ---------------------------------------------------------------
-
-#define NULL_HEAP ((_heap_t){NULL, 0})
-
-static _heap_t _frames      = NULL_HEAP;
-static _heap_t _frames_heap = NULL_HEAP;
-
-static size_t max_pid = 0;
-#ifdef NATIVE
-static void**         _tids      = NULL;
-static unsigned char* _tids_idle = NULL;
-static unsigned char* _tids_int  = NULL;
-static char**         _kstacks   = NULL;
 #endif
 
 // ----------------------------------------------------------------------------
@@ -158,9 +158,8 @@ _py_thread__resolve_py_stack(py_thread_t* self) {
                 FAIL;
             }
             lru_cache__store(cache, frame_key, frame);
-            if (pargs.binary) {
-                mojo_frame(frame);
-            }
+
+            event_handler__emit_new_frame(frame);
         }
 
         stack_set(i, frame);
@@ -436,7 +435,7 @@ py_thread__set_idle(py_thread_t* self) {
         FAIL;
     }
 
-    if (_py_thread__is_idle(self)) {
+    if (py_thread__is_idle(self)) {
         _tids_idle[index] |= bit;
     } else {
         _tids_idle[index] &= ~bit;
@@ -586,9 +585,9 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
 
         frame_t* frame = lru_cache__maybe_hit(cache, frame_key);
         if (!isvalid(frame)) {
-            char*       scope    = NULL;
-            char*       filename = NULL;
-            vm_range_t* range    = NULL;
+            cached_string_t* scope    = NULL;
+            cached_string_t* filename = NULL;
+            vm_range_t*      range    = NULL;
             if (pargs.where) {
                 range = vm_range_tree__find(self->proc->maps_tree, pc);
 // TODO: A failed attempt to find a range is an indication that we need
@@ -612,24 +611,30 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                     scope            = lru_cache__maybe_hit(string_cache, scope_key);
                     if (!isvalid(scope)) {
                         if (unw_get_proc_name(&cursor, _native_buf, MAXLEN, &offset) == 0) {
-                            scope = strdup(_native_buf);
-                            lru_cache__store(string_cache, scope_key, scope);
-                            if (pargs.binary) {
-                                mojo_string_event(scope_key, scope);
+                            scope = cached_string_new(scope_key, strdup(_native_buf));
+                            if (!isvalid(scope)) {
+                                log_ie("Failed to create scope string");
+                                set_error(ETHREAD);
+                                FAIL;
                             }
+                            lru_cache__store(string_cache, scope_key, (value_t)scope);
+                            event_handler__emit_new_string(scope);
                         }
-                    }
-                    if (pargs.binary && isvalid(scope)) {
-                        scope = (char*)scope_key;
                     }
                 }
                 if (!isvalid(scope)) {
                     scope  = UNKNOWN_SCOPE;
                     offset = 0;
                 }
-                if (isvalid(range)) // For now this is only relevant in `where` mode
-                    filename = strdup(range->name);
-                else {
+
+                if (isvalid(range)) { // For now this is only relevant in `where` mode
+                    filename = cached_string_new((key_dt)pc, range->name);
+                    if (!isvalid(filename)) {
+                        log_ie("Failed to create filename string");
+                        set_error(ETHREAD);
+                        FAIL;
+                    }
+                } else {
                     // The program counter carries information about the file name *and*
                     // the line number. Given that we don't resolve the file name using
                     // memory ranges at runtime for performance reasons, we need to store
@@ -640,14 +645,14 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                     filename            = lru_cache__maybe_hit(string_cache, filename_key);
                     if (!isvalid(filename)) {
                         sprintf(_native_buf, "native@%" PRIxPTR, pc);
-                        filename = strdup(_native_buf);
-                        lru_cache__store(string_cache, (key_dt)pc, filename);
-                        if (pargs.binary) {
-                            mojo_string_event(filename_key, filename);
+                        filename = cached_string_new(filename_key, strdup(_native_buf));
+                        if (!isvalid(filename)) {
+                            log_ie("Failed to create filename string");
+                            set_error(ETHREAD);
+                            FAIL;
                         }
-                    }
-                    if (pargs.binary) {
-                        filename = (char*)filename_key;
+                        lru_cache__store(string_cache, filename_key, (value_t)filename);
+                        event_handler__emit_new_string(filename);
                     }
                 }
 
@@ -660,9 +665,8 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
             }
 
             lru_cache__store(cache, frame_key, (value_t)frame);
-            if (pargs.binary) {
-                mojo_frame(frame);
-            }
+
+            event_handler__emit_new_frame(frame);
         }
 
         stack_native_push(frame);
@@ -809,38 +813,7 @@ py_thread__next(py_thread_t* self) {
 
 // ----------------------------------------------------------------------------
 void
-py_thread__emit_collapsed_stack(py_thread_t* self, int64_t interp_id, ctime_t time_delta, ssize_t mem_delta) {
-    if (!pargs.full && pargs.memory && mem_delta == 0)
-        return;
-
-    if (self->invalid)
-        return;
-
-    if (mem_delta == 0 && time_delta == 0)
-        return;
-
-    int is_idle = FALSE;
-    if (pargs.full || pargs.sleepless || unlikely(pargs.where)) {
-#ifdef NATIVE
-        size_t index  = self->tid >> 3;
-        int    offset = self->tid & 7;
-
-        is_idle = _tids_idle[index] & (1 << offset);
-#else
-        is_idle = _py_thread__is_idle(self);
-#endif
-        if (!pargs.full && is_idle && pargs.sleepless) {
-            return;
-        }
-    }
-
-    // Group entries by thread.
-    emit_stack(
-        pargs.head_format, self->proc->pid, interp_id, self->tid,
-        // These are relevant only in `where` mode
-        is_idle ? "💤" : "🚀", self->proc->child ? "🧒" : ""
-    );
-
+py_thread__unwind(py_thread_t* self) {
     int error = FALSE;
 
 #ifdef NATIVE
@@ -853,7 +826,6 @@ py_thread__emit_collapsed_stack(py_thread_t* self, int64_t interp_id, ctime_t ti
         _py_thread__unwind_kernel_frame_stack(self);
     }
     if (fail(_py_thread__unwind_native_frame_stack(self))) {
-        emit_invalid_frame();
         error = TRUE;
     }
 
@@ -866,103 +838,20 @@ py_thread__emit_collapsed_stack(py_thread_t* self, int64_t interp_id, ctime_t ti
     if (isvalid(self->top_frame)) {
         if (V_MIN(3, 13)) {
             if (fail(_py_thread__unwind_iframe_stack(self, self->top_frame))) {
-                emit_invalid_frame();
                 error = TRUE;
             }
         } else if (V_MIN(3, 11)) {
             if (fail(_py_thread__unwind_cframe_stack(self))) {
-                emit_invalid_frame();
                 error = TRUE;
             }
         } else {
             if (fail(_py_thread__unwind_frame_stack(self))) {
-                emit_invalid_frame();
                 error = TRUE;
             }
         }
 
         if (fail(_py_thread__resolve_py_stack(self))) {
-            emit_invalid_frame();
             error = TRUE;
-        }
-    }
-
-#ifdef NATIVE
-
-    if (V_MIN(3, 11)) {
-        // We expect a CFrame to sit at the top of the stack
-        if (!stack_is_empty() && stack_pop() != CFRAME_MAGIC) {
-            log_e("Invalid resolved Python stack");
-        }
-    }
-    while (!stack_native_is_empty()) {
-        frame_t* native_frame = stack_native_pop();
-        if (!isvalid(native_frame)) {
-            log_e("Invalid native frame");
-            break;
-        }
-        char* scope = pargs.binary ? lru_cache__maybe_hit(self->proc->string_cache, (key_dt)native_frame->scope)
-                                   : native_frame->scope;
-        if (!isvalid(scope)) {
-            scope = UNKNOWN_SCOPE;
-        }
-
-        int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope, "PyEval_EvalFrameDefault"));
-        if (!stack_is_empty() && is_frame_eval) {
-            // TODO: if the py stack is empty we have a mismatch.
-            frame_t* frame = stack_pop();
-            if (V_MIN(3, 11)) {
-                while (frame != CFRAME_MAGIC) {
-                    emit_frame_ref(pargs.format, frame);
-
-                    if (stack_is_empty())
-                        break;
-
-                    frame = stack_pop();
-                }
-            } else {
-                emit_frame_ref(pargs.format, frame);
-            }
-        } else {
-            emit_frame_ref(pargs.native_format, native_frame);
-        }
-    }
-    if (!stack_is_empty()) {
-        log_d("Stack mismatch: left with %d Python frames after interleaving", stack_pointer());
-        set_error(ETHREADINV);
-#ifdef DEBUG
-        emit_frames_left(stack_pointer());
-#endif
-    }
-    while (!stack_kernel_is_empty()) {
-        char* scope = stack_kernel_pop();
-        emit_kernel_frame(pargs.kernel_format, scope);
-        free(scope);
-    }
-
-#else
-    while (!stack_is_empty()) {
-        frame_t* frame = stack_pop();
-        emit_frame_ref(pargs.format, frame);
-    }
-#endif
-
-    if (pargs.gc && py_proc__is_gc_collecting(self->proc) == TRUE) {
-        emit_gc();
-        stats_gc_time(time_delta);
-    }
-
-    if (unlikely(pargs.where))
-        return;
-
-    // Finish off sample with the metric(s)
-    if (pargs.full) {
-        emit_full_metrics(time_delta, !!is_idle, mem_delta);
-    } else {
-        if (pargs.memory) {
-            emit_memory_metric(mem_delta);
-        } else {
-            emit_time_metric(time_delta);
         }
     }
 

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -20,8 +20,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef PY_THREAD_H
-#define PY_THREAD_H
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -84,15 +83,12 @@ int
 py_thread__next(py_thread_t*);
 
 /**
- * Print the frame stack using the collapsed format.
+ * Unwind the thread.
  *
  * @param  py_thread_t  self.
- * @param  int64_t      the interpreter ID.
- * @param  ctime_t      the time delta.
- * @param  ssize_t      the memory delta.
  */
 void
-py_thread__emit_collapsed_stack(py_thread_t*, int64_t, ctime_t, ssize_t);
+py_thread__unwind(py_thread_t*);
 
 /**
  * Allocate memory for dumping the thread data.
@@ -122,4 +118,5 @@ int
 py_thread__save_kernel_stack(py_thread_t*);
 #endif
 
-#endif // PY_THREAD_H
+int
+py_thread__is_idle(py_thread_t*);

--- a/src/resources.h
+++ b/src/resources.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <stdio.h>
+
 #include "hints.h"
 #include "platform.h"
 

--- a/src/stack.c
+++ b/src/stack.c
@@ -39,11 +39,11 @@
 int
 stack_allocate(size_t size) {
     if (isvalid(_stack))
-        SUCCESS;
+        SUCCESS; // GCOV_EXCL_LINE
 
     _stack = (stack_dt*)calloc(1, sizeof(stack_dt));
     if (!isvalid(_stack))
-        FAIL;
+        FAIL; // GCOV_EXCL_LINE
 
     _stack->size    = size;
     _stack->base    = (frame_t**)calloc(size, sizeof(frame_t*));
@@ -59,7 +59,7 @@ stack_allocate(size_t size) {
 void
 stack_deallocate(void) {
     if (!isvalid(_stack))
-        return;
+        return; // GCOV_EXCL_LINE
 
     free(_stack->base);
     free(_stack->py_base);

--- a/src/stack.c
+++ b/src/stack.c
@@ -1,0 +1,72 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018-2021 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#define STACK_C
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "cache.h"
+#include "frame.h"
+#include "hints.h"
+#include "mojo.h"
+#include "platform.h"
+#include "py_proc.h"
+#include "py_string.h"
+#include "python/misc.h"
+#include "stack.h"
+#include "version.h"
+
+int
+stack_allocate(size_t size) {
+    if (isvalid(_stack))
+        SUCCESS;
+
+    _stack = (stack_dt*)calloc(1, sizeof(stack_dt));
+    if (!isvalid(_stack))
+        FAIL;
+
+    _stack->size    = size;
+    _stack->base    = (frame_t**)calloc(size, sizeof(frame_t*));
+    _stack->py_base = (py_frame_t*)calloc(size, sizeof(py_frame_t));
+#ifdef NATIVE
+    _stack->native_base = (frame_t**)calloc(size, sizeof(frame_t*));
+    _stack->kernel_base = (char**)calloc(size, sizeof(char*));
+#endif
+
+    SUCCESS;
+}
+
+void
+stack_deallocate(void) {
+    if (!isvalid(_stack))
+        return;
+
+    free(_stack->base);
+    free(_stack->py_base);
+#ifdef NATIVE
+    free(_stack->native_base);
+    free(_stack->kernel_base);
+#endif
+
+    free(_stack);
+}

--- a/src/stack.h
+++ b/src/stack.h
@@ -49,6 +49,8 @@ typedef struct {
 #endif
 } stack_dt;
 
+// Global stack pointer. This is a global variable that points to the allocated
+// memory for stack unwinding.
 #ifndef STACK_C
 extern
 #endif

--- a/src/stack.h
+++ b/src/stack.h
@@ -49,42 +49,16 @@ typedef struct {
 #endif
 } stack_dt;
 
-static stack_dt* _stack;
-
-static inline int
-stack_allocate(size_t size) {
-    if (isvalid(_stack))
-        SUCCESS;
-
-    _stack = (stack_dt*)calloc(1, sizeof(stack_dt));
-    if (!isvalid(_stack))
-        FAIL;
-
-    _stack->size    = size;
-    _stack->base    = (frame_t**)calloc(size, sizeof(frame_t*));
-    _stack->py_base = (py_frame_t*)calloc(size, sizeof(py_frame_t));
-#ifdef NATIVE
-    _stack->native_base = (frame_t**)calloc(size, sizeof(frame_t*));
-    _stack->kernel_base = (char**)calloc(size, sizeof(char*));
+#ifndef STACK_C
+extern
 #endif
+    stack_dt* _stack;
 
-    SUCCESS;
-}
+int
+stack_allocate(size_t size);
 
-static inline void
-stack_deallocate(void) {
-    if (!isvalid(_stack))
-        return;
-
-    free(_stack->base);
-    free(_stack->py_base);
-#ifdef NATIVE
-    free(_stack->native_base);
-    free(_stack->kernel_base);
-#endif
-
-    free(_stack);
-}
+void
+stack_deallocate(void);
 
 static inline int
 stack_has_cycle(void) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -147,14 +147,14 @@ stats_log_metrics() {
             goto release;
         }
 
-        emit_metadata(
+        event_handler__emit_metadata(
             "sampling", MICROSECONDS_FMT "," MICROSECONDS_FMT "," MICROSECONDS_FMT, stats_get_min_sampling_time(),
             stats_get_avg_sampling_time(), stats_get_max_sampling_time()
         );
 
-        emit_metadata("saturation", "%ld/%ld", _long_cnt, _sample_cnt);
+        event_handler__emit_metadata("saturation", "%ld/%ld", _long_cnt, _sample_cnt);
 
-        emit_metadata("errors", "%ld/%ld", _error_cnt, _sample_cnt);
+        event_handler__emit_metadata("errors", "%ld/%ld", _error_cnt, _sample_cnt);
     } else {
         microseconds_t duration = stats_duration();
 

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -29,8 +29,8 @@ static PVOID _pi_buffer      = NULL;
 static ULONG _pi_buffer_size = 0;
 
 // ----------------------------------------------------------------------------
-static int
-_py_thread__is_idle(py_thread_t* self) {
+int
+py_thread__is_idle(py_thread_t* self) {
     ULONG    n;
     NTSTATUS status = NtQuerySystemInformation(SystemProcessInformation, _pi_buffer, _pi_buffer_size, &n);
     if (status == STATUS_INFO_LENGTH_MISMATCH) {
@@ -42,7 +42,7 @@ _py_thread__is_idle(py_thread_t* self) {
             return -1;
         }
         _pi_buffer = _new_buffer;
-        return _py_thread__is_idle(self);
+        return py_thread__is_idle(self);
     }
     if (status != STATUS_SUCCESS) {
         log_d("[NtQuerySystemInformation] Cannot get the status of running threads: %d.", status);

--- a/test/cunit/stats.py
+++ b/test/cunit/stats.py
@@ -8,7 +8,9 @@ CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 EXTRA_SOURCES = [
     SRC / "argparse.c",
+    SRC / "events.c",
     SRC / "logging.c",
+    SRC / "stack.c",
 ]
 
 sys.modules[__name__] = CModule.compile(


### PR DESCRIPTION
We improve separation of concerns by encapsulating the presentation logic into the event handlers. We remove the core of the output generation from the thread unwinding process to make smaller functions with clear responsibilities.