### PR TITLE
perf: code object caching

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -22,7 +22,55 @@
 
 #pragma once
 
+#include "cache.h"
+#include "py_proc.h"
 #include "py_string.h"
+
+typedef unsigned char* line_table_t;
+
+typedef struct {
+    key_dt           key;
+    cached_string_t* filename;
+    cached_string_t* scope;
+    line_table_t     line_table;
+    size_t           line_table_size;
+    unsigned int     first_line_number;
+} code_t;
+
+// ----------------------------------------------------------------------------
+static inline code_t*
+code_new(
+    key_dt key, cached_string_t* filename, cached_string_t* scope, line_table_t line_table, size_t line_table_size,
+    unsigned int first_line_number
+) {
+    code_t* code = (code_t*)malloc(sizeof(code_t));
+    if (!isvalid(code)) {
+        return NULL;
+    }
+
+    code->key               = key;
+    code->filename          = filename;
+    code->scope             = scope;
+    code->line_table        = line_table;
+    code->line_table_size   = line_table_size;
+    code->first_line_number = first_line_number;
+
+    return code;
+}
+
+// ----------------------------------------------------------------------------
+static inline void
+code__destroy(code_t* self) {
+    if (!isvalid(self)) {
+        return;
+    }
+
+    sfree(self->line_table);
+
+    free(self);
+}
+
+// ----------------------------------------------------------------------------
 
 #define _code__get_filename(self, pref, py_v)                                           \
     _string_from_raddr(pref, *((void**)((void*)self + py_v->py_code.o_filename)), py_v)
@@ -35,3 +83,68 @@
 
 #define _code__get_lnotab(self, pref, len, py_v)                                          \
     _bytes_from_raddr(pref, *((void**)((void*)self + py_v->py_code.o_lnotab)), len, py_v)
+
+// ----------------------------------------------------------------------------
+static inline code_t*
+_code_from_code_raddr(py_proc_t* py_proc, void* code_raddr) {
+    V_DESC(py_proc->py_v);
+
+    proc_ref_t pref = py_proc->proc_ref;
+
+    PyCodeObject code;
+    if (fail(copy_py(pref, code_raddr, py_code, code))) {
+        log_ie("Cannot read remote PyCodeObject");
+        return NULL;
+    }
+
+    lru_cache_t* cache = py_proc->string_cache;
+
+    // Get the file name from the code object
+    key_dt           string_key = py_string_key(code, o_filename);
+    cached_string_t* filename   = (cached_string_t*)lru_cache__maybe_hit(cache, string_key);
+    if (!isvalid(filename)) {
+        char* filename_value = _code__get_filename(&code, pref, py_v);
+        if (!isvalid(filename_value)) {
+            log_ie("Cannot get file name from PyCodeObject");
+            return NULL;
+        }
+        filename = cached_string_new(string_key, filename_value);
+        if (!isvalid(filename)) {
+            log_ie("Cannot create cached string for file name");
+            return NULL;
+        }
+        lru_cache__store(cache, string_key, filename);
+
+        event_handler__emit_new_string(filename);
+    }
+
+    // Get the function name from the code object
+    string_key             = V_MIN(3, 11) ? py_string_key(code, o_qualname) : py_string_key(code, o_name);
+    cached_string_t* scope = (cached_string_t*)lru_cache__maybe_hit(cache, string_key);
+    if (!isvalid(scope)) {
+        char* scope_value = V_MIN(3, 11) ? _code__get_qualname(&code, pref, py_v) : _code__get_name(&code, pref, py_v);
+        if (!isvalid(scope_value)) {
+            log_ie("Cannot get scope name from PyCodeObject");
+            return NULL;
+        }
+        scope = cached_string_new(string_key, scope_value);
+        if (!isvalid(scope)) {
+            log_ie("Cannot create cached string for scope name");
+            return NULL;
+        }
+        lru_cache__store(cache, string_key, scope);
+
+        event_handler__emit_new_string(scope);
+    }
+
+    // Get the code location table from the code object
+    ssize_t      len    = 0;
+    line_table_t lnotab = _code__get_lnotab(&code, pref, &len, py_v);
+    if (!isvalid(lnotab) || len <= 0) {
+        return NULL;
+    }
+
+    return code_new(
+        (key_dt)code_raddr, filename, scope, lnotab, len, V_FIELD(unsigned int, code, py_code, o_firstlineno)
+    );
+}

--- a/src/frame.h
+++ b/src/frame.h
@@ -24,6 +24,7 @@
 
 #include "cache.h"
 #include "events.h"
+#include "py_proc.h"
 #include "py_string.h"
 #include "resources.h"
 
@@ -69,6 +70,10 @@ frame_new(
 // ----------------------------------------------------------------------------
 static inline void
 frame__destroy(frame_t* self) {
+    if (!isvalid(self)) {
+        return;
+    }
+
     sfree(self);
 }
 
@@ -80,8 +85,7 @@ frame__destroy(frame_t* self) {
 #include "mojo.h"
 #include "py_proc.h"
 
-#define py_frame_key(code, lasti)  (((key_dt)(((key_dt)code) & MOJO_INT32) << 16) | lasti)
-#define py_string_key(code, field) ((key_dt) * ((void**)((void*)&code + py_v->py_code.field)))
+#define py_frame_key(code, lasti) (((key_dt)(((key_dt)code) & MOJO_INT32) << 16) | lasti)
 
 // ----------------------------------------------------------------------------
 static inline int
@@ -104,63 +108,26 @@ _read_signed_varint(unsigned char* lnotab, size_t* i) {
 
 // ----------------------------------------------------------------------------
 static inline frame_t*
-_frame_from_code_raddr(py_proc_t* py_proc, void* code_raddr, int lasti, python_v* py_v) {
-    cu_uchar*    lnotab = NULL;
-    proc_ref_t   pref   = py_proc->proc_ref;
-    PyCodeObject code;
+_frame_from_code_raddr(py_proc_t* py_proc, void* code_raddr, int lasti) {
+    V_DESC(py_proc->py_v);
 
-    if (fail(copy_py(pref, code_raddr, py_code, code))) {
-        log_ie("Cannot read remote PyCodeObject");
-        return NULL;
+    code_t* code = lru_cache__maybe_hit(py_proc->code_cache, (key_dt)code_raddr);
+    if (!isvalid(code)) {
+        code = _code_from_code_raddr(py_proc, code_raddr);
+        if (!isvalid(code))
+            return NULL;
+        lru_cache__store(py_proc->code_cache, (key_dt)code_raddr, code);
     }
 
-    lru_cache_t* cache = py_proc->string_cache;
-
-    key_dt           string_key = py_string_key(code, o_filename);
-    cached_string_t* filename   = (cached_string_t*)lru_cache__maybe_hit(cache, string_key);
-    if (!isvalid(filename)) {
-        char* filename_value = _code__get_filename(&code, pref, py_v);
-        if (!isvalid(filename_value)) {
-            log_ie("Cannot get file name from PyCodeObject");
-            return NULL;
-        }
-        filename = cached_string_new(string_key, filename_value);
-        if (!isvalid(filename)) {
-            log_ie("Cannot create cached string for file name");
-            return NULL;
-        }
-        lru_cache__store(cache, string_key, filename);
-
-        event_handler__emit_new_string(filename);
-    }
-
-    string_key             = V_MIN(3, 11) ? py_string_key(code, o_qualname) : py_string_key(code, o_name);
-    cached_string_t* scope = (cached_string_t*)lru_cache__maybe_hit(cache, string_key);
-    if (!isvalid(scope)) {
-        char* scope_value = V_MIN(3, 11) ? _code__get_qualname(&code, pref, py_v) : _code__get_name(&code, pref, py_v);
-        if (!isvalid(scope_value)) {
-            log_ie("Cannot get scope name from PyCodeObject");
-            return NULL;
-        }
-        scope = cached_string_new(string_key, scope_value);
-        if (!isvalid(scope)) {
-            log_ie("Cannot create cached string for scope name");
-            return NULL;
-        }
-        lru_cache__store(cache, string_key, scope);
-
-        event_handler__emit_new_string(scope);
-    }
-
-    ssize_t len = 0;
-
-    unsigned int lineno     = V_FIELD(unsigned int, code, py_code, o_firstlineno);
+    // Compute the code location information
+    line_table_t lnotab     = code->line_table;
+    ssize_t      len        = code->line_table_size;
+    unsigned int lineno     = code->first_line_number;
     unsigned int line_end   = 0;
     unsigned int column     = 0;
     unsigned int column_end = 0;
 
     if (V_MIN(3, 11)) {
-        lnotab = _code__get_lnotab(&code, pref, &len, py_v);
         if (!isvalid(lnotab) || len == 0) {
             log_ie("Cannot get line information from PyCodeObject");
             return NULL;
@@ -208,7 +175,6 @@ _frame_from_code_raddr(py_proc_t* py_proc, void* code_raddr, int lasti, python_v
                 break;
         }
     } else {
-        lnotab = _code__get_lnotab(&code, pref, &len, py_v);
         if (!isvalid(lnotab) || len % 2) {
             log_ie("Cannot get line information from PyCodeObject");
             return NULL;
@@ -247,11 +213,7 @@ _frame_from_code_raddr(py_proc_t* py_proc, void* code_raddr, int lasti, python_v
         }
     }
 
-    frame_t* frame = frame_new(py_frame_key(code_raddr, lasti), filename, scope, lineno, line_end, column, column_end);
-    if (!isvalid(frame)) {
-        log_e("Failed to create frame object");
-        return NULL;
-    }
-
-    return frame;
+    return frame_new(
+        py_frame_key(code_raddr, lasti), code->filename, code->scope, lineno, line_end, column, column_end
+    );
 }

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -55,6 +55,17 @@
 
 // ---- PRIVATE ---------------------------------------------------------------
 
+// In native mode we have both the Python and native stacks (the kernel stack
+// is negligible). We make sure we have a cache large enough to hold the full.
+// stack.
+#ifdef NATIVE
+#define MAX_FRAME_CACHE_SIZE (MAX_STACK_SIZE << 1)
+#else
+#define MAX_FRAME_CACHE_SIZE MAX_STACK_SIZE
+#endif
+#define MAX_STRING_CACHE_SIZE LRU_CACHE_EXPAND
+#define MAX_CODE_CACHE_SIZE   LRU_CACHE_EXPAND
+
 #define py_proc__memcpy(self, raddr, size, dest) copy_memory(self->proc_ref, raddr, size, dest)
 
 // ----------------------------------------------------------------------------
@@ -786,6 +797,15 @@ py_proc_new(bool child) {
     py_proc->string_cache->name = "string cache";
 #endif
 
+    py_proc->code_cache = lru_cache_new(MAX_CODE_CACHE_SIZE, (void (*)(value_t))code__destroy);
+    if (!isvalid(py_proc->code_cache)) {
+        log_e("Failed to allocate code cache");
+        goto error;
+    }
+#ifdef DEBUG
+    py_proc->code_cache->name = "code cache";
+#endif
+
     py_proc->extra = (proc_extra_info*)calloc(1, sizeof(proc_extra_info));
     if (!isvalid(py_proc->extra))
         goto error;
@@ -1462,6 +1482,7 @@ py_proc__destroy(py_proc_t* self) {
 
     lru_cache__destroy(self->string_cache);
     lru_cache__destroy(self->frame_cache);
+    lru_cache__destroy(self->code_cache);
 
     free(self);
 }

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -79,6 +79,7 @@ typedef struct {
 
     lru_cache_t* frame_cache;
     lru_cache_t* string_cache;
+    lru_cache_t* code_cache;
 
     // Temporal profiling support
     microseconds_t timestamp;

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -161,3 +161,5 @@ error:
     sfree(array);
     return NULL;
 }
+
+#define py_string_key(code, field) ((key_dt) * ((void**)((void*)&code + py_v->py_code.field)))

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -95,7 +95,7 @@ _py_thread__resolve_py_stack(py_thread_t* self) {
         frame_t* frame     = lru_cache__maybe_hit(cache, frame_key);
 
         if (!isvalid(frame)) {
-            frame = _frame_from_code_raddr(self->proc, py_frame.code, lasti, self->proc->py_v);
+            frame = _frame_from_code_raddr(self->proc, py_frame.code, lasti);
             if (!isvalid(frame)) {
                 log_ie("Failed to get frame from code object");
                 // Truncate the stack to the point where we have successfully resolved.

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -34,15 +34,6 @@
 
 #define MAXLEN         1024
 #define MAX_STACK_SIZE 2048
-#ifdef NATIVE
-// In native mode we have both the Python and native stacks (the kernel stack
-// is negligible). We make sure we have a cache large enough to hold the full.
-// stack.
-#define MAX_FRAME_CACHE_SIZE (MAX_STACK_SIZE << 1)
-#else
-#define MAX_FRAME_CACHE_SIZE MAX_STACK_SIZE
-#endif
-#define MAX_STRING_CACHE_SIZE LRU_CACHE_EXPAND
 
 typedef struct thread {
     raddr_t raddr;


### PR DESCRIPTION
We build upon frame caching by also caching code object reads. In more complicated code bases, this should save re-reading the same code code object information multiple times for frames that differ in just the instruction pointer, at the cost of extra memory.

We expect this new caching to have a minimal performance impact on simple applications, where the frame cache does the major work in general. The following cache statistics have been derived from the `target34.py` test target

```
(string cache) hit ratio: 14/34 (41.18%)
(string cache) hash collisions: 0/20 (0.00%, prob: 12.99%)
(frame cache) hit ratio: 465344/465382 (99.99%)
(frame cache) hash collisions: 1/38 (2.63%, prob: 22.70%)
(code cache) hit ratio: 21/38 (55.26%)
(code cache) hash collisions: 0/17 (0.00%, prob: 9.48%)
```