### PR TITLE
chore: event buffering in pipe mode

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -21,7 +21,7 @@ SCENARIOS = [
         (
             "austin",
             f"Wall time [sampling interval: {i}]",
-            ["-Pi", str(i), sys.executable, target("target34.py")],
+            ["-i", str(i), sys.executable, target("target34.py")],
         )
         for i in (1, 10, 100, 1000)
     ],
@@ -29,7 +29,7 @@ SCENARIOS = [
         (
             "austin",
             f"CPU time [sampling interval: {i}]",
-            ["-Pci", str(i), sys.executable, target("target34.py")],
+            ["-ci", str(i), sys.executable, target("target34.py")],
         )
         for i in (1, 10, 100, 1000)
     ],
@@ -37,7 +37,7 @@ SCENARIOS = [
         (
             "austin",
             f"RSA keygen [sampling interval: {i}]",
-            ["-Pci", str(i), sys.executable, "-m", "test.bm.rsa_key_generator"],
+            ["-ci", str(i), sys.executable, "-m", "test.bm.rsa_key_generator"],
         )
         for i in (1, 10, 100, 1000)
     ],
@@ -45,7 +45,7 @@ SCENARIOS = [
         (
             "austin",
             f"Full metrics [sampling interval: {i}]",
-            ["-Pfi", str(i), sys.executable, target("target34.py")],
+            ["-fi", str(i), sys.executable, target("target34.py")],
         )
         for i in (1, 10, 100, 1000)
     ],
@@ -53,7 +53,7 @@ SCENARIOS = [
         (
             "austin",
             f"Multiprocess wall time [sampling interval: {i}]",
-            ["-CPfi", str(i), sys.executable, target("target_mp.py"), "16"],
+            ["-Cfi", str(i), sys.executable, target("target_mp.py"), "16"],
         )
         for i in (1, 10, 100, 1000)
     ],

--- a/src/austin.c
+++ b/src/austin.c
@@ -406,13 +406,7 @@ main(int argc, char** argv) {
         goto finally;
     }
 
-    event_handler__emit_metadata("duration", MICROSECONDS_FMT, stats_duration());
-    if (pargs.gc) {
-        event_handler__emit_metadata("gc", MICROSECONDS_FMT, _gc_time);
-    }
-
-    if (!pargs.where)
-        stats_log_metrics();
+    stats_log_metrics();
 
 finally:
     py_thread_free();

--- a/src/events.c
+++ b/src/events.c
@@ -58,6 +58,10 @@ mojo_event_handler__handle_metadata(base_event_handler_t* self, char* key, char*
     mojo_string(key);
     vfprintf(pargs.output_file, value, args);
     fputc('\0', pargs.output_file);
+
+    // In pipe mode we do Austin event buffering.
+    if (pargs.pipe)
+        fflush(pargs.output_file);
 }
 
 static inline void
@@ -152,6 +156,10 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
             mojo_metric_time(sample->time);
         }
     }
+
+    // In pipe mode we do Austin event buffering.
+    if (pargs.pipe)
+        fflush(pargs.output_file);
 }
 
 event_handler_t*


### PR DESCRIPTION
When in pipe mode we do event buffering. This is the equivalent of line buffering but for the two main Austin events, that is samples and metadata. With this change, any tool communicating with Austin via a pipe will get the bytes for each event immediately instead of at the default stream buffer size. This allows tools to get events from Austin in real-time as they are collected instead of periodic bursts.

> [!NOTE]
> This change has a performance impact on pipe mode.