### PR TITLE
tests: convert arguments in between major versions

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -29,7 +29,7 @@ SCENARIOS = [
         (
             "austin",
             f"CPU time [sampling interval: {i}]",
-            ["-Psi", str(i), sys.executable, target("target34.py")],
+            ["-Pci", str(i), sys.executable, target("target34.py")],
         )
         for i in (1, 10, 100, 1000)
     ],
@@ -37,7 +37,7 @@ SCENARIOS = [
         (
             "austin",
             f"RSA keygen [sampling interval: {i}]",
-            ["-Psi", str(i), sys.executable, "-m", "test.bm.rsa_key_generator"],
+            ["-Pci", str(i), sys.executable, "-m", "test.bm.rsa_key_generator"],
         )
         for i in (1, 10, 100, 1000)
     ],

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -4,6 +4,7 @@ import typing as t
 import zipfile
 from itertools import product
 from pathlib import Path
+from subprocess import CompletedProcess
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -30,6 +31,32 @@ class VersionedVariant(Variant):
     def __init__(self, name: str, version: str) -> None:
         super().__init__(name)
         self.version = version
+
+    @property
+    def version_info(self) -> t.Tuple[int, ...]:
+        if self.version == "dev":
+            return (float("inf"), float("inf"), float("inf"))
+        return tuple(int(part) for part in self.version.split("."))
+
+    def __call__(
+        self,
+        *args: str,
+        timeout: int = 60,
+        mojo: bool = False,
+        convert: bool = True,
+        expect_fail: t.Union[bool, int] = False,
+    ) -> CompletedProcess:
+        # Convert `-c` to `-s` for versions < 4.0.0
+        if self.version_info < (4, 0, 0):
+            args = tuple(a.replace("c", "s") if a.startswith("-") else a for a in args)
+
+        return super().__call__(
+            *args,
+            timeout=timeout,
+            mojo=mojo,
+            convert=convert,
+            expect_fail=expect_fail,
+        )
 
     def __repr__(self) -> str:
         return f"VersionedVariant(name={self.name!r}, version={self.version!r})"


### PR DESCRIPTION
We convert arguments in between major versions to allow jobs such as the benchmarks and the validation to run. In this case, we convert the sleepless switch to the cpu one, which is the equivalent in v4.