### PR TITLE
ci: remove 3.8 from code coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -139,7 +139,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install \
             valgrind \
-            python3.{8..13} \
+            python3.{9..13} \
             python3.10-full python3.10-dev
 
           python3.10 -m venv .venv

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,7 @@
 import os
 import platform
 
-PY3_EARLIEST = 8
+PY3_EARLIEST = 9
 PY3_LATEST = 13
 
 try:


### PR DESCRIPTION
After dropping support for 3.8 we still try to run coverage tests for this version of CPython.