### PR TITLE
fix(macos): base address detection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-10-xx v3.8.0
+
+  Bugfix: fixed a bug that caused Austin to fail to attach to a MacOS process
+  for a second time with CPython 3.13.
+
+
 2024-10-14 v3.7.0
 
   Added support for CPython 3.13.

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.69])
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"AC_INIT([austin], [{version()}], [https://github.com/p403n1x87/austin/issues])")
 # ]]]
-AC_INIT([austin], [3.7.0], [https://github.com/p403n1x87/austin/issues])
+AC_INIT([austin], [3.8.0], [https://github.com/p403n1x87/austin/issues])
 # [[[end]]]
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ base: core20
 # from scripts.utils import get_current_version_from_changelog as version
 # print(f"version: '{version()}+git'")
 # ]]]
-version: '3.7.0+git'
+version: '3.8.0+git'
 # [[[end]]]
 summary: A Python frame stack sampler for CPython
 description: |

--- a/src/austin.h
+++ b/src/austin.h
@@ -33,5 +33,5 @@
 from scripts.utils import get_current_version_from_changelog as version
 print(f'#define VERSION "{version()}"')
 ]]] */
-#define VERSION "3.7.0"
+#define VERSION "3.8.0"
 // [[[end]]]

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -111,35 +111,10 @@ _py_proc__analyze_macho64(py_proc_t* self, void* base, void* map) {
     int                        cmd_cnt = 0;
     struct segment_command_64* cmd     = map + sizeof(struct mach_header_64);
 
-    mach_vm_size_t                 size    = 0;
-    mach_msg_type_number_t         count   = sizeof(vm_region_basic_info_data_64_t);
-    mach_vm_address_t              address = (mach_vm_address_t)base;
-    vm_region_basic_info_data_64_t region_info;
-    mach_port_t                    object_name;
-
     for (register int i = 0; cmd_cnt < 2 && i < ncmds; i++) {
         switch (cmd->cmd) {
         case LC_SEGMENT_64:
             if (strcmp(cmd->segname, "__DATA") == 0) {
-                // Get the address of the data segment. This way we can compute the base
-                // address of the binary.
-                // NOTE: Here we are vulnerable to size collisions. Unfortunately, we
-                // can't check for the same byte content as the data section is not
-                // read-only.
-                while (cmd->filesize != size) {
-                    address += size;
-                    if (mach_vm_region(
-                            self->proc_ref, &address, &size, VM_REGION_BASIC_INFO_64,
-                            (vm_region_info_t)&region_info, // cppcheck-suppress [uninitvar]
-                            &count, &object_name
-                        )
-                        != KERN_SUCCESS) {
-                        log_e("Cannot get any more VM maps.");
-                        return 0;
-                    }
-                }
-                base = (void*)address - cmd->vmaddr;
-
                 int                nsects = cmd->nsects;
                 struct section_64* sec    = (struct section_64*)((void*)cmd + sizeof(struct segment_command_64));
                 self->map.bss.size        = 0;
@@ -211,35 +186,10 @@ _py_proc__analyze_macho32(py_proc_t* self, void* base, void* map) {
     int                     cmd_cnt = 0;
     struct segment_command* cmd     = map + sizeof(struct mach_header);
 
-    mach_vm_size_t              size    = 0;
-    mach_msg_type_number_t      count   = sizeof(vm_region_basic_info_data_t);
-    mach_vm_address_t           address = (mach_vm_address_t)base;
-    vm_region_basic_info_data_t region_info;
-    mach_port_t                 object_name;
-
     for (register int i = 0; cmd_cnt < 2 && i < ncmds; i++) {
         switch (cmd->cmd) {
         case LC_SEGMENT:
             if (strcmp(cmd->segname, "__DATA") == 0) {
-                // Get the address of the data segment. This way we can compute the base
-                // address of the binary.
-                // NOTE: Here we are vulnerable to size collisions. Unfortunately, we
-                // can't check for the same byte content as the data section is not
-                // read-only.
-                while (cmd->filesize != size) {
-                    address += size;
-                    if (mach_vm_region(
-                            self->proc_ref, &address, &size, VM_REGION_BASIC_INFO,
-                            (vm_region_info_t)&region_info, // cppcheck-suppress [uninitvar]
-                            &count, &object_name
-                        )
-                        != KERN_SUCCESS) {
-                        log_e("Cannot get any more VM maps.");
-                        return 0;
-                    }
-                }
-                base = (void*)address - cmd->vmaddr;
-
                 int             nsects = cmd->nsects;
                 struct section* sec    = (struct section*)((void*)cmd + sizeof(struct segment_command));
                 self->map.bss.size     = 0;
@@ -493,6 +443,13 @@ _py_proc__get_maps(py_proc_t* self) {
            )
            == KERN_SUCCESS) {
         int path_len = proc_regionfilename(self->pid, address, path, MAXPATHLEN);
+
+        // We assume that the first segment is the executable part. Under this
+        // assumption, the address of this map will be the base address.
+        if (!(region_info.protection & VM_PROT_EXECUTE)) {
+            address += size;
+            continue;
+        }
 
         if (isvalid(prev_path) && strcmp(path, prev_path) == 0) { // Avoid analysing a binary multiple times
             goto next;

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1361,6 +1361,10 @@ py_proc__destroy(py_proc_t* self) {
     hash_table__destroy(self->base_table);
 #endif
 
+#if defined PL_MACOS
+    mach_port_deallocate(mach_task_self(), self->proc_ref);
+#endif
+
     _py_proc__free_local_buffers(self);
 
     sfree(self->bin_path);

--- a/test/functional/test_attach.py
+++ b/test/functional/test_attach.py
@@ -110,6 +110,21 @@ def test_where(py, mojo):
         assert "<module>" in result.stdout
 
 
+@requires_sudo
+@allpythons()
+def test_where_multiple_times(py):
+    n = 10
+    with run_python(py, target("sleepy.py"), str(n), sleep_after=1) as p:
+        for _ in range(n):
+            result = austin("-w", str(p.pid))
+            assert result.returncode == 0
+
+            assert "Process" in result.stdout
+            assert "Thread" in result.stdout
+            assert "sleepy.py" in result.stdout
+            assert "<module>" in result.stdout
+
+
 @flaky
 @requires_sudo
 @pytest.mark.xfail(platform.system() == "Windows", reason="Does not pass in Windows CI")


### PR DESCRIPTION
We improve the logic for the base VM address detection on MacOS. When attaching to a running process, VM regions might change shape/get split/disappear. We assume that the first executable map is the one that provides the base address for the binary in memory.

Fixes #277.