### PR TITLE
perf: page size cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,9 +345,10 @@ process ID, the sub-interpreter ID, and the thread ID respectively.
 
 Some behaviour of Austin can be configured via environment variables.
 
-| Variable            | Effect                                                      |
-| ------------------- | ----------------------------------------------------------- |
-| `AUSTIN_NO_LOGGING` | Disables all [log messages](#logging) (since Austin 3.4.0). |
+| Variable               | Effect                                                               |
+| ---------------------- | -------------------------------------------------------------------- |
+| `AUSTIN_NO_LOGGING`    | Disables all [log messages](#logging) (since Austin 3.4.0).          |
+| `AUSTIN_PAGE_SIZE_CAP` | Cap the page size used to perform remote reads (since Austin 4.0.0). |
 
 
 ## Normal Mode

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,6 +52,7 @@ austin_SOURCES = \
   argparse.c     \
   austin.c       \
   cache.c        \
+  env.c          \
   error.c        \
   events.c       \
   logging.c      \

--- a/src/austin.c
+++ b/src/austin.c
@@ -33,6 +33,7 @@
 
 #include "argparse.h"
 #include "austin.h"
+#include "env.h"
 #include "error.h"
 #include "events.h"
 #include "hints.h"
@@ -275,6 +276,10 @@ main(int argc, char** argv) {
     int        retval  = 0;
     py_proc_t* py_proc = NULL;
 
+    if (fail(parse_env())) {
+        log_e("Failed to parse environment variables");
+        return EENV;
+    }
     parse_args(argc, argv);
 
 #if defined PL_MACOS

--- a/src/env.c
+++ b/src/env.c
@@ -1,0 +1,81 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2025 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "env.h"
+#include "hints.h"
+
+// Globals for command line arguments
+parsed_env_t env = {
+    /* logging       */ true,
+    /* page_size_cap */ 4096, // 4 KiB
+};
+
+// ----------------------------------------------------------------------------
+static inline void
+_env_error(char* var) {
+    fprintf(stderr, "Invalid value '%s' for Austin environment variable '%s'\n", getenv(var), var);
+}
+
+// ----------------------------------------------------------------------------
+static inline bool
+_is_set(const char* s) {
+    const char* v = getenv(s);
+    return v != NULL && *v != '\0';
+}
+
+// ----------------------------------------------------------------------------
+static inline int
+_to_number(char* var, long* num, long default_value) {
+    char* value = getenv(var);
+    if (!isvalid(value)) {
+        *num = default_value;
+        return 0;
+    }
+
+    char* p_err;
+
+    *num = strtol(value, &p_err, 10);
+
+    return (p_err == value || *p_err != '\0') ? 1 : 0;
+}
+
+// ----------------------------------------------------------------------------
+int
+parse_env() {
+    // AUSTIN_NO_LOGGING
+    if (_is_set("AUSTIN_NO_LOGGING")) {
+        env.logging = false;
+    }
+
+    // AUSTIN_PAGE_SIZE_CAP
+    long page_size_cap;
+    if (fail(_to_number("AUSTIN_PAGE_SIZE_CAP", &page_size_cap, env.page_size_cap))) {
+        _env_error("AUSTIN_PAGE_SIZE_CAP");
+        FAIL;
+    }
+    env.page_size_cap = (size_t)page_size_cap;
+
+    SUCCESS;
+}

--- a/src/env.h
+++ b/src/env.h
@@ -1,0 +1,39 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2025 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct {
+    bool   logging;
+    size_t page_size_cap;
+} parsed_env_t;
+
+#ifndef ENV_C
+extern parsed_env_t env;
+#endif
+
+// ----------------------------------------------------------------------------
+int
+parse_env();

--- a/src/error.h
+++ b/src/error.h
@@ -35,6 +35,7 @@
 #define ENULLDEV   4
 #define ECMDLINE   5
 #define ESYM       6
+#define EENV       7
 
 // PyCodeObject
 #define ECODE         ((1 << 3) + 0)

--- a/src/logging.c
+++ b/src/logging.c
@@ -23,6 +23,7 @@
 #define _DEFAULT_SOURCE
 
 #include "austin.h"
+#include "env.h"
 #include "events.h"
 #include "mem.h"
 #include "platform.h"
@@ -52,11 +53,9 @@ FILE* logfile = NULL;
 #include "austin.h"
 #include "logging.h"
 
-bool logging = true;
-
 void
 _log_writer(int prio, const char* fmt, va_list ap) {
-    if (!logging)
+    if (!env.logging)
         return;
 #ifdef PL_UNIX
     vsyslog(prio, fmt, ap);
@@ -91,18 +90,8 @@ _log_writer(int prio, const char* fmt, va_list ap) {
 #endif
 }
 
-static bool
-has_nonempty_env(const char* s) {
-    const char* v = getenv(s);
-    return v != NULL && *v != '\0';
-}
-
 void
 logger_init(void) {
-    if (has_nonempty_env("AUSTIN_NO_LOGGING"))
-        logging = false;
-    if (!logging)
-        return;
 #ifdef PL_UNIX
     setlogmask(LOG_UPTO(LOG_DEBUG));
     openlog(PROGRAM_NAME, LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);
@@ -192,7 +181,7 @@ log_t(const char* fmt, ...) {
 
 void
 logger_close(void) {
-    if (!logging)
+    if (!env.logging)
         return;
 #ifdef PL_UNIX
     closelog();

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -40,6 +40,7 @@
 
 #include "argparse.h"
 #include "bin.h"
+#include "env.h"
 #include "error.h"
 #include "events.h"
 #include "hints.h"
@@ -739,7 +740,12 @@ _py_proc__run(py_proc_t* self) {
     V_DESC(self->py_v);
 
     size_t page_size = get_page_size();
-    size_t com       = (py_v->py_is.o_gc + py_v->py_is.o_gil_state + py_v->py_is.o_id + py_v->py_is.o_next
+    if (page_size > env.page_size_cap) {
+        log_d("Page size %zu is larger than the configured cap %zu, using cap instead", page_size, env.page_size_cap);
+        page_size = env.page_size_cap;
+    }
+
+    size_t com = (py_v->py_is.o_gc + py_v->py_is.o_gil_state + py_v->py_is.o_id + py_v->py_is.o_next
                   + py_v->py_is.o_tstate_head)
                / 5;
 

--- a/test/cunit/stats.py
+++ b/test/cunit/stats.py
@@ -1,13 +1,13 @@
 import sys
 from pathlib import Path
-from test.cunit import SRC
-from test.cunit import CModule
 
+from test.cunit import SRC, CModule
 
 CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 EXTRA_SOURCES = [
     SRC / "argparse.c",
+    SRC / "env.c",
     SRC / "events.c",
     SRC / "logging.c",
     SRC / "stack.c",


### PR DESCRIPTION
We introduce a page size cap for remote VM reads that can be configured via environment variables. A smaller page size on systems that have large defaults (e.g. 16K on M1) appears to be beneficial in terms of performance. We expose this via env var to allow tuning it if required.