### PR TITLE
tests: improve compatibility of C unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           ulimit -c unlimited
           echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
-          .venv/bin/pytest -sv test/cunit
+          .venv/bin/pytest -vv test/cunit
   
       - name: Run functional Austin tests (with sudo)
         run: |
@@ -304,7 +304,14 @@ jobs:
           python3.10 -m pip install -r test/requirements.txt
           python${{ matrix.python-version }} -m venv .venv \
             || (python${{ matrix.python-version }} -m pip install virtualenv && python${{ matrix.python-version }} -m virtualenv .venv)
-      
+
+      - name: Run unit tests
+        env:
+          CC: gcc-12
+        run: |
+          source .venv/bin/activate
+          pytest -vv test/cunit
+
       - name: Run functional tests
         run: |
           source .venv/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ stamp-h1
 *.lo
 *.gcno
 *.gcda
+*.dylib*
 
 src/austin
 src/austinp

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -1,5 +1,7 @@
 import ctypes
+import os
 import re
+import sys
 from ctypes import CDLL
 from ctypes import POINTER
 from ctypes import Structure
@@ -35,6 +37,7 @@ _header_head = r"""
 #define __extension__
 #define __inline inline
 #define __asm__(x)
+#define __asm(x)
 #define __const const
 #define __inline__ inline
 #define __inline inline
@@ -43,8 +46,15 @@ _header_head = r"""
 #define __GNUC_VA_LIST
 #define __gnuc_va_list char
 #define __thread
-// typedef struct __builtin_va_list { } __builtin_va_list;
+typedef struct __builtin_va_list { } __builtin_va_list;
+#define _Nullable
+#define __uint128_t unsigned long long
+#define _Nonnull
+#define __float128 long double
 """
+
+
+CC = os.getenv("CC", "gcc")
 
 
 def preprocess(source: Path) -> str:
@@ -53,7 +63,7 @@ def preprocess(source: Path) -> str:
         return restrict_re.sub(
             "",
             run(
-                ["gcc", "-E", "-P", "-"],
+                [CC, "-E", "-P", "-"],
                 stdout=PIPE,
                 input=code.encode(),
                 cwd=SRC,
@@ -65,6 +75,15 @@ class CompilationError(Exception):
     pass
 
 
+match sys.platform:
+    case "linux":
+        SHARED_OBJECT_SUFFIX = ".so"
+    case "darwin":
+        SHARED_OBJECT_SUFFIX = ".dylib"
+    case "win32":
+        SHARED_OBJECT_SUFFIX = ".dll"
+
+
 def compile(
     source: Path,
     cflags: list[str] = [],
@@ -72,14 +91,14 @@ def compile(
     ldadd: list[str] = [],
     force: bool = False,
 ) -> None:
-    binary = source.with_suffix(".so")
+    binary = source.with_suffix(SHARED_OBJECT_SUFFIX)
 
     if not force and binary.is_file():
         return
 
     result = run(
         [
-            "gcc",
+            CC,
             "-shared",
             *cflags,
             "-o",
@@ -99,7 +118,15 @@ def compile(
     raise CompilationError(result.stdout.decode())
 
 
-C = CDLL("libc.so.6")
+match sys.platform:
+    case "linux":
+        C = CDLL("libc.so.6")
+    case "darwin":
+        import ctypes.util
+
+        C = CDLL(ctypes.util.find_library("c"))
+    case "win32":
+        C = CDLL("msvcrt.dll")
 
 
 class CFunctionDef:
@@ -134,11 +161,11 @@ class CType(Structure):
 class CFunction:
     def __init__(self, cfuncdef: CFunctionDef, cfunc: Callable[..., Any]) -> None:
         self.__name__ = cfuncdef.name
-        self.__args__ = [_[0] for _ in cfuncdef.args]
+        self.__args__ = [_[0] for _ in cfuncdef.args if _ is not None]
         self.__cfunc__ = cfunc
 
         # Prevent argument values from being truncated/mangled
-        self.__cfunc__.argtypes = [_[1] for _ in cfuncdef.args]
+        self.__cfunc__.argtypes = [_[1] for _ in cfuncdef.args if _ is not None]
         self.__cfunc__.restype = cfuncdef.rtype
 
         self._posonly = all(_ is None for _ in self.__args__)
@@ -157,8 +184,8 @@ class CFunction:
         self.check_args(args, kwargs)
         return self.__cfunc__(*args, **kwargs)
 
-    def __repr__(self) -> None:
-        return f"<CFunction '{self.__name__}'>"
+    def __repr__(self) -> str:
+        return f"<CFunction '{self.__name__}({', '.join(self.__args__)})'>"
 
 
 class CMethod(CFunction):
@@ -233,7 +260,7 @@ class DeclCollector(c_ast.NodeVisitor):
             struct = node.type.type
             self.types[node.type.declname[:-2]] = CTypeDef(
                 node.type.declname,
-                [decl.name for decl in struct.decls],
+                [decl.name for decl in struct.decls or []],
             )
 
     def visit_Decl(self, node: c_ast.Node) -> None:
@@ -259,6 +286,7 @@ class DeclCollector(c_ast.NodeVisitor):
                     else c_void_p
                 )
 
+            # Function arguments
             args = (
                 [
                     (
@@ -274,18 +302,21 @@ class DeclCollector(c_ast.NodeVisitor):
                 if node.type.args is not None
                 else []
             )
-            if func_name.endswith("_new"):
+
+            if func_name.endswith("_new"):  # Constructor
                 self.types[f"{func_name[:-4]}"].constructor = CFunctionDef(
                     "new", args, rtype
                 )
-            elif "__" in func_name:
+
+            elif "__" in func_name:  # Method
                 type_name, _, method_name = func_name.partition("__")
                 if not type_name:
                     return
                 self.types[type_name].methods.append(
                     CFunctionDef(method_name, args, rtype)
                 )
-            else:
+
+            else:  # Function
                 self.functions.append(CFunctionDef(func_name, args, rtype))
 
     def collect(self, decl: str) -> dict[str, CTypeDef]:
@@ -299,9 +330,9 @@ class DeclCollector(c_ast.NodeVisitor):
             )
             for i in range(max(0, line - 4), min(line + 5, len(lines))):
                 if i != line:
-                    print(f"{i+1:5d}  {lines[i]}")
+                    print(f"{i + 1:5d}  {lines[i]}")
                 else:
-                    print(f"{i+1:5d}  \033[33;1m{lines[line]}\033[0m")
+                    print(f"{i + 1:5d}  \033[33;1m{lines[line]}\033[0m")
                     print(" " * (col + 5) + "\033[31;1m<<^\033[0m")
             raise
 
@@ -317,15 +348,15 @@ class CModule(ModuleType):
     def __init__(self, source: Path) -> None:
         super().__init__(source.name, f"Generated from {source.with_suffix('.c')}")
 
-        so_file = source.with_suffix(".so")
+        shared_object_file = source.with_suffix(SHARED_OBJECT_SUFFIX)
         while True:
             try:
-                self.__binary__ = CDLL(so_file)
+                self.__binary__ = CDLL(str(shared_object_file))
                 break
             except OSError:
                 # On parallel runs we might still be compiling the source file
                 # so we try until we succeed.
-                if not so_file.exists():
+                if not shared_object_file.exists():
                     raise
 
         collector = DeclCollector()

--- a/test/cunit/test_error.py
+++ b/test/cunit/test_error.py
@@ -1,3 +1,4 @@
+import sys
 from test.cunit.error import cglobal
 from test.cunit.error import error_get_msg
 from test.cunit.error import is_fatal
@@ -38,5 +39,6 @@ def test_error_is_fatal(code, fatal):
     assert is_fatal(code) == fatal
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Only applicable on Linux")
 def test_error_austin_errno_global():
     assert cglobal("austin_errno", "int") == 0

--- a/test/cunit/test_platform.py
+++ b/test/cunit/test_platform.py
@@ -1,6 +1,10 @@
+import sys
 from test.cunit.platform import pid_max
 
+import pytest
 
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Only applicable on Linux")
 def test_pid_max():
     with open("/proc/sys/kernel/pid_max", "rb") as f:
         assert pid_max() == int(f.read()) > (1 << 15)

--- a/test/cunit/test_stats.py
+++ b/test/cunit/test_stats.py
@@ -2,15 +2,27 @@ import test.cunit.stats as stats
 import time
 
 
+def spinlock(duration: float) -> None:
+    end = time.monotonic() + duration
+    while time.monotonic() < end:
+        pass
+
+
 def test_stats_gettime():
+    stats.stats_start()
+
     begin = stats.gettime()
-    time.sleep(1)
+
+    spinlock(1)
+
     delta = stats.gettime() - begin
+
     assert 0.95 <= delta / 1e6 <= 1.05
 
 
 def test_stats_duration():
     stats.stats_start()
-    time.sleep(1)
-    dur = stats.stats_duration()
-    assert 0.95 <= dur / 1e6 <= 1.05
+
+    spinlock(1)
+
+    assert 0.95 <= stats.stats_duration() / 1e6 <= 1.05


### PR DESCRIPTION
We improve the compatibility of C unit tests so that they can run on other platforms other than Linux. In this particular change we focus on allowing running C unit tests on macOS with gcc.