### PR TITLE
fix: continue sampling after thread info retrieve failure

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@
   Bugfix: fixed a bug that caused Austin to fail to attach to a MacOS process
   for a second time with CPython 3.13.
 
+  Bugfix: fixed a bug that caused the sampling to halt if Austin failed to
+  retrieve valid thread information.
 
 2024-10-14 v3.7.0
 

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1278,7 +1278,7 @@ py_proc__sample(py_proc_t* self) {
 #endif
 
         if (fail(result))
-            FAIL;
+            continue;
     } while (isvalid(current_interp = V_FIELD_PTR(void*, self->is, py_is, o_next)));
 
 #ifdef NATIVE


### PR DESCRIPTION
We fix an issue that caused the sampling to stop if we failed to retrieve thread information for a given thread. This can happen and in general is not a fatal error. We let the sampling thread continue sampling all sub-interpreters instead of halting.
