### PR TITLE
chore: add options to debug builds

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Compile Austin
         run: |
           autoreconf --install
-          ./configure --enable-debug-symbols=yes
+          ./configure --enable-debug=symbols
           make
 
       - name: Install runtime dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Compile Austin
         run: |
           autoreconf --install
-          ./configure --enable-debug-symbols=yes
+          ./configure --enable-debug
           make
 
       - uses: actions/upload-artifact@v4
@@ -510,7 +510,7 @@ jobs:
       - name: Compile Austin
         run: |
           autoreconf --install
-          ./configure --enable-debug-symbols=yes
+          ./configure --enable-debug=symbols
           make
 
       - name: Install runtime dependencies

--- a/configure.ac
+++ b/configure.ac
@@ -93,19 +93,32 @@ esac], [coverage=false])
 
 AM_CONDITIONAL([COVERAGE], [test x$coverage = xtrue])
 
-# Debug symbols
-AC_ARG_ENABLE([debug-symbols], [
-  --enable-debug-symbols    Include debug symbols], [
+# Debug
+AC_ARG_ENABLE([debug], [
+  --enable-debug    Enable debug build. To include only debug symbols use "symbols"
+], [
 case "${enableval}" in
+    symbols)
+        debugsymbols=true
+        debug=false
+        ;;
     yes)
         debugsymbols=true
+        debug=true
         AUSTINP_LDADD+=" -lm"
         ;;
-    no)  debugsymbols=false ;;
-    *) AC_MSG_ERROR([bad value ${enableval} for --enable-debug-symbols]) ;;
-esac], [debugsymbols=false])
+    no)
+        debugsymbols=false
+        debug=false
+        ;;
+    *) AC_MSG_ERROR([bad value ${enableval} for --enable-debug]) ;;
+esac], [
+    debugsymbols=false
+    debug=false
+])
 
 AM_CONDITIONAL([DEBUG_SYMBOLS], [test x$debugsymbols = xtrue])
+AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,11 +23,16 @@
 AM_CFLAGS = -I$(srcdir) -Wall -Werror -Wno-unused-command-line-argument -pthread
 OPT_FLAGS = -O3
 STRIP_FLAGS = -Os -s
+DEBUG_OPTS = 
 
 if DEBUG_SYMBOLS
-DEBUG_OPTS = -g -DDEBUG
-austin_LDADD = -lm
+DEBUG_OPTS += -g
 undefine STRIP_FLAGS
+endif
+
+if DEBUG
+DEBUG_OPTS += -DDEBUG
+austin_LDADD = -lm
 endif
 
 if COVERAGE


### PR DESCRIPTION
We change the debug build option to allow for more configuration options. In particular, we add the option to allow building with just debug symbols, or a full debug build that includes debug logs.

Resolves #265.