### PR TITLE
refactor: migrate to stdbool

### DIFF
--- a/src/argparse.c
+++ b/src/argparse.c
@@ -295,19 +295,19 @@ parse_opt(int key, char* arg, struct argp_state* state) {
         break;
 
     case 'b':
-        pargs.binary = 1;
+        pargs.binary = true;
         break;
 
     case 's':
-        pargs.sleepless = 1;
+        pargs.sleepless = true;
         break;
 
     case 'm':
-        pargs.memory = 1;
+        pargs.memory = true;
         break;
 
     case 'f':
-        pargs.full = 1;
+        pargs.full = true;
         break;
 
     case 'p':
@@ -321,7 +321,7 @@ parse_opt(int key, char* arg, struct argp_state* state) {
         break;
 
     case 'C':
-        pargs.children = 1;
+        pargs.children = true;
         break;
 
     case 'x':
@@ -330,11 +330,11 @@ parse_opt(int key, char* arg, struct argp_state* state) {
         break;
 
     case 'P':
-        pargs.pipe = 1;
+        pargs.pipe = true;
         break;
 
     case 'g':
-        pargs.gc = 1;
+        pargs.gc = true;
         break;
 
     case 'h':
@@ -347,13 +347,13 @@ parse_opt(int key, char* arg, struct argp_state* state) {
         if (str_to_num(arg, &l_pid) == 1 || l_pid <= 0)
             argp_error(state, "invalid PID");
         pargs.attach_pid = (pid_t)l_pid;
-        pargs.where      = TRUE;
+        pargs.where      = true;
 
         break;
 
 #ifdef NATIVE
     case 'k':
-        pargs.kernel = 1;
+        pargs.kernel = true;
         break;
 #endif
 
@@ -613,19 +613,19 @@ cb(const char opt, const char* arg, const int index) {
         break;
 
     case 'b':
-        pargs.binary = 1;
+        pargs.binary = true;
         break;
 
     case 's':
-        pargs.sleepless = 1;
+        pargs.sleepless = true;
         break;
 
     case 'm':
-        pargs.memory = 1;
+        pargs.memory = true;
         break;
 
     case 'f':
-        pargs.full = 1;
+        pargs.full = true;
         break;
 
     case 'p':
@@ -638,7 +638,7 @@ cb(const char opt, const char* arg, const int index) {
         if (str_to_num((char*)arg, (long*)&pargs.attach_pid) == 1 || pargs.attach_pid <= 0) {
             arg_error("invalid PID");
         }
-        pargs.where = TRUE;
+        pargs.where = true;
 
         break;
 
@@ -647,7 +647,7 @@ cb(const char opt, const char* arg, const int index) {
         break;
 
     case 'C':
-        pargs.children = 1;
+        pargs.children = true;
         break;
 
     case 'x':
@@ -657,11 +657,11 @@ cb(const char opt, const char* arg, const int index) {
         break;
 
     case 'P':
-        pargs.pipe = 1;
+        pargs.pipe = true;
         break;
 
     case 'g':
-        pargs.gc = 1;
+        pargs.gc = true;
         break;
 
     case 'h':
@@ -700,7 +700,7 @@ static inline void
 validate() {
     if (pargs.binary && pargs.where) {
         // silently ignore the binary option
-        pargs.binary = 0;
+        pargs.binary = false;
     }
 
     if (isvalid(pargs.output_filename)) {

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -34,20 +35,20 @@ typedef struct {
     ctime_t        timeout;
     pid_t          attach_pid;
     int            cmd_index;
-    int            where;
-    int            sleepless;
-    int            full;
-    int            memory;
-    int            binary;
+    bool           where;
+    bool           sleepless;
+    bool           full;
+    bool           memory;
+    bool           binary;
     FILE*          output_file;
     char*          output_filename;
-    int            children;
+    bool           children;
     ctime_t        exposure;
-    int            pipe;
-    int            gc;
+    bool           pipe;
+    bool           gc;
     size_t         heap;
 #ifdef NATIVE
-    int kernel;
+    bool kernel;
 #endif
 } parsed_args_t;
 

--- a/src/austin.c
+++ b/src/austin.c
@@ -24,6 +24,7 @@
 #define AUSTIN_C
 
 #include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -51,7 +52,7 @@
 
 // ---- SIGNAL HANDLING -------------------------------------------------------
 
-static int interrupt = FALSE;
+static int interrupt = 0;
 
 static void
 signal_callback_handler(int signum) {
@@ -70,12 +71,12 @@ do_single_process(py_proc_t* py_proc) {
     if (!pargs.where)
         log_meta_header();
 
-    py_proc__log_version(py_proc, TRUE);
+    py_proc__log_version(py_proc, true);
     if (!pargs.where)
         NL;
 
     if (pargs.exposure == 0) {
-        while (interrupt == FALSE) {
+        while (interrupt == false) {
             stopwatch_start();
 
             if (fail(py_proc__sample(py_proc)))
@@ -91,7 +92,7 @@ do_single_process(py_proc_t* py_proc) {
         if (!pargs.where && !pargs.pipe)
             log_m("🕑 Sampling for %d second%s", pargs.exposure, pargs.exposure != 1 ? "s" : "");
         microseconds_t end_time = gettime() + pargs.exposure * 1000000;
-        while (interrupt == FALSE) {
+        while (interrupt == false) {
             stopwatch_start();
 
             if (fail(py_proc__sample(py_proc)))
@@ -158,10 +159,10 @@ do_child_processes(py_proc_t* py_proc) {
             return;
         }
     } else {
-        py_proc__log_version(py_proc, TRUE);
+        py_proc__log_version(py_proc, true);
     }
 
-    if (!py_proc_list__is_empty(list) && interrupt == FALSE) {
+    if (!py_proc_list__is_empty(list) && interrupt == false) {
         if (!pargs.pipe) {
             log_m("");
             log_m("\033[1mChild processes\033[0m");
@@ -174,7 +175,7 @@ do_child_processes(py_proc_t* py_proc) {
     }
 
     if (pargs.exposure == 0) {
-        while (!py_proc_list__is_empty(list) && interrupt == FALSE) {
+        while (!py_proc_list__is_empty(list) && interrupt == false) {
 #ifndef NATIVE
             microseconds_t start_time = gettime();
 #endif
@@ -190,7 +191,7 @@ do_child_processes(py_proc_t* py_proc) {
         if (!pargs.pipe && !pargs.where)
             log_m("🕑 Sampling for %d second%s", pargs.exposure, pargs.exposure != 1 ? "s" : "");
         microseconds_t end_time = gettime() + pargs.exposure * 1000000;
-        while (!py_proc_list__is_empty(list) && interrupt == FALSE) {
+        while (!py_proc_list__is_empty(list) && interrupt == false) {
 #ifndef NATIVE
             microseconds_t start_time = gettime();
 #endif
@@ -317,7 +318,7 @@ main(int argc, char** argv) {
     }
     event_handler_install(handler);
 
-    py_proc = py_proc_new(FALSE);
+    py_proc = py_proc_new(false);
     if (!isvalid(py_proc)) {
         log_ie("Cannot create process");
         goto finally;
@@ -370,11 +371,11 @@ main(int argc, char** argv) {
         if (pargs.sleepless)
             log_w("The sleepless switch is redundant in full mode");
         log_i("Producing full set of metrics (time +mem -mem)");
-        pargs.memory = TRUE;
+        pargs.memory = true;
     } else if (pargs.memory) {
         if (pargs.sleepless)
             log_w("The sleepless switch is incompatible with memory mode.");
-        pargs.sleepless = FALSE;
+        pargs.sleepless = false;
     }
 
     // Register signal handler for Ctrl+C and terminate signals.

--- a/src/cache.c
+++ b/src/cache.c
@@ -69,13 +69,13 @@ queue_new(int capacity, void (*deallocator)(value_t)) {
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 queue__is_full(queue_t* queue) {
     return queue->count == queue->capacity;
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 queue__is_empty(queue_t* queue) {
     return queue->rear == NULL;
 }
@@ -177,7 +177,7 @@ chain__add(chain_t* self, key_dt key, value_t value) {
 int
 chain__remove(chain_t* self, key_dt key) {
     if (!isvalid(self) || !isvalid(self->next))
-        return FALSE;
+        return false;
 
     if (self->next->key == key) {
         chain_t* next = self->next;
@@ -186,7 +186,7 @@ chain__remove(chain_t* self, key_dt key) {
 
         free(next);
 
-        return TRUE;
+        return true;
     }
 
     return chain__remove(self->next, key);
@@ -205,13 +205,13 @@ chain__find(chain_t* self, key_dt key) {
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 chain__has(chain_t* self, key_dt key) {
     if (!isvalid(self))
-        return FALSE;
+        return false;
 
     if (self->key == key)
-        return TRUE;
+        return true;
 
     return chain__has(self->next, key);
 }
@@ -268,7 +268,7 @@ hash_table__get(hash_table_t* self, key_dt key) {
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 hash_table__is_full(hash_table_t* self) {
     if (!isvalid(self))
         return -1;
@@ -405,7 +405,7 @@ lru_cache__maybe_hit(lru_cache_t* self, key_dt key) {
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 lru_cache__is_full(lru_cache_t* self) {
     return queue__is_full(self->queue);
 }

--- a/src/cache.h
+++ b/src/cache.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -89,9 +90,9 @@ queue_new(int, void (*)(value_t));
  *
  * @param self  the queue
  *
- * @return TRUE if the queue is full, else FALSE.
+ * @return true if the queue is full, else false.
  */
-int
+bool
 queue__is_full(queue_t*);
 
 /**
@@ -99,9 +100,9 @@ queue__is_full(queue_t*);
  *
  * @param self  the queue
  *
- * @return TRUE if the queue is empty, else FALSE.
+ * @return true if the queue is empty, else false.
  */
-int
+bool
 queue__is_empty(queue_t*);
 
 /**
@@ -191,7 +192,7 @@ chain_t* chain_new(key_dt, value_t);
  *
  * @param self  the chain.
  *
- * @return TRUE if the chain is empty (i.e. there is no next element), FALSE
+ * @return true if the chain is empty (i.e. there is no next element), false
  *         otherwise.
  */
 #define chain__is_empty(chain) (!isvalid(chain->next))
@@ -237,9 +238,9 @@ chain__find(chain_t*, key_dt);
  * @param self  the chain to check
  * @param key   the key to match.
  *
- * @return TRUE if the chain has an item with the given key, FALSE otherwise.
+ * @return true if the chain has an item with the given key, false otherwise.
  */
-int
+bool
 chain__has(chain_t*, key_dt);
 
 /**
@@ -282,10 +283,10 @@ hash_table__get(hash_table_t*, key_dt);
  *
  * @param self  the hash table
  *
- * @return TRUE if the hash table has grown over the load factor, FALSE
+ * @return true if the hash table has grown over the load factor, false
  * otherwise.
  */
-int
+bool
 hash_table__is_full(hash_table_t*);
 
 /**
@@ -393,9 +394,9 @@ lru_cache__maybe_hit(lru_cache_t*, key_dt);
  *
  * @param self  the cache
  *
- * @return TRUE if the cache is full, else FALSE.
+ * @return true if the cache is full, else false.
  */
-int
+bool
 lru_cache__is_full(lru_cache_t*);
 
 /**

--- a/src/error.c
+++ b/src/error.c
@@ -82,56 +82,56 @@ const char* _error_msg_tab[MAXERROR] = {
     "Non-Python parent process has no Python children",
 };
 
-const int _fatal_error_tab[MAXERROR] = {
+const bool _fatal_error_tab[MAXERROR] = {
     // generic error messages
-    0,
-    1,
-    1,
-    1,
-    0,
-    1,
-    0,
-    0,
+    false,
+    true,
+    true,
+    true,
+    false,
+    true,
+    false,
+    false,
 
     // PyCodeObject
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
 
     // PyFrameObject
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
 
     // py_thread_t
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
 
     // py_proc_t
-    0,
-    1,
-    1,
-    1,
-    1,
-    1,
-    1,
-    1,
+    false,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
 };
 
 const char*
@@ -142,10 +142,10 @@ error_get_msg(error_t n) {
     return _error_msg_tab[n];
 }
 
-const int
+const bool
 is_fatal(error_t n) {
     if (n >= MAXERROR)
-        return FALSE;
+        return false;
 
     return _fatal_error_tab[n];
 }

--- a/src/error.h
+++ b/src/error.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <errno.h>
+#include <stdbool.h>
 
 #include "logging.h"
 
@@ -95,9 +96,9 @@ const char* error_get_msg(error_t);
  *
  * @param  error_t  the error number
  *
- * @return 1 if the error is fatal, 0 otherwise.
+ * @return true if the error is fatal, false otherwise.
  */
-const int is_fatal(error_t);
+const bool is_fatal(error_t);
 
 /**
  * Log the last error

--- a/src/events.c
+++ b/src/events.c
@@ -88,9 +88,9 @@ collapsed_stack_kernel_frame_ref(const char* format, char* scope) {
 void
 collapsed_stack_event_handler__handle_stack_end(base_event_handler_t* self) {
 #ifdef NATIVE
-    int has_cframes = FALSE;
+    bool has_cframes = false;
     if (stack_top() == CFRAME_MAGIC) {
-        has_cframes = TRUE;
+        has_cframes = true;
         (void)stack_pop();
     }
 
@@ -102,7 +102,8 @@ collapsed_stack_event_handler__handle_stack_end(base_event_handler_t* self) {
         }
         cached_string_t* scope = native_frame->scope;
 
-        int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
+        bool is_frame_eval
+            = (scope == UNKNOWN_SCOPE) ? false : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
         if (!stack_is_empty() && is_frame_eval) {
             // TODO: if the py stack is empty we have a mismatch.
             frame_t* frame = stack_pop();
@@ -221,9 +222,9 @@ mojo_event_handler__handle_new_frame(base_event_handler_t* self, frame_t* frame)
 static inline void
 mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
 #ifdef NATIVE
-    int has_cframes = FALSE;
+    bool has_cframes = false;
     if (stack_top() == CFRAME_MAGIC) {
-        has_cframes = TRUE;
+        has_cframes = true;
         (void)stack_pop();
     }
 
@@ -234,7 +235,8 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
             break;                         // GCOV_EXCL_STOP
         }
         cached_string_t* scope = native_frame->scope;
-        int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
+        bool             is_frame_eval
+            = (scope == UNKNOWN_SCOPE) ? false : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
         if (!stack_is_empty() && is_frame_eval) {
             // TODO: if the py stack is empty we have a mismatch.
             frame_t* frame = stack_pop();
@@ -337,9 +339,9 @@ where_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sa
 void
 where_event_handler__handle_stack_end(base_event_handler_t* self) {
 #ifdef NATIVE
-    int has_cframes = FALSE;
+    bool has_cframes = false;
     if (stack_top() == CFRAME_MAGIC) {
-        has_cframes = TRUE;
+        has_cframes = true;
         (void)stack_pop();
     }
 
@@ -354,7 +356,8 @@ where_event_handler__handle_stack_end(base_event_handler_t* self) {
             scope = UNKNOWN_SCOPE; // GCOV_EXCL_LINE
         }
 
-        int is_frame_eval = (scope == UNKNOWN_SCOPE) ? FALSE : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
+        bool is_frame_eval
+            = (scope == UNKNOWN_SCOPE) ? false : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
         if (!stack_is_empty() && is_frame_eval) {
             // TODO: if the py stack is empty we have a mismatch.
             frame_t* frame = stack_pop();

--- a/src/events.h
+++ b/src/events.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "argparse.h"
@@ -60,7 +61,7 @@ typedef struct {
     microseconds_t time;     // Time of the sample
     ssize_t        memory;   // Memory usage
     gc_state_t     gc_state; // GC state
-    int            is_idle;  // Is the thread idle?
+    bool           is_idle;  // Is the thread idle?
 } sample_t;
 
 struct _eh;

--- a/src/hints.h
+++ b/src/hints.h
@@ -25,9 +25,6 @@
 #define SUCCESS return 0
 #define FAIL    return 1
 
-#define TRUE  1
-#define FALSE 0
-
 #define success(x) (!(x))
 #define fail(x)    (x)
 #define sfree(x)           \

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -427,7 +427,7 @@ _py_proc__inspect_vm_maps(py_proc_t* self) {
             map->file_size   = _file_size(map->path);
             map->base        = first_lib_map->address;
             map->size        = first_lib_map->size;
-            map->has_symbols = TRUE;
+            map->has_symbols = true;
             map->bss_base    = bss.base;
             map->bss_size    = bss.size;
 
@@ -449,7 +449,7 @@ _py_proc__inspect_vm_maps(py_proc_t* self) {
                     map->file_size   = _file_size(map->path);
                     map->base        = m->address;
                     map->size        = m->size;
-                    map->has_symbols = FALSE;
+                    map->has_symbols = false;
 
                     log_d("Library path: %s (from pattern match)", map->path);
 
@@ -476,7 +476,7 @@ _py_proc__inspect_vm_maps(py_proc_t* self) {
             self->map.exe.base  = map->base;
             self->map.exe.size  = map->size;
             maps_flag          |= BIN_MAP;
-            self->sym_loaded    = TRUE;
+            self->sym_loaded    = true;
             break;
         }
     }

--- a/src/linux/py_thread.h
+++ b/src/linux/py_thread.h
@@ -34,7 +34,7 @@
 #include "../resources.h"
 
 // ----------------------------------------------------------------------------
-int
+bool
 py_thread__is_idle(py_thread_t* self) {
 #ifdef NATIVE
     size_t index  = self->tid >> 3;

--- a/src/logging.c
+++ b/src/logging.c
@@ -52,7 +52,7 @@ FILE* logfile = NULL;
 #include "austin.h"
 #include "logging.h"
 
-int logging = 1;
+bool logging = true;
 
 void
 _log_writer(int prio, const char* fmt, va_list ap) {
@@ -91,7 +91,7 @@ _log_writer(int prio, const char* fmt, va_list ap) {
 #endif
 }
 
-static int
+static bool
 has_nonempty_env(const char* s) {
     const char* v = getenv(s);
     return v != NULL && *v != '\0';
@@ -100,7 +100,7 @@ has_nonempty_env(const char* s) {
 void
 logger_init(void) {
     if (has_nonempty_env("AUSTIN_NO_LOGGING"))
-        logging = 0;
+        logging = false;
     if (!logging)
         return;
 #ifdef PL_UNIX

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -338,7 +338,7 @@ _py_proc__analyze_macho(py_proc_t* self, char* path, void* base, mach_vm_size_t 
         return _py_proc__analyze_fat(self, base, map_addr);
 
     default:
-        self->sym_loaded = FALSE;
+        self->sym_loaded = false;
     }
 
     return 0;
@@ -503,7 +503,7 @@ _py_proc__get_maps(py_proc_t* self) {
                 map->file_size   = size;
                 map->base        = (void*)address;
                 map->size        = size;
-                map->has_symbols = TRUE;
+                map->has_symbols = true;
                 map->bss_base    = self->map.bss.base;
                 map->bss_size    = self->map.bss.size;
 
@@ -528,7 +528,7 @@ _py_proc__get_maps(py_proc_t* self) {
                         map->file_size   = size;
                         map->base        = (void*)address;
                         map->size        = size;
-                        map->has_symbols = FALSE;
+                        map->has_symbols = false;
                         log_d("Library map: %s (needle)", map->path);
                     }
                 }
@@ -557,7 +557,7 @@ _py_proc__get_maps(py_proc_t* self) {
         if (map->has_symbols) {
             self->map.exe.base = map->base;
             self->map.exe.size = map->size;
-            self->sym_loaded   = TRUE;
+            self->sym_loaded   = true;
             break;
         }
     }

--- a/src/mac/py_thread.h
+++ b/src/mac/py_thread.h
@@ -71,7 +71,7 @@ _infer_thread_id_offset(py_thread_t* py_thread) {
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 py_thread__is_idle(py_thread_t* self) {
     if (unlikely(_silly_offset == 0)) {
         _infer_thread_id_offset(self);

--- a/src/mem.h
+++ b/src/mem.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <sys/types.h>
 
 #include "hints.h"
@@ -211,7 +212,7 @@ get_total_memory(void) {
 
 #elif defined PL_WIN /* WIN */
     ULONGLONG size;
-    return GetPhysicallyInstalledSystemMemory(&size) == TRUE ? size : 0;
+    return GetPhysicallyInstalledSystemMemory(&size) ? size : 0;
 
 #endif
 
@@ -225,7 +226,7 @@ struct vm_map {
     size_t  size;
     void*   bss_base;
     size_t  bss_size;
-    int     has_symbols;
+    bool    has_symbols;
 };
 
 enum {

--- a/src/platform.c
+++ b/src/platform.c
@@ -1,3 +1,26 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "hints.h"
@@ -18,7 +41,7 @@ pid_max() {
     if (!isvalid(pid_max_file))
         return 0;
 
-    int has_pid_max = (fscanf(pid_max_file, "%zu", &max_pid) == 1);
+    bool has_pid_max = (fscanf(pid_max_file, "%zu", &max_pid) == 1);
     fclose(pid_max_file);
     if (!has_pid_max)
         return 0;

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -89,10 +89,10 @@ _py_proc__check_sym(py_proc_t* self, char* name, void* value) {
         if (success(symcmp(name, i))) {
             self->symbols[i] = value;
             log_d("Symbol %s found @ %p", name, value);
-            return TRUE;
+            return true;
         }
     }
-    return FALSE;
+    return false;
 }
 
 // ----------------------------------------------------------------------------
@@ -201,7 +201,7 @@ _find_version_in_binary(char* path, int* version) {
     char*  current_pos  = binary_map->addr;
     int    major, minor, patch;
     major = 0;
-    while (TRUE) {
+    while (true) {
         char* p = memmem(current_pos, current_size, needle, sizeof(needle));
         if (!isvalid(p))
             break;
@@ -652,9 +652,9 @@ _py_proc__find_interpreter_state(py_proc_t* self) {
 // ----------------------------------------------------------------------------
 static int
 _py_proc__run(py_proc_t* self) {
-    int try_once = self->child;
-    int init     = FALSE;
-    int attempts = 0;
+    bool try_once = self->child;
+    bool init     = false;
+    int  attempts = 0;
 
 #ifdef DEBUG
     if (!try_once)
@@ -678,10 +678,10 @@ _py_proc__run(py_proc_t* self) {
 
     sfree(self->bin_path);
     sfree(self->lib_path);
-    self->sym_loaded = FALSE;
+    self->sym_loaded = false;
 
     if (success(_py_proc__find_interpreter_state(self))) {
-        init = TRUE;
+        init = true;
 
         log_d("Interpreter State de-referenced @ raddr: %p after %d attempts", self->is_raddr, attempts);
 
@@ -741,7 +741,7 @@ _py_proc__run(py_proc_t* self) {
 
 // ----------------------------------------------------------------------------
 py_proc_t*
-py_proc_new(int child) {
+py_proc_new(bool child) {
     py_proc_t* py_proc = (py_proc_t*)calloc(1, sizeof(py_proc_t));
     if (!isvalid(py_proc))
         return NULL;
@@ -793,7 +793,7 @@ py_proc__attach(py_proc_t* self, pid_t pid) {
     log_d("Attaching to process with PID %d", pid);
 
 #if defined PL_WIN /* WIN */
-    self->proc_ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, pid);
+    self->proc_ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, false, pid);
     if (self->proc_ref == INVALID_HANDLE_VALUE) {
         set_error(EPROCATTACH);
         FAIL;
@@ -836,7 +836,7 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
     ZeroMemory(&siStartInfo, sizeof(STARTUPINFO));
 
     saAttr.nLength              = sizeof(SECURITY_ATTRIBUTES);
-    saAttr.bInheritHandle       = TRUE;
+    saAttr.bInheritHandle       = true;
     saAttr.lpSecurityDescriptor = NULL;
 
     CreatePipe(&hChildStdInRd, &hChildStdInWr, &saAttr, 0);
@@ -885,7 +885,7 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
     register int pos = strlen(exec);
     i                = 1;
     while (argv[i]) {
-        int has_space   = isvalid(strchr(argv[i], ' '));
+        bool has_space  = isvalid(strchr(argv[i], ' '));
         cmd_line[pos++] = ' ';
         if (has_space)
             cmd_line[pos++] = '"';
@@ -898,7 +898,7 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
 
     log_t("Computed command line: %s", cmd_line);
 
-    BOOL process_created = CreateProcess(NULL, cmd_line, NULL, NULL, TRUE, 0, NULL, NULL, &siStartInfo, &piProcInfo);
+    BOOL process_created = CreateProcess(NULL, cmd_line, NULL, NULL, true, 0, NULL, NULL, &siStartInfo, &piProcInfo);
 
     sfree(cmd_line);
 
@@ -1025,7 +1025,7 @@ _py_proc__find_current_thread_offset(py_proc_t* self, void* thread_raddr) {
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 py_proc__is_running(py_proc_t* self) {
 #if defined PL_WIN /* WIN */
     DWORD ec = 0;
@@ -1040,7 +1040,7 @@ py_proc__is_running(py_proc_t* self) {
 }
 
 // ----------------------------------------------------------------------------
-int
+bool
 py_proc__is_python(py_proc_t* self) {
     return self->is_raddr != NULL;
 }
@@ -1097,7 +1097,7 @@ _py_proc__interrupt_threads(py_proc_t* self, raddr_t* tstate_head_raddr) {
             FAIL;
         }
 
-        if (fail(py_thread__set_interrupted(&py_thread, TRUE))) {
+        if (fail(py_thread__set_interrupted(&py_thread, true))) {
             if (fail(wait_ptrace(PTRACE_CONT, py_thread.tid, 0, 0))) {
                 log_d("ptrace: failed to resume interrupted thread %d (errno: %d)", py_thread.tid, errno);
             }
@@ -1132,7 +1132,7 @@ _py_proc__resume_threads(py_proc_t* self, raddr_t* tstate_head_raddr) {
                 FAIL;
             }
             log_t("ptrace: thread %d resumed", py_thread.tid);
-            if (fail(py_thread__set_interrupted(&py_thread, FALSE))) {
+            if (fail(py_thread__set_interrupted(&py_thread, false))) {
                 log_ie("Failed to mark thread as interrupted");
                 FAIL;
             }
@@ -1226,7 +1226,7 @@ _py_proc__sample_interpreter(py_proc_t* self, void* interp, microseconds_t time_
         if (mem_delta == 0 && time_delta == 0)
             continue;
 
-        int is_idle = FALSE;
+        bool is_idle = false;
         if (pargs.full || pargs.sleepless || unlikely(pargs.where)) {
             is_idle = py_thread__is_idle(&py_thread);
             if (!pargs.full && is_idle && pargs.sleepless) {

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -793,7 +793,7 @@ py_proc__attach(py_proc_t* self, pid_t pid) {
     log_d("Attaching to process with PID %d", pid);
 
 #if defined PL_WIN /* WIN */
-    self->proc_ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, false, pid);
+    self->proc_ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, pid);
     if (self->proc_ref == INVALID_HANDLE_VALUE) {
         set_error(EPROCATTACH);
         FAIL;
@@ -836,7 +836,7 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
     ZeroMemory(&siStartInfo, sizeof(STARTUPINFO));
 
     saAttr.nLength              = sizeof(SECURITY_ATTRIBUTES);
-    saAttr.bInheritHandle       = true;
+    saAttr.bInheritHandle       = TRUE;
     saAttr.lpSecurityDescriptor = NULL;
 
     CreatePipe(&hChildStdInRd, &hChildStdInWr, &saAttr, 0);
@@ -898,7 +898,7 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
 
     log_t("Computed command line: %s", cmd_line);
 
-    BOOL process_created = CreateProcess(NULL, cmd_line, NULL, NULL, true, 0, NULL, NULL, &siStartInfo, &piProcInfo);
+    BOOL process_created = CreateProcess(NULL, cmd_line, NULL, NULL, TRUE, 0, NULL, NULL, &siStartInfo, &piProcInfo);
 
     sfree(cmd_line);
 

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <sys/types.h>
 
 #ifdef NATIVE
@@ -55,7 +56,7 @@ typedef struct _proc_extra_info proc_extra_info; // Forward declaration.
 typedef struct {
     pid_t      pid;
     proc_ref_t proc_ref;
-    int        child;
+    bool       child;
 
     char* bin_path;
     char* lib_path;
@@ -113,7 +114,7 @@ typedef struct {
  * @return a pointer to the newly created py_proc_t object.
  */
 py_proc_t*
-py_proc_new(int child);
+py_proc_new(bool child);
 
 /**
  * Start the process
@@ -151,9 +152,9 @@ py_proc__wait(py_proc_t*);
  *
  * @param py_proc_t * the process object.
  *
- * @return 1 if the process is still running, 0 otherwise.
+ * @return true if the process is still running, false otherwise.
  */
-int
+bool
 py_proc__is_running(py_proc_t*);
 
 /**
@@ -161,9 +162,9 @@ py_proc__is_running(py_proc_t*);
  *
  * @param py_proc_t * the process object.
  *
- * @return 1 if the process is a Python process, 0 otherwise.
+ * @return true if the process is a Python process, false otherwise.
  */
-int
+bool
 py_proc__is_python(py_proc_t*);
 
 /**
@@ -173,10 +174,10 @@ py_proc__is_python(py_proc_t*);
  *
  * @param py_proc_t * the process object.
  *
- * @return TRUE if the GC is collecting, FALSE otherwise.
+ * @return true if the GC is collecting, false otherwise.
  *
  */
-int
+bool
 py_proc__is_gc_collecting(py_proc_t*);
 
 /**
@@ -227,7 +228,7 @@ py_proc__sample(py_proc_t*);
 /**
  * Log the Python interpreter version
  * @param self  the process object.
- * @param int   whether the process is the parent process.
+ * @param bool  whether the process is the parent process.
  */
 void
 py_proc__log_version(py_proc_t*, int);

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -74,7 +74,7 @@ _py_proc_list__add(py_proc_list_t* self, py_proc_t* py_proc) {
 } /* _py_proc_list__add */
 
 // ----------------------------------------------------------------------------
-static int
+static bool
 _py_proc_list__has_pid(py_proc_list_t* self, pid_t pid) {
     return isvalid(lookup__get(self->py_proc_for_pid, pid));
 } /* _py_proc_list__has_pid */
@@ -139,7 +139,7 @@ void
 py_proc_list__add_proc_children(py_proc_list_t* self, uintptr_t ppid) {
     lookup__iteritems_start(self->ppid_for_pid, key_dt, pid, value_t, pid_ppid) {
         if (pid_ppid == (value_t)ppid && !_py_proc_list__has_pid(self, pid)) {
-            py_proc_t* child_proc = py_proc_new(TRUE);
+            py_proc_t* child_proc = py_proc_new(true);
             if (child_proc == NULL)
                 continue;
 
@@ -149,7 +149,7 @@ py_proc_list__add_proc_children(py_proc_list_t* self, uintptr_t ppid) {
             }
 
             _py_proc_list__add(self, child_proc);
-            py_proc__log_version(child_proc, FALSE);
+            py_proc__log_version(child_proc, false);
             py_proc_list__add_proc_children(self, pid);
         }
     }
@@ -157,7 +157,7 @@ py_proc_list__add_proc_children(py_proc_list_t* self, uintptr_t ppid) {
 } /* py_proc_list__add_proc_children */
 
 // ----------------------------------------------------------------------------
-int
+bool
 py_proc_list__is_empty(py_proc_list_t* self) {
     return !isvalid(self->first);
 } /* py_proc_list__is_empty */

--- a/src/py_proc_list.h
+++ b/src/py_proc_list.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #include "cache.h"
 #include "py_proc.h"
 #include "resources.h"
@@ -56,9 +58,9 @@ py_proc_list_new(py_proc_t*);
  *
  * @param  py_proc_list_t  the list.
  *
- * @return 1 if empty; 0 otherwise.
+ * @return true if empty; false otherwise.
  */
-int
+bool
 py_proc_list__is_empty(py_proc_list_t*);
 
 /**

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -435,7 +435,7 @@ py_thread__set_idle(py_thread_t* self) {
 
 // ----------------------------------------------------------------------------
 int
-py_thread__set_interrupted(py_thread_t* self, int state) {
+py_thread__set_interrupted(py_thread_t* self, bool state) {
     unsigned char bit   = 1 << (self->tid & 7);
     size_t        index = self->tid >> 3;
 
@@ -703,7 +703,7 @@ py_thread__fill_from_raddr(py_thread_t* self, raddr_t* raddr, py_proc_t* proc) {
 
     PyThreadState ts;
 
-    self->invalid = TRUE;
+    self->invalid = true;
 
     if (fail(copy_from_raddr(raddr, ts))) {
         log_ie("Cannot read remote PyThreadState");
@@ -771,7 +771,7 @@ py_thread__fill_from_raddr(py_thread_t* self, raddr_t* raddr, py_proc_t* proc) {
     }
 #endif
 
-    self->invalid = FALSE;
+    self->invalid = false;
     SUCCESS;
 } /* py_thread__fill_from_raddr */
 
@@ -803,7 +803,7 @@ py_thread__next(py_thread_t* self) {
 // ----------------------------------------------------------------------------
 void
 py_thread__unwind(py_thread_t* self) {
-    int error = FALSE;
+    bool error = false;
 
 #ifdef NATIVE
 
@@ -815,7 +815,7 @@ py_thread__unwind(py_thread_t* self) {
         _py_thread__unwind_kernel_frame_stack(self);
     }
     if (fail(_py_thread__unwind_native_frame_stack(self))) {
-        error = TRUE;
+        error = true;
     }
 
     // Update the thread state to improve guarantees that it will be in sync with
@@ -827,20 +827,20 @@ py_thread__unwind(py_thread_t* self) {
     if (isvalid(self->top_frame)) {
         if (V_MIN(3, 13)) {
             if (fail(_py_thread__unwind_iframe_stack(self, self->top_frame))) {
-                error = TRUE;
+                error = true;
             }
         } else if (V_MIN(3, 11)) {
             if (fail(_py_thread__unwind_cframe_stack(self))) {
-                error = TRUE;
+                error = true;
             }
         } else {
             if (fail(_py_thread__unwind_frame_stack(self))) {
-                error = TRUE;
+                error = true;
             }
         }
 
         if (fail(_py_thread__resolve_py_stack(self))) {
-            error = TRUE;
+            error = true;
         }
     }
 

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -54,7 +55,7 @@ typedef struct thread {
 
     void* top_frame;
 
-    int invalid;
+    bool invalid;
 
     /* The per-thread datastack was introduced in Python 3.11 */
     stack_chunk_t* stack;
@@ -109,7 +110,7 @@ int
 py_thread__set_idle(py_thread_t*);
 
 int
-py_thread__set_interrupted(py_thread_t*, int);
+py_thread__set_interrupted(py_thread_t*, bool);
 
 int
 py_thread__is_interrupted(py_thread_t* self);
@@ -118,5 +119,5 @@ int
 py_thread__save_kernel_stack(py_thread_t*);
 #endif
 
-int
+bool
 py_thread__is_idle(py_thread_t*);

--- a/src/stack.h
+++ b/src/stack.h
@@ -62,10 +62,10 @@ stack_allocate(size_t size);
 void
 stack_deallocate(void);
 
-static inline int
+static inline bool
 stack_has_cycle(void) {
     if (_stack->pointer < 2)
-        return FALSE;
+        return false;
 
     // This sucks! :( Worst case is quadratic in the stack height, but if the
     // sampled stacks are short on average, it might still be faster than the
@@ -77,9 +77,9 @@ stack_has_cycle(void) {
 #else
         if (top.origin == _stack->py_base[i].origin)
 #endif
-            return TRUE;
+            return true;
     }
-    return FALSE;
+    return false;
 }
 
 static inline void

--- a/src/version.h
+++ b/src/version.h
@@ -70,8 +70,8 @@
  * @param  M  requested major version
  * @param  m  requested minor version
  *
- * @return    TRUE if the current version is at least/at most the requested one,
- *            FALSE otherwise.
+ * @return    true if the current version is at least/at most the requested one,
+ *            false otherwise.
  */
 #define V_MIN(M, m) (((py_v->major << 8) | py_v->minor) >= ((M << 8) | m))
 #define V_MAX(M, m) (((py_v->major << 8) | py_v->minor) <= ((M << 8) | m))

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -266,7 +266,7 @@ _py_proc__get_modules(py_proc_t* self) {
         // The first memory map of the shared library (if any)
         char* needle = strstr(module.szExePath, "python");
         if (!isvalid(pd->maps[MAP_LIBSYM].path) && isvalid(needle)) {
-            int has_symbols = success(_py_proc__analyze_pe(self, module.szExePath, (void*)module.modBaseAddr));
+            bool has_symbols = success(_py_proc__analyze_pe(self, module.szExePath, (void*)module.modBaseAddr));
             if (has_symbols) {
                 map       = &(pd->maps[MAP_LIBSYM]);
                 map->path = strdup(module.szExePath);
@@ -278,7 +278,7 @@ _py_proc__get_modules(py_proc_t* self) {
                 map->file_size   = module.modBaseSize;
                 map->base        = (void*)module.modBaseAddr;
                 map->size        = module.modBaseSize;
-                map->has_symbols = TRUE;
+                map->has_symbols = true;
                 map->bss_base    = self->map.bss.base;
                 map->bss_size    = self->map.bss.size;
 
@@ -302,7 +302,7 @@ _py_proc__get_modules(py_proc_t* self) {
                         map->file_size   = module.modBaseSize;
                         map->base        = (void*)module.modBaseAddr;
                         map->size        = module.modBaseSize;
-                        map->has_symbols = FALSE;
+                        map->has_symbols = false;
                         log_d("Library map: %s (needle)", map->path);
                         continue;
                     }

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -29,7 +29,7 @@ static PVOID _pi_buffer      = NULL;
 static ULONG _pi_buffer_size = 0;
 
 // ----------------------------------------------------------------------------
-int
+bool
 py_thread__is_idle(py_thread_t* self) {
     ULONG    n;
     NTSTATUS status = NtQuerySystemInformation(SystemProcessInformation, _pi_buffer, _pi_buffer_size, &n);

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -2,14 +2,28 @@ import ctypes
 import os
 import re
 import sys
-from ctypes import CDLL, POINTER, Structure, c_bool, c_char_p, c_long, c_void_p, cast
+from ctypes import CDLL
+from ctypes import POINTER
+from ctypes import Structure
+from ctypes import c_bool
+from ctypes import c_char_p
+from ctypes import c_long
+from ctypes import c_void_p
+from ctypes import cast
 from pathlib import Path
-from subprocess import PIPE, STDOUT, run
+from subprocess import PIPE
+from subprocess import STDOUT
+from subprocess import run
 from types import ModuleType
-from typing import Any, Callable, Optional, Type
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Type
 
-from pycparser import c_ast, c_parser
+from pycparser import c_ast
+from pycparser import c_parser
 from pycparser.plyparser import ParseError
+
 
 HERE = Path(__file__).resolve().parent
 TEST = HERE.parent

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -2,27 +2,14 @@ import ctypes
 import os
 import re
 import sys
-from ctypes import CDLL
-from ctypes import POINTER
-from ctypes import Structure
-from ctypes import c_char_p
-from ctypes import c_long
-from ctypes import c_void_p
-from ctypes import cast
+from ctypes import CDLL, POINTER, Structure, c_bool, c_char_p, c_long, c_void_p, cast
 from pathlib import Path
-from subprocess import PIPE
-from subprocess import STDOUT
-from subprocess import run
+from subprocess import PIPE, STDOUT, run
 from types import ModuleType
-from typing import Any
-from typing import Callable
-from typing import Optional
-from typing import Type
+from typing import Any, Callable, Optional, Type
 
-from pycparser import c_ast
-from pycparser import c_parser
+from pycparser import c_ast, c_parser
 from pycparser.plyparser import ParseError
-
 
 HERE = Path(__file__).resolve().parent
 TEST = HERE.parent
@@ -196,6 +183,9 @@ class CMethod(CFunction):
         self.__ctype__ = ctype
 
     def __get__(self, obj: Any, objtype: Optional[Type] = None) -> None:
+        if obj is None:
+            return self
+
         def _(*args, **kwargs):
             cargs = [obj.__cself__, *args]
             self.check_args(cargs, kwargs)
@@ -203,11 +193,16 @@ class CMethod(CFunction):
             return self.__cfunc__(*cargs, **kwargs)
 
         _.__cmethod__ = self
+        _.__name__ = (
+            f"<bound CMethod '{self.__ctype__.__name__}.{self.__name__}' "
+            f"of {obj.__cself__}>"
+        )
+        _.__repr__ = lambda self: self.__name__
 
         return _
 
     def __repr__(self) -> str:
-        return f"<CMethod '{self.__name__}' of CType '{self.__ctype__.__name__}'>"
+        return f"<CMethod '{self.__ctype__.__name__}.{self.__name__}'>"
 
 
 class CStaticMethod(CFunction):
@@ -218,7 +213,7 @@ class CStaticMethod(CFunction):
         self.__ctype__ = ctype
 
     def __repr__(self) -> str:
-        return f"<CStaticMethod '{self.__name__}' of CType '{self.__ctype__.__name__}'>"
+        return f"<CStaticMethod '{self.__ctype__.__name__}.{self.__name__}'>"
 
 
 class CMetaType(type(Structure)):
@@ -270,12 +265,17 @@ class DeclCollector(c_ast.NodeVisitor):
         if isinstance(node.type, c_ast.FuncDecl):
             func_name = node.name
             ret_type = node.type.type
-            rtype = None
+            rtype: Optional[Any] = None
 
             if isinstance(ret_type, c_ast.TypeDecl) and isinstance(
                 ret_type.type, c_ast.IdentifierType
             ):  # Non-pointer return type
-                rtype = getattr(ctypes, f"c_{''.join(ret_type.type.names)}", c_long)
+                type_name = "".join(ret_type.type.names)
+                rtype = (
+                    c_bool
+                    if type_name == "_Bool"
+                    else getattr(ctypes, f"c_{type_name}", c_long)
+                )
 
             elif isinstance(ret_type, c_ast.PtrDecl) and isinstance(
                 ret_type.type.type, c_ast.IdentifierType


### PR DESCRIPTION
We migrate the custom support for booleans to the one provided by the standard library of C99+.
