### PR TITLE
chore: handle missing/invalid datastack chunk

### DIFF
--- a/src/stack.h
+++ b/src/stack.h
@@ -143,8 +143,13 @@ static inline stack_chunk_t*
 stack_chunk_new(proc_ref_t pref, void* origin) {
     _PyStackChunk original_chunk;
 
+    if (!isvalid(origin)) {
+        // Not a valid datastack chunk.
+        return NULL;
+    }
+
     if (copy_datatype(pref, origin, original_chunk)) {
-        log_e("Failed to copy _PyStackChunk");
+        log_e("Failed to copy _PyStackChunk from %p", origin);
         return NULL;
     }
 


### PR DESCRIPTION
A thread that has no frames might not have a datastack chunk allocated for it. In this case we get a null pointer that we can handle gracefully instead of giving an error in logs.