### PR TITLE
refactor: dynamic stack allocations

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -91,7 +91,8 @@ _code_from_code_raddr(py_proc_t* py_proc, void* code_raddr) {
 
     proc_ref_t pref = py_proc->proc_ref;
 
-    PyCodeObject code;
+    V_ALLOCA(code, code);
+
     if (fail(copy_py(pref, code_raddr, py_code, code))) {
         log_ie("Cannot read remote PyCodeObject");
         return NULL;

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -369,21 +369,22 @@ _py_proc__check_interp_state(py_proc_t* self, void* raddr) {
 
     V_DESC(self->py_v);
 
-    if (py_proc__copy_v(self, is, raddr, self->is)) {
-        log_ie("Cannot get remote interpreter state");
+    V_ALLOCA(thread, tstate);
+
+    void* tstate_head_addr;
+    if (fail(py_proc__copy_field_v(self, is, tstate_head, raddr, tstate_head_addr))) {
+        log_ie("Cannot get remote interpreter state head");
         FAIL;
     }
-    log_d("Interpreter state buffer %p", self->is);
-    void* tstate_head_addr = V_FIELD_PTR(void*, self->is, py_is, o_tstate_head);
 
-    if (fail(py_proc__copy_v(self, thread, tstate_head_addr, self->ts))) {
+    if (fail(py_proc__copy_v(self, thread, tstate_head_addr, &tstate))) {
         log_e("Cannot copy PyThreadState head at %p from PyInterpreterState instance", tstate_head_addr);
         FAIL;
     }
 
     log_t("PyThreadState head loaded @ %p", V_FIELD(void*, is, py_is, o_tstate_head));
 
-    if (V_FIELD_PTR(void*, self->ts, py_thread, o_interp) != raddr) {
+    if (V_FIELD(void*, tstate, py_thread, o_interp) != raddr) {
         log_d("PyThreadState head does not point to interpreter state");
         set_error(EPROC);
         FAIL;
@@ -393,8 +394,12 @@ _py_proc__check_interp_state(py_proc_t* self, void* raddr) {
 
     log_t("PyInterpreterState loaded @ %p. Thread State head @ %p", raddr, V_FIELD(void*, is, py_is, o_tstate_head));
 
-    raddr_t     thread_raddr = {self->proc_ref, V_FIELD_PTR(void*, self->is, py_is, o_tstate_head)};
     py_thread_t thread;
+    raddr_t     thread_raddr = {self->proc_ref};
+    if (fail(py_proc__copy_field_v(self, is, tstate_head, raddr, thread_raddr.addr))) {
+        log_ie("Cannot get remote thread state head");
+        FAIL;
+    }
 
     if (fail(py_thread__fill_from_raddr(&thread, &thread_raddr, self))) {
         log_d("Failed to fill thread structure");
@@ -511,6 +516,8 @@ _py_proc__deref_interp_head(py_proc_t* self) {
 
     V_DESC(self->py_v);
 
+    V_ALLOCA(runtime, runtime);
+
     void* interp_head_raddr = NULL;
 
     void* runtime_addr = self->symbols[DYNSYM_RUNTIME];
@@ -532,12 +539,13 @@ _py_proc__deref_interp_head(py_proc_t* self) {
 #endif
 
     for (void* current_addr = lower; current_addr <= upper; current_addr += sizeof(void*)) {
-        if (py_proc__copy_v(self, runtime, current_addr, self->rs)) {
+        if (py_proc__copy_v(self, runtime, current_addr, &runtime)) {
             log_d("Cannot copy runtime state structure from remote address %p", current_addr);
             continue;
         }
 
-        interp_head_raddr = V_FIELD_PTR(void*, self->rs, py_runtime, o_interp_head);
+        interp_head_raddr = V_FIELD(void*, runtime, py_runtime, o_interp_head);
+
         if (fail(_py_proc__check_interp_state(self, interp_head_raddr))) {
             log_d("Interpreter state check failed while dereferencing runtime state");
             interp_head_raddr = NULL;
@@ -572,47 +580,6 @@ _py_proc__get_current_thread_state_raddr(py_proc_t* self) {
 }
 
 // ----------------------------------------------------------------------------
-static void
-_py_proc__free_local_buffers(py_proc_t* self) {
-    sfree(self->is);
-    sfree(self->ts);
-    sfree(self->rs);
-}
-
-// ----------------------------------------------------------------------------
-#define LOCAL_ALLOC(dest, src, name)                       \
-    {                                                      \
-        self->dest = calloc(1, self->py_v->py_##src.size); \
-        if (!isvalid(self->dest)) {                        \
-            log_e("Cannot allocate memory for " #name);    \
-            goto error;                                    \
-        }                                                  \
-    }
-
-static int
-_py_proc__init_local_buffers(py_proc_t* self) {
-    if (!isvalid(self)) {
-        set_error(EPROC);
-        FAIL;
-    }
-
-    LOCAL_ALLOC(rs, runtime, "PyRuntimeState");
-    LOCAL_ALLOC(is, is, "PyInterpreterState");
-    LOCAL_ALLOC(ts, thread, "PyThreadState");
-
-    log_d("Local buffers initialised");
-
-    SUCCESS;
-
-error:
-    set_error(ENOMEM);
-
-    _py_proc__free_local_buffers(self);
-
-    FAIL;
-}
-
-// ----------------------------------------------------------------------------
 static int
 _py_proc__find_interpreter_state(py_proc_t* self) {
     if (!isvalid(self)) {
@@ -625,9 +592,6 @@ _py_proc__find_interpreter_state(py_proc_t* self) {
 
     // Determine and set version
     if (fail(_py_proc__infer_python_version(self)))
-        FAIL;
-
-    if (fail(_py_proc__init_local_buffers(self)))
         FAIL;
 
     if (self->sym_loaded || isvalid(self->map.runtime.base)) {
@@ -778,10 +742,6 @@ py_proc_new(bool child) {
     py_proc->child          = child;
     py_proc->gc_state_raddr = NULL;
     py_proc->py_v           = NULL;
-
-    py_proc->is = NULL;
-    py_proc->ts = NULL;
-    py_proc->rs = NULL;
 
     _prehash_symbols();
 
@@ -1031,19 +991,14 @@ _py_proc__find_current_thread_offset(py_proc_t* self, void* thread_raddr) {
 
     V_DESC(self->py_v);
 
-    void* interp_head_raddr;
+    V_ALLOCA(runtime, runtime);
 
-    if (py_proc__copy_v(self, runtime, self->symbols[DYNSYM_RUNTIME], self->rs))
+    if (py_proc__copy_v(self, runtime, self->symbols[DYNSYM_RUNTIME], &runtime))
         FAIL;
 
-    interp_head_raddr = V_FIELD_PTR(void*, self->rs, py_runtime, o_interp_head);
-
     // Search offset of current thread in _PyRuntimeState structure
-    PyInterpreterState is;
-    py_proc__get_type(self, interp_head_raddr, is);
-    void* current_thread_raddr = NULL;
-
-    register int hit_count = 0;
+    void*        current_thread_raddr = NULL;
+    register int hit_count            = 0;
     for (register void** raddr = (void**)self->symbols[DYNSYM_RUNTIME];
          (void*)raddr < self->symbols[DYNSYM_RUNTIME] + PYRUNTIMESTATE_SIZE; raddr++) {
         py_proc__get_type(self, raddr, current_thread_raddr);
@@ -1479,8 +1434,6 @@ py_proc__destroy(py_proc_t* self) {
 #if defined PL_MACOS
     mach_port_deallocate(mach_task_self(), self->proc_ref);
 #endif
-
-    _py_proc__free_local_buffers(self);
 
     sfree(self->bin_path);
     sfree(self->lib_path);

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -98,11 +98,6 @@ typedef struct {
     hash_table_t*    base_table;
 #endif
 
-    // Local buffers
-    _PyRuntimeState*    rs;
-    PyInterpreterState* is;
-    PyThreadState*      ts;
-
     com_t interpreter_state_com;
 
     // Platform-dependent fields

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -151,7 +151,7 @@ static unsigned int _stack_chunk_misses = 0;
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_thread__push_iframe_from_addr(py_thread_t* self, PyInterpreterFrame* iframe, void** prev) {
+_py_thread__push_iframe_from_addr(py_thread_t* self, void* iframe, void** prev) {
     V_DESC(self->proc->py_v);
 
     void* origin     = *prev;
@@ -193,9 +193,9 @@ _py_thread__push_iframe_from_addr(py_thread_t* self, PyInterpreterFrame* iframe,
 // ----------------------------------------------------------------------------
 static inline int
 _py_thread__push_iframe_from_raddr(py_thread_t* self, void** prev) {
-    PyInterpreterFrame iframe;
-
     V_DESC(self->proc->py_v);
+
+    V_ALLOCA(iframe, iframe);
 
     if (fail(copy_py(self->raddr.pref, *prev, py_iframe, iframe))) {
         log_ie("Cannot read remote PyInterpreterFrame");
@@ -588,7 +588,7 @@ py_thread__fill_from_raddr(py_thread_t* self, raddr_t* raddr, py_proc_t* proc) {
 
     V_DESC(proc->py_v);
 
-    PyThreadState ts;
+    V_ALLOCA(thread, ts);
 
     self->invalid = true;
 

--- a/src/version.h
+++ b/src/version.h
@@ -65,6 +65,15 @@
 #define V_DESC(desc) python_v* py_v = (desc)
 
 /**
+ * Allocate a variable of the given type on the stack, using the size
+ * specified in the versioned Python structure.
+ *
+ * @param type the type of the variable to allocate, e.g. thread for py_thread.
+ * @param var  the name of the variable to allocate.
+ */
+#define V_ALLOCA(type, var) char var[py_v->py_##type.size];
+
+/**
  * Ensure the current version of Python is at least/at most the request version.
  *
  * @param  M  requested major version


### PR DESCRIPTION
We make the allocation of Python structures in the stack frame dynamic to allow them to take the size specified by the Python version descriptors.