### PR TITLE
tests: improve stability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,7 +177,7 @@ jobs:
         run: |
           ulimit -c unlimited
           echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
-          sudo -E env PATH="$PATH" .venv/bin/pytest -sv test/support
+          sudo -E env PATH="$PATH" .venv/bin/pytest -n 0 -sv test/support
         if: always()
 
   wheels-linux:
@@ -320,7 +320,7 @@ jobs:
       - name: Run support tests
         run: |
           source .venv/bin/activate
-          sudo -E pytest --pastebin=failed -svr a -n auto test/support
+          sudo -E pytest --pastebin=failed -svr a test/support
         if: always()
 
       - name: Run Darwin-only tests

--- a/test/functional/test_attach.py
+++ b/test/functional/test_attach.py
@@ -72,7 +72,7 @@ def test_attach_wall_time(austin, py, mode, mode_meta, heap):
         a = sum_metric(result.stdout)
         d = int(meta["duration"])
 
-        assert a <= d
+        assert a <= 1.1 * d
 
 
 @requires_sudo


### PR DESCRIPTION
We improve the stability of some tests by relaxing some thresholds and by avoiding parallel runs for support tests.