### PR TITLE
bm: compare against the base of the PR

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,8 +12,6 @@ jobs:
   benchmarks:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -24,7 +22,20 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Compile Austin
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Compile Austin from the base branch
+        run: |
+          autoreconf --install
+          ./configure --enable-debug=symbols
+          make
+          mv src/austin src/austin.base
+
+      - uses: actions/checkout@v3
+
+      - name: Compile Austin from the PR
         run: |
           autoreconf --install
           ./configure --enable-debug=symbols
@@ -44,7 +55,7 @@ jobs:
           ulimit -c unlimited
           echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
           source .venv/bin/activate
-          python scripts/benchmark.py --format markdown --last | tee comment.txt
+          python scripts/benchmark.py --format markdown | tee comment.txt
 
       - name: Post results on PR
         uses: marocchino/sticky-pull-request-comment@v2

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -15,7 +15,7 @@ from scipy.stats import ttest_ind
 
 from test.utils import metadata, target
 
-VERSIONS = ("3.6.0", "3.7.0", "dev")
+VERSIONS = ("base", "dev")
 SCENARIOS = [
     *[
         (
@@ -161,7 +161,9 @@ class TerminalRenderer(Renderer):
 
     def render_summary(self, summary):
         self.render_header("Benchmark Summary", level=2)
-        self.render_paragraph(f"Comparison of {VERSIONS[-1]} against {VERSIONS[-2]}.")
+        self.render_paragraph(
+            f"Comparison of **{VERSIONS[-1]}** against **{VERSIONS[-2]}**."
+        )
 
         if not summary:
             self.render_paragraph(
@@ -282,48 +284,7 @@ def summarize(results: t.List[t.Tuple[str, t.List[Results]]]):
     return summary
 
 
-def main():
-    argp = ArgumentParser()
-
-    argp.add_argument(
-        "-k",
-        type=re.compile,
-        help="Run benchmark scenarios that match the given regular expression",
-    )
-
-    argp.add_argument(
-        "-n",
-        type=int,
-        default=10,
-        help="Number of times to run each scenario",
-    )
-
-    argp.add_argument(
-        "-f",
-        "--format",
-        type=str,
-        choices=["terminal", "markdown"],
-        default="terminal",
-        help="The output format",
-    )
-
-    argp.add_argument(
-        "-l",
-        "--last",
-        action="store_true",
-        help="Run only with the last release of Austin",
-    )
-
-    argp.add_argument(
-        "-p",
-        "--pvalue",
-        type=float,
-        default=0.025,
-        help="The p-value to use when testing for statistical significance",
-    )
-
-    opts = argp.parse_args()
-
+def benchmark(opts: ArgumentParser) -> None:
     Outcome.__critical_p__ = opts.pvalue
 
     renderer = {"terminal": TerminalRenderer, "markdown": MarkdownRenderer}[
@@ -342,7 +303,7 @@ def main():
             continue
 
         table: t.List[Results] = []
-        for version in VERSIONS[-2:] if opts.last else VERSIONS:
+        for version in VERSIONS:
             print(f"> Running with Austin {version} ...    ", end="\r", file=sys.stderr)
             try:
                 austin = download_release(version, Path("/tmp"), variant_name=variant)
@@ -376,6 +337,44 @@ def main():
     renderer.render_header("Benchmark Results", level=2)
     for title, table in results:
         renderer.render_scenario(title, table)
+
+
+def main():
+    argp = ArgumentParser()
+
+    argp.add_argument(
+        "-k",
+        type=re.compile,
+        help="Run benchmark scenarios that match the given regular expression",
+    )
+
+    argp.add_argument(
+        "-n",
+        type=int,
+        default=10,
+        help="Number of times to run each scenario",
+    )
+
+    argp.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        choices=["terminal", "markdown"],
+        default="terminal",
+        help="The output format",
+    )
+
+    argp.add_argument(
+        "-p",
+        "--pvalue",
+        type=float,
+        default=0.025,
+        help="The p-value to use when testing for statistical significance",
+    )
+
+    opts = argp.parse_args()
+
+    benchmark(opts)
 
 
 if __name__ == "__main__":

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -35,7 +35,9 @@ class VersionedVariant(Variant):
     @property
     def version_info(self) -> t.Tuple[int, ...]:
         if self.version == "dev":
-            return (float("inf"), float("inf"), float("inf"))
+            return (float("inf"), float("inf"), float("inf"), float("inf"))
+        if self.version == "base":
+            return (float("inf"), float("inf"), float("inf"), 0)
         return tuple(int(part) for part in self.version.split("."))
 
     def __call__(
@@ -74,6 +76,9 @@ def download_release(
 ) -> VersionedVariant:
     if version == "dev":
         return VersionedVariant(f"src/{variant_name}", version)
+
+    if version == "base":
+        return VersionedVariant(f"src/{variant_name}.base", version)
 
     if dest is None:
         msg = "Destination path must be provided for non-dev versions"


### PR DESCRIPTION
Currently the benchmarks compare each PR against the latest release. The result is a comparison of all the cumulative changes. We make the benchmark compare against the base of each PR instead to get an idea of the performance impact of each incremental change instead.