### PR TITLE
refactor: remote address data type

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -73,24 +73,23 @@ code__destroy(code_t* self) {
 
 // ----------------------------------------------------------------------------
 
-#define _code__get_filename(self, pref, py_v)                                           \
-    _string_from_raddr(pref, *((void**)((void*)self + py_v->py_code.o_filename)), py_v)
+#define _code__get_filename(self, pref, py_v)                                         \
+    _string_remote(pref, *((raddr_t*)((void*)self + py_v->py_code.o_filename)), py_v)
 
-#define _code__get_name(self, pref, py_v)                                           \
-    _string_from_raddr(pref, *((void**)((void*)self + py_v->py_code.o_name)), py_v)
+#define _code__get_name(self, pref, py_v) _string_remote(pref, *((raddr_t*)((void*)self + py_v->py_code.o_name)), py_v)
 
-#define _code__get_qualname(self, pref, py_v)                                           \
-    _string_from_raddr(pref, *((void**)((void*)self + py_v->py_code.o_qualname)), py_v)
+#define _code__get_qualname(self, pref, py_v)                                         \
+    _string_remote(pref, *((raddr_t*)((void*)self + py_v->py_code.o_qualname)), py_v)
 
-#define _code__get_lnotab(self, pref, len, py_v)                                          \
-    _bytes_from_raddr(pref, *((void**)((void*)self + py_v->py_code.o_lnotab)), len, py_v)
+#define _code__get_lnotab(self, pref, len, py_v)                                        \
+    _bytes_remote(pref, *((raddr_t*)((void*)self + py_v->py_code.o_lnotab)), len, py_v)
 
 // ----------------------------------------------------------------------------
 static inline code_t*
-_code_from_code_raddr(py_proc_t* py_proc, void* code_raddr) {
+_code_remote(py_proc_t* py_proc, raddr_t code_raddr) {
     V_DESC(py_proc->py_v);
 
-    proc_ref_t pref = py_proc->proc_ref;
+    proc_ref_t pref = py_proc->ref;
 
     V_ALLOCA(code, code);
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -40,9 +40,9 @@ typedef struct {
 } frame_t;
 
 typedef struct {
-    void* origin;
-    void* code;
-    int   lasti;
+    raddr_t origin;
+    raddr_t code;
+    int     lasti;
 } py_frame_t;
 
 // ----------------------------------------------------------------------------
@@ -110,12 +110,12 @@ _read_signed_varint(unsigned char* lnotab, size_t* i) {
 
 // ----------------------------------------------------------------------------
 static inline frame_t*
-_frame_from_code_raddr(py_proc_t* py_proc, void* code_raddr, int lasti) {
+_frame_remote(py_proc_t* py_proc, raddr_t code_raddr, int lasti) {
     V_DESC(py_proc->py_v);
 
     code_t* code = lru_cache__maybe_hit(py_proc->code_cache, (key_dt)code_raddr);
     if (!isvalid(code)) {
-        code = _code_from_code_raddr(py_proc, code_raddr);
+        code = _code_remote(py_proc, code_raddr);
         if (!isvalid(code))
             FAIL_PTR;
         lru_cache__store(py_proc->code_cache, (key_dt)code_raddr, code);

--- a/src/linux/common.h
+++ b/src/linux/common.h
@@ -42,8 +42,8 @@ struct _proc_extra_info {
     uintptr_t    _pthread_buffer[PTHREAD_BUFFER_ITEMS];
 };
 
-#define read_pthread_t(py_proc, addr)                                                                                \
-    (copy_memory(py_proc->proc_ref, addr, sizeof(py_proc->extra->_pthread_buffer), py_proc->extra->_pthread_buffer))
+#define read_pthread_t(py_proc, addr)                                                                           \
+    (copy_memory(py_proc->ref, addr, sizeof(py_proc->extra->_pthread_buffer), py_proc->extra->_pthread_buffer))
 
 #ifdef NATIVE
 #include <sched.h>

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -647,23 +647,25 @@ _infer_tid_field_offset(py_thread_t* py_thread) {
 
     // If the target process is in a different PID namespace, we need to get its
     // other PID to be able to determine the offset of the TID field.
-    pid_t nspid = _get_nspid(py_thread->raddr.pref);
+    py_proc_t*       proc  = py_thread->proc;
+    proc_ref_t       pref  = proc->ref;
+    proc_extra_info* extra = proc->extra;
+    pid_t            nspid = _get_nspid(pref);
 
     for (register int i = 0; i < PTHREAD_BUFFER_ITEMS; i++) {
-        if (py_thread->raddr.pref == py_thread->proc->extra->_pthread_buffer[i]
-            || (nspid && nspid == py_thread->proc->extra->_pthread_buffer[i])) {
+        if (pref == extra->_pthread_buffer[i] || (nspid && nspid == extra->_pthread_buffer[i])) {
             log_d("TID field offset: %d", i);
-            py_thread->proc->extra->pthread_tid_offset = i;
+            extra->pthread_tid_offset = i;
             SUCCESS;
         }
     }
 
     // Fall-back to smaller steps if we failed
     for (register int i = 0; i < PTHREAD_BUFFER_ITEMS * (sizeof(uintptr_t) / sizeof(pid_t)); i++) {
-        if (py_thread->raddr.pref == (pid_t)((pid_t*)py_thread->proc->extra->_pthread_buffer)[i]
-            || (nspid && nspid == (pid_t)((pid_t*)py_thread->proc->extra->_pthread_buffer)[i])) {
+        if (pref == (pid_t)((pid_t*)extra->_pthread_buffer)[i]
+            || (nspid && nspid == (pid_t)((pid_t*)extra->_pthread_buffer)[i])) {
             log_d("TID field offset (from fall-back): %d", i);
-            py_thread->proc->extra->pthread_tid_offset = -i;
+            extra->pthread_tid_offset = -i;
             SUCCESS;
         }
     }

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -430,15 +430,15 @@ _py_proc__get_maps(py_proc_t* self) {
     }
     log_d("Executable path: '%s'", pd->exe_path);
 
-    self->proc_ref = pid_to_task(self->pid);
-    if (self->proc_ref == 0) {
+    self->ref = pid_to_task(self->pid);
+    if (self->ref == 0) {
         FAIL; // cppcheck-suppress [memleak]
     }
 
     struct vm_map* map = NULL;
 
     while (mach_vm_region(
-               self->proc_ref, &address, &size, VM_REGION_BASIC_INFO_64,
+               self->ref, &address, &size, VM_REGION_BASIC_INFO_64,
                (vm_region_info_t)&region_info, // cppcheck-suppress [uninitvar]
                &count, &object_name
            )
@@ -579,7 +579,7 @@ _py_proc__get_resident_memory(py_proc_t* self) {
     mach_msg_type_number_t      count = MACH_TASK_BASIC_INFO_COUNT;
 
     return task_info(
-               self->proc_ref, MACH_TASK_BASIC_INFO, (task_info_t)&info, &count // cppcheck-suppress [uninitvar]
+               self->ref, MACH_TASK_BASIC_INFO, (task_info_t)&info, &count // cppcheck-suppress [uninitvar]
            ) == KERN_SUCCESS
              ? info.resident_size
              : -1;

--- a/src/mem.h
+++ b/src/mem.h
@@ -55,11 +55,12 @@ __declspec(dllimport) extern BOOL GetPhysicallyInstalledSystemMemory(PULONGLONG)
 
 /**
  * Copy a data structure from the given remote address structure.
- * @param  raddr the remote address
- * @param  dt    the data structure as a local variable
- * @return       zero on success, otherwise non-zero.
+ * @param  pref the process reference
+ * @param  addr the remote address
+ * @param  dt   the data structure as a local variable
+ * @return      zero on success, otherwise non-zero.
  */
-#define copy_from_raddr(raddr, dt) copy_memory((raddr)->pref, (raddr)->addr, sizeof(dt), &dt)
+#define copy_remote(pref, addr, dt) copy_memory(pref, addr, sizeof(dt), &dt)
 
 /**
  * Copy a data structure from the given remote address structure.
@@ -67,10 +68,10 @@ __declspec(dllimport) extern BOOL GetPhysicallyInstalledSystemMemory(PULONGLONG)
  * @param  dt    the data structure as a local variable
  * @return       zero on success, otherwise non-zero.
  */
-#define copy_from_raddr_v(raddr, dt, n) copy_memory(raddr->pref, raddr->addr, n, &dt)
+#define copy_remote_v(pref, addr, dt, n) copy_memory(pref, addr, n, &dt)
 
 /**
- * Same as copy_from_raddr, but with explicit arguments instead of a pointer to
+ * Same as copy_remote, but with explicit arguments instead of a pointer to
  * a remote address structure
  * @param  pref the process reference
  * @param  addr the remote address
@@ -80,7 +81,7 @@ __declspec(dllimport) extern BOOL GetPhysicallyInstalledSystemMemory(PULONGLONG)
 #define copy_datatype(pref, addr, dt) copy_memory(pref, addr, sizeof(dt), &dt)
 
 /**
- * Same as copy_from_raddr, but for versioned Python data structures.
+ * Same as copy_remote, but for versioned Python data structures.
  * @param  pref     the process reference
  * @param  addr     the remote address
  * @param  py_type  the versioned Python type (e.g. py_runtime).
@@ -101,15 +102,7 @@ __declspec(dllimport) extern BOOL GetPhysicallyInstalledSystemMemory(PULONGLONG)
 #define copy_field_v(pref, type, field, raddr, dst)                         \
     copy_memory(pref, raddr + py_v->py_##type.o_##field, sizeof(dst), &dst)
 
-// Whilst the PID is generally used to identify processes across platforms,
-// operations can only be performed on other process references, like a Win32
-// HANDLE or a OSX mach_port_t. We use this structure to abstract the process
-// reference to identify a remote address location in a platoform-independent
-// way.
-typedef struct {
-    proc_ref_t pref; // Process reference
-    void*      addr; // Virtual memory address within the process
-} raddr_t;
+typedef void* raddr_t;
 
 /**
  * Copy a chunk of memory from a portion of the virtual memory of another
@@ -123,7 +116,7 @@ typedef struct {
  * @return  zero on success, otherwise non-zero.
  */
 static inline int
-copy_memory(proc_ref_t proc_ref, void* restrict addr, ssize_t len, void* restrict buf) {
+copy_memory(proc_ref_t proc_ref, raddr_t restrict addr, ssize_t len, void* restrict buf) {
     ssize_t result = -1;
 
 #if defined(PL_LINUX) /* LINUX */
@@ -222,9 +215,9 @@ get_total_memory(void) {
 struct vm_map {
     char*   path;
     ssize_t file_size;
-    void*   base;
+    raddr_t base;
     size_t  size;
-    void*   bss_base;
+    raddr_t bss_base;
     size_t  bss_size;
     bool    has_symbols;
 };

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -67,7 +67,7 @@
 #define MAX_STRING_CACHE_SIZE LRU_CACHE_EXPAND
 #define MAX_CODE_CACHE_SIZE   LRU_CACHE_EXPAND
 
-#define py_proc__memcpy(self, raddr, size, dest) copy_memory(self->proc_ref, raddr, size, dest)
+#define py_proc__memcpy(self, raddr, size, dest) copy_memory(self->ref, raddr, size, dest)
 
 // ----------------------------------------------------------------------------
 // -- Platform-dependent implementations of _py_proc__init
@@ -369,7 +369,7 @@ set_version:
 
 // ----------------------------------------------------------------------------
 static int
-_py_proc__check_interp_state(py_proc_t* self, void* raddr) {
+_py_proc__check_interp_state(py_proc_t* self, raddr_t interp) {
     if (!isvalid(self)) {
         set_error(NULL, "Invalid process structure");
         FAIL;
@@ -379,35 +379,33 @@ _py_proc__check_interp_state(py_proc_t* self, void* raddr) {
 
     V_ALLOCA(thread, tstate);
 
-    void* tstate_head_addr;
-    if (fail(_py_proc__get_interpreter_state_field(self, raddr, tstate_head, tstate_head_addr)))
+    raddr_t tstate_head = NULL;
+    if (fail(_py_proc__get_interpreter_state_field(self, interp, tstate_head, tstate_head)))
         FAIL;
 
-    if (fail(py_proc__copy_v(self, thread, tstate_head_addr, &tstate)))
+    if (fail(py_proc__copy_v(self, thread, tstate_head, &tstate)))
         FAIL;
 
-    log_t("PyThreadState head loaded @ %p", V_FIELD(void*, is, py_is, o_tstate_head));
+    log_t("PyThreadState head loaded @ %p", V_FIELD(raddr_t, is, py_is, o_tstate_head));
 
-    if (V_FIELD(void*, tstate, py_thread, o_interp) != raddr) {
+    if (V_FIELD(raddr_t, tstate, py_thread, o_interp) != interp) {
         set_error(PYOBJECT, "PyThreadState head does not point to interpreter state");
         FAIL;
     }
 
-    log_d("Found possible interpreter state @ %p (offset %p).", raddr, raddr - self->map.exe.base);
+    log_d("Found possible interpreter state @ %p (offset %p).", interp, interp - self->map.exe.base);
 
-    log_t("PyInterpreterState loaded @ %p. Thread State head @ %p", raddr, V_FIELD(void*, is, py_is, o_tstate_head));
-
-    py_thread_t thread;
-    raddr_t     thread_raddr = {self->proc_ref};
-    if (fail(_py_proc__get_interpreter_state_field(self, raddr, tstate_head, thread_raddr.addr)))
+    py_thread_t thread       = py_thread__init(self);
+    raddr_t     thread_raddr = NULL;
+    if (fail(_py_proc__get_interpreter_state_field(self, interp, tstate_head, thread_raddr)))
         FAIL;
 
-    if (fail(py_thread__fill_from_raddr(&thread, &thread_raddr, self)))
+    if (fail(py_thread__read_remote(&thread, thread_raddr)))
         FAIL;
 
     log_d("Stack trace constructed from possible interpreter state");
 
-    self->gc_state_raddr = (void*)(((char*)raddr) + py_v->py_is.o_gc);
+    self->gc_state_raddr = (raddr_t)(((char*)interp) + py_v->py_is.o_gc);
     log_d("GC runtime state @ %p", self->gc_state_raddr);
 
     if (V_MIN(3, 11)) {
@@ -423,8 +421,8 @@ _py_proc__check_interp_state(py_proc_t* self, void* raddr) {
     // Try to determine the TID by reading the remote struct pthread structure.
     // We can then use this information to parse the appropriate procfs file and
     // determine the native thread's running state.
-    void* initial_thread_addr = thread.raddr.addr;
-    while (isvalid(thread.raddr.addr)) {
+    raddr_t initial_thread_addr = thread.addr;
+    while (isvalid(thread.addr)) {
         if (success(_infer_tid_field_offset(&thread)))
             SUCCESS;
         if (!error_is(OS))
@@ -435,7 +433,7 @@ _py_proc__check_interp_state(py_proc_t* self, void* raddr) {
             FAIL;
         }
 
-        if (thread.raddr.addr == initial_thread_addr)
+        if (thread.addr == initial_thread_addr)
             break;
     }
     log_d("tid field offset not ready");
@@ -476,22 +474,22 @@ _py_proc__scan_bss(py_proc_t* self) {
     size_t step = self->map.bss.size > 0x10000 ? 0x10000 : self->map.bss.size;
 
     for (int shift = 0; shift < 1; shift++) {
-        void* base = self->map.bss.base - (shift * step);
+        raddr_t base = self->map.bss.base - (shift * step);
         if (fail(py_proc__memcpy(self, base, self->map.bss.size, bss))) {
             FAIL;
         }
 
         log_d("Scanning the BSS section @ %p (shift %d)", base, shift);
 
-        void* upper_bound = bss + (shift ? step : self->map.bss.size);
-        for (register void** raddr = (void**)bss; (void*)raddr < upper_bound; raddr++) {
+        void* upper_bound = (void*)((char*)bss + (shift ? step : self->map.bss.size));
+        for (register raddr_t* raddr = (raddr_t*)bss; (raddr_t)raddr < upper_bound; raddr++) {
             if ((!shift && success(_py_proc__check_interp_state(self, *raddr)))
-                || (shift && success(_py_proc__check_interp_state(self, (void*)raddr - bss + base)))) {
+                || (shift && success(_py_proc__check_interp_state(self, (raddr_t)raddr - bss + base)))) {
                 log_d(
                     "Possible interpreter state referenced by BSS @ %p (offset %x)",
-                    (void*)raddr - (void*)bss + (void*)base, (void*)raddr - (void*)bss
+                    (raddr_t)raddr - (raddr_t)bss + (raddr_t)base, (raddr_t)raddr - (raddr_t)bss
                 );
-                self->is_raddr = shift ? (void*)raddr - bss + base : *raddr;
+                self->istate_raddr = shift ? (raddr_t)raddr - bss + base : *raddr;
                 SUCCESS;
             }
 
@@ -510,7 +508,7 @@ _py_proc__scan_bss(py_proc_t* self) {
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_proc__prefetch_interpreter_state(py_proc_t* self, void* interp) {
+_py_proc__prefetch_interpreter_state(py_proc_t* self, raddr_t interp) {
     if (!isvalid(self)) {
         set_error(NULL, "Invalid process structure"); // GCOV_EXCL_START
         FAIL;                                         // GCOV_EXCL_END
@@ -519,7 +517,7 @@ _py_proc__prefetch_interpreter_state(py_proc_t* self, void* interp) {
     // The interpreter state structure is quite large, so we prefetch the
     // chunk that we are more likely to need.
     if (fail(copy_memory(
-            self->proc_ref, interp + self->interpreter_state_com.base_offset, self->interpreter_state_com.size,
+            self->ref, interp + self->interpreter_state_com.base_offset, self->interpreter_state_com.size,
             self->interpreter_state_com.data
         ))) {
         FAIL;
@@ -545,17 +543,17 @@ _py_proc__deref_interp_head(py_proc_t* self) {
 
     V_ALLOCA(runtime, runtime);
 
-    void* interp_head_raddr = NULL;
+    raddr_t interp_head_raddr = NULL;
 
-    void* runtime_addr = self->symbols[DYNSYM_RUNTIME];
+    raddr_t runtime_addr = self->symbols[DYNSYM_RUNTIME];
 #if defined PL_LINUX
     const size_t size = getpagesize();
 #else
     const size_t size = 0;
 #endif
 
-    void* lower = isvalid(runtime_addr) ? runtime_addr : self->map.runtime.base;
-    void* upper = isvalid(runtime_addr) ? runtime_addr : lower + size;
+    raddr_t lower = isvalid(runtime_addr) ? runtime_addr : self->map.runtime.base;
+    raddr_t upper = isvalid(runtime_addr) ? runtime_addr : lower + size;
 
 #ifdef DEBUG
     if (isvalid(runtime_addr)) {
@@ -565,13 +563,13 @@ _py_proc__deref_interp_head(py_proc_t* self) {
     }
 #endif
 
-    for (void* current_addr = lower; current_addr <= upper; current_addr += sizeof(void*)) {
+    for (raddr_t current_addr = lower; current_addr <= upper; current_addr += sizeof(raddr_t)) {
         if (py_proc__copy_v(self, runtime, current_addr, &runtime)) {
             log_d("Cannot copy runtime state structure from remote address %p", current_addr);
             continue;
         }
 
-        interp_head_raddr = V_FIELD(void*, runtime, py_runtime, o_interp_head);
+        interp_head_raddr = V_FIELD(raddr_t, runtime, py_runtime, o_interp_head);
 
         if (fail(_py_proc__prefetch_interpreter_state(self, interp_head_raddr))) {
             log_d("Failed to prefetch interpreter state from runtime state @ %p", interp_head_raddr);
@@ -591,25 +589,25 @@ _py_proc__deref_interp_head(py_proc_t* self) {
         FAIL;
     }
 
-    self->is_raddr = interp_head_raddr;
+    self->istate_raddr = interp_head_raddr;
 
     SUCCESS;
 }
 
 // ----------------------------------------------------------------------------
-static inline void*
+static inline raddr_t
 _py_proc__get_current_thread_state_raddr(py_proc_t* self) {
-    void* p_tstate_current = NULL;
+    raddr_t p_tstate_current = NULL;
 
     if (self->symbols[DYNSYM_RUNTIME] != NULL) {
         if (self->tstate_current_offset == 0
             || py_proc__get_type(self, self->symbols[DYNSYM_RUNTIME] + self->tstate_current_offset, p_tstate_current))
-            return (void*)-1;
+            return (raddr_t)-1;
 
         return p_tstate_current;
     }
 
-    return (void*)-1;
+    return (raddr_t)-1;
 }
 
 // ----------------------------------------------------------------------------
@@ -630,7 +628,7 @@ _py_proc__find_interpreter_state(py_proc_t* self) {
     if (self->sym_loaded || isvalid(self->map.runtime.base)) {
         // Try to resolve the symbols or the runtime section, if we have them
 
-        self->is_raddr = NULL;
+        self->istate_raddr = NULL;
 
         if (fail(_py_proc__deref_interp_head(self))) {
             log_d("Cannot dereference PyInterpreterState head from symbols (pid: %d)", self->pid);
@@ -683,7 +681,7 @@ _py_proc__run(py_proc_t* self) {
     if (success(_py_proc__find_interpreter_state(self))) {
         init = true;
 
-        log_d("Interpreter State de-referenced @ raddr: %p after %d attempts", self->is_raddr, attempts);
+        log_d("Interpreter State de-referenced @ raddr: %p after %d attempts", self->istate_raddr, attempts);
 
         TIMER_STOP;
     }
@@ -822,8 +820,8 @@ py_proc__attach(py_proc_t* self, pid_t pid) {
     log_d("Attaching to process with PID %d", pid);
 
 #if defined PL_WIN /* WIN */
-    self->proc_ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, pid);
-    if (self->proc_ref == INVALID_HANDLE_VALUE) {
+    self->ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, pid);
+    if (self->ref == INVALID_HANDLE_VALUE) {
         set_error(OS, "Failed to open attach process");
         FAIL;
     }
@@ -832,7 +830,7 @@ py_proc__attach(py_proc_t* self, pid_t pid) {
     self->pid = pid;
 
 #if defined PL_LINUX /* LINUX */
-    self->proc_ref = pid;
+    self->ref = pid;
 #endif
 
     if (fail(_py_proc__run(self))) {
@@ -929,8 +927,8 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
         set_error(OS, "Failed to create process");
         FAIL;
     }
-    self->proc_ref = piProcInfo.hProcess;
-    self->pid      = (pid_t)piProcInfo.dwProcessId;
+    self->ref = piProcInfo.hProcess;
+    self->pid = (pid_t)piProcInfo.dwProcessId;
 
     CloseHandle(hChildStdInRd);
     CloseHandle(hChildStdOutWr);
@@ -953,7 +951,7 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
 #endif /* ANY */
 
 #if defined PL_LINUX
-    self->proc_ref = self->pid;
+    self->ref = self->pid;
 
     // On Linux we need to wait for the forked process or otherwise it will
     // become a zombie and we cannot tell with kill if it has terminated.
@@ -997,8 +995,8 @@ py_proc__wait(py_proc_t* self) {
         WaitForSingleObject(self->extra->h_reader_thread, INFINITE);
         CloseHandle(self->extra->h_reader_thread);
     }
-    WaitForSingleObject(self->proc_ref, INFINITE);
-    CloseHandle(self->proc_ref);
+    WaitForSingleObject(self->ref, INFINITE);
+    CloseHandle(self->ref);
 #else /* UNIX */
 #ifdef NATIVE
     wait(NULL);
@@ -1012,7 +1010,7 @@ py_proc__wait(py_proc_t* self) {
 #define PYRUNTIMESTATE_SIZE 2048 // We expect _PyRuntimeState to be < 2K.
 
 static inline int
-_py_proc__find_current_thread_offset(py_proc_t* self, void* thread_raddr) {
+_py_proc__find_current_thread_offset(py_proc_t* self, raddr_t thread_raddr) {
     if (!isvalid(self->symbols[DYNSYM_RUNTIME])) {
         set_error(OS, "Invalid runtime symbol");
         FAIL;
@@ -1026,14 +1024,14 @@ _py_proc__find_current_thread_offset(py_proc_t* self, void* thread_raddr) {
         FAIL;
 
     // Search offset of current thread in _PyRuntimeState structure
-    void*        current_thread_raddr = NULL;
+    raddr_t      current_thread_raddr = NULL;
     register int hit_count            = 0;
-    for (register void** raddr = (void**)self->symbols[DYNSYM_RUNTIME];
-         (void*)raddr < self->symbols[DYNSYM_RUNTIME] + PYRUNTIMESTATE_SIZE; raddr++) {
+    for (register raddr_t* raddr = (raddr_t*)self->symbols[DYNSYM_RUNTIME];
+         (raddr_t)raddr < (raddr_t)(((char*)self->symbols[DYNSYM_RUNTIME]) + PYRUNTIMESTATE_SIZE); raddr++) {
         py_proc__get_type(self, raddr, current_thread_raddr);
         if (current_thread_raddr == thread_raddr) {
             if (++hit_count == 2) {
-                self->tstate_current_offset = (void*)raddr - self->symbols[DYNSYM_RUNTIME];
+                self->tstate_current_offset = (raddr_t)raddr - self->symbols[DYNSYM_RUNTIME];
                 log_d("Offset of _PyRuntime.gilstate.tstate_current found at %x", self->tstate_current_offset);
                 SUCCESS;
             }
@@ -1049,7 +1047,7 @@ bool
 py_proc__is_running(py_proc_t* self) {
 #if defined PL_WIN /* WIN */
     DWORD ec = 0;
-    return GetExitCodeProcess(self->proc_ref, &ec) ? ec == STILL_ACTIVE : 0;
+    return GetExitCodeProcess(self->ref, &ec) ? ec == STILL_ACTIVE : 0;
 
 #elif defined PL_MACOS /* MACOS */
     return success(check_pid(self->pid));
@@ -1062,7 +1060,7 @@ py_proc__is_running(py_proc_t* self) {
 // ----------------------------------------------------------------------------
 bool
 py_proc__is_python(py_proc_t* self) {
-    return self->is_raddr != NULL;
+    return self->istate_raddr != NULL;
 }
 
 // ----------------------------------------------------------------------------
@@ -1095,10 +1093,10 @@ py_proc__get_gc_state(py_proc_t* self) {
 #ifdef NATIVE
 // ----------------------------------------------------------------------------
 static int
-_py_proc__interrupt_threads(py_proc_t* self, raddr_t* tstate_head_raddr) {
-    py_thread_t py_thread;
+_py_proc__interrupt_threads(py_proc_t* self, raddr_t tstate_head) {
+    py_thread_t py_thread = py_thread__init(self);
 
-    if (fail(py_thread__fill_from_raddr(&py_thread, tstate_head_raddr, self))) {
+    if (fail(py_thread__read_remote(&py_thread, tstate_head))) {
         FAIL;
     }
 
@@ -1132,10 +1130,10 @@ _py_proc__interrupt_threads(py_proc_t* self, raddr_t* tstate_head_raddr) {
 
 // ----------------------------------------------------------------------------
 static int
-_py_proc__resume_threads(py_proc_t* self, raddr_t* tstate_head_raddr) {
-    py_thread_t py_thread;
+_py_proc__resume_threads(py_proc_t* self, raddr_t tstate_head) {
+    py_thread_t py_thread = py_thread__init(self);
 
-    if (fail(py_thread__fill_from_raddr(&py_thread, tstate_head_raddr, self))) {
+    if (fail(py_thread__read_remote(&py_thread, tstate_head))) {
         FAIL;
     }
 
@@ -1160,13 +1158,13 @@ _py_proc__resume_threads(py_proc_t* self, raddr_t* tstate_head_raddr) {
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_proc__sample_interpreter(py_proc_t* self, void* interp, microseconds_t time_delta) {
+_py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t time_delta) {
     ssize_t mem_delta      = 0;
-    void*   current_thread = NULL;
+    raddr_t current_thread = NULL;
 
     V_DESC(self->py_v);
 
-    void* tstate_head = NULL;
+    raddr_t tstate_head = NULL;
     if (fail(_py_proc__get_interpreter_state_field(self, interp, tstate_head, tstate_head)))
         FAIL;
 
@@ -1175,10 +1173,9 @@ _py_proc__sample_interpreter(py_proc_t* self, void* interp, microseconds_t time_
         FAIL;
     }
 
-    raddr_t     raddr = {.pref = self->proc_ref, .addr = tstate_head};
-    py_thread_t py_thread;
+    py_thread_t py_thread = py_thread__init(self);
 
-    if (fail(py_thread__fill_from_raddr(&py_thread, &raddr, self))) {
+    if (fail(py_thread__read_remote(&py_thread, tstate_head))) {
         if (is_fatal(austin_errno)) {
             FAIL;
         }
@@ -1188,7 +1185,7 @@ _py_proc__sample_interpreter(py_proc_t* self, void* interp, microseconds_t time_
     if (pargs.memory) {
         // Use the current thread to determine which thread is manipulating memory
         if (V_MIN(3, 12)) {
-            void* gil_state_raddr = NULL;
+            raddr_t gil_state_raddr = NULL;
             if (fail(_py_proc__get_interpreter_state_field(self, interp, gil_state, gil_state_raddr)))
                 FAIL;
 
@@ -1196,10 +1193,10 @@ _py_proc__sample_interpreter(py_proc_t* self, void* interp, microseconds_t time_
                 SUCCESS;
 
             gil_state_t gil_state = {0};
-            if (fail(copy_datatype(self->proc_ref, gil_state_raddr, gil_state)))
+            if (fail(copy_datatype(self->ref, gil_state_raddr, gil_state)))
                 FAIL;
 
-            current_thread = (void*)gil_state.last_holder._value;
+            current_thread = (raddr_t)gil_state.last_holder._value;
         } else
             current_thread = _py_proc__get_current_thread_state_raddr(self);
     }
@@ -1212,12 +1209,12 @@ _py_proc__sample_interpreter(py_proc_t* self, void* interp, microseconds_t time_
         if (pargs.memory) {
             mem_delta = 0;
             if (V_MAX(3, 11) && self->symbols[DYNSYM_RUNTIME] != NULL && current_thread == (void*)-1) {
-                if (_py_proc__find_current_thread_offset(self, py_thread.raddr.addr))
+                if (_py_proc__find_current_thread_offset(self, py_thread.addr))
                     continue;
                 else
                     current_thread = _py_proc__get_current_thread_state_raddr(self);
             }
-            if (py_thread.raddr.addr == current_thread) {
+            if (py_thread.addr == current_thread) {
                 mem_delta = _py_proc__get_memory_delta(self);
                 log_t("Thread %lx holds the GIL", py_thread.tid);
             }
@@ -1280,7 +1277,7 @@ _py_proc__sample_interpreter(py_proc_t* self, void* interp, microseconds_t time_
 int
 py_proc__sample(py_proc_t* self) {
     microseconds_t time_delta     = gettime() - self->timestamp; // Time delta since last sample.
-    void*          current_interp = self->is_raddr;
+    raddr_t        current_interp = self->istate_raddr;
 
     V_DESC(self->py_v);
 
@@ -1288,7 +1285,7 @@ py_proc__sample(py_proc_t* self) {
         if (fail(_py_proc__prefetch_interpreter_state(self, current_interp)))
             FAIL;
 
-        void* tstate_head = NULL;
+        raddr_t tstate_head = NULL;
         if (fail(_py_proc__get_interpreter_state_field(self, current_interp, tstate_head, tstate_head)))
             FAIL;
 
@@ -1298,8 +1295,7 @@ py_proc__sample(py_proc_t* self) {
             SUCCESS;
 
 #ifdef NATIVE
-        raddr_t raddr = {.pref = self->proc_ref, .addr = tstate_head};
-        if (fail(_py_proc__interrupt_threads(self, &raddr)))
+        if (fail(_py_proc__interrupt_threads(self, tstate_head)))
             FAIL;
 
         time_delta = gettime() - self->timestamp;
@@ -1307,7 +1303,7 @@ py_proc__sample(py_proc_t* self) {
         int result = _py_proc__sample_interpreter(self, current_interp, time_delta);
 
 #ifdef NATIVE
-        if (fail(_py_proc__resume_threads(self, &raddr)))
+        if (fail(_py_proc__resume_threads(self, tstate_head)))
             FAIL;
 #endif
 
@@ -1370,7 +1366,7 @@ py_proc__signal(py_proc_t* self, int signal) {
         GenerateConsoleCtrlEvent(CTRL_C_EVENT, self->pid);
         break;
     case SIGTERM:
-        TerminateProcess(self->proc_ref, signal);
+        TerminateProcess(self->ref, signal);
         break;
     default:
         log_e("Cannot send signal %d to process %d", signal, self->pid);
@@ -1400,7 +1396,7 @@ py_proc__destroy(py_proc_t* self) {
 #endif
 
 #if defined PL_MACOS
-    mach_port_deallocate(mach_task_self(), self->proc_ref);
+    mach_port_deallocate(mach_task_self(), self->ref);
 #endif
 
     sfree(self->bin_path);

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -38,7 +38,7 @@
 #include "version.h"
 
 typedef struct {
-    void*   base;
+    raddr_t base;
     ssize_t size;
 } proc_vm_map_block_t;
 
@@ -60,7 +60,7 @@ typedef struct _proc_extra_info proc_extra_info; // Forward declaration.
 
 typedef struct {
     pid_t      pid;
-    proc_ref_t proc_ref;
+    proc_ref_t ref;
     bool       child;
 
     char* bin_path;
@@ -71,11 +71,11 @@ typedef struct {
     int       sym_loaded;
     python_v* py_v;
 
-    void* symbols[DYNSYM_COUNT]; // Binary symbols
+    raddr_t symbols[DYNSYM_COUNT]; // Binary symbols
 
-    void* gc_state_raddr;
+    raddr_t gc_state_raddr;
 
-    void* is_raddr;
+    raddr_t istate_raddr;
 
     lru_cache_t* frame_cache;
     lru_cache_t* string_cache;
@@ -222,7 +222,7 @@ py_proc__sample(py_proc_t*);
 
  * @return        zero on success, otherwise non-zero.
  */
-#define py_proc__copy_field_v(self, type, field, raddr, dst) copy_field_v(self->proc_ref, type, field, raddr, dst)
+#define py_proc__copy_field_v(self, type, field, raddr, dst) copy_field_v(self->ref, type, field, raddr, dst)
 
 /**
  * Log the Python interpreter version

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -85,7 +85,7 @@ string__hash(char* string) {
 
 // ----------------------------------------------------------------------------
 static inline char*
-_string_from_raddr(proc_ref_t pref, void* raddr, python_v* py_v) {
+_string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
     PyUnicodeObject unicode;
     char*           buffer = NULL;
     ssize_t         len    = 0;
@@ -103,7 +103,7 @@ _string_from_raddr(proc_ref_t pref, void* raddr, python_v* py_v) {
     // Because changes to PyASCIIObject are rare, we handle the version manually
     // instead of using a version offset descriptor.
     ssize_t ascii_size = V_MIN(3, 12) ? sizeof(unicode.v3_12._base._base) : sizeof(unicode.v3._base._base);
-    void*   data       = ascii.state.compact ? p_ascii_data(raddr, ascii_size)
+    raddr_t data       = ascii.state.compact ? p_ascii_data(raddr, ascii_size)
                                              : (V_MIN(3, 12) ? unicode.v3_12._base.utf8 : unicode.v3._base.utf8);
     len                = ascii.state.compact ? ascii.length
                                              : (V_MIN(3, 12) ? unicode.v3_12._base.utf8_length : unicode.v3._base.utf8_length);
@@ -136,7 +136,7 @@ _string_from_raddr(proc_ref_t pref, void* raddr, python_v* py_v) {
 
 // ----------------------------------------------------------------------------
 static inline unsigned char*
-_bytes_from_raddr(proc_ref_t pref, void* raddr, ssize_t* size, python_v* py_v) {
+_bytes_remote(proc_ref_t pref, raddr_t raddr, ssize_t* size, python_v* py_v) {
     PyBytesObject  bytes = {0};
     ssize_t        len   = 0;
     unsigned char* array = NULL;
@@ -166,4 +166,4 @@ _bytes_from_raddr(proc_ref_t pref, void* raddr, ssize_t* size, python_v* py_v) {
     return array;
 }
 
-#define py_string_key(code, field) ((key_dt) * ((void**)((void*)&code + py_v->py_code.field)))
+#define py_string_key(code, field) ((key_dt) * ((raddr_t*)((raddr_t) & code + py_v->py_code.field)))

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -95,7 +95,7 @@ _py_thread__resolve_py_stack(py_thread_t* self) {
         frame_t* frame     = lru_cache__maybe_hit(cache, frame_key);
 
         if (!isvalid(frame)) {
-            frame = _frame_from_code_raddr(self->proc, py_frame.code, lasti);
+            frame = _frame_remote(self->proc, py_frame.code, lasti);
             if (!isvalid(frame)) {
                 // Truncate the stack to the point where we have successfully resolved.
                 _stack->pointer = i;
@@ -114,24 +114,23 @@ _py_thread__resolve_py_stack(py_thread_t* self) {
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_thread__push_frame_from_raddr(py_thread_t* self, void** prev) {
+_py_thread__push_remote_frame(py_thread_t* self, raddr_t* prev) {
     PyFrameObject frame;
 
-    raddr_t raddr = {self->raddr.pref, *prev};
-    if (fail(copy_from_raddr_v((&raddr), frame, self->proc->py_v->py_frame.size)))
+    if (fail(copy_remote_v(self->proc->ref, *prev, frame, self->proc->py_v->py_frame.size)))
         FAIL;
 
     V_DESC(self->proc->py_v);
 
-    void* origin = *prev;
+    raddr_t origin = *prev;
 
-    *prev = V_FIELD(void*, frame, py_frame, o_back);
+    *prev = V_FIELD(raddr_t, frame, py_frame, o_back);
     if (unlikely(origin == *prev)) {
         set_error(PYOBJECT, "Frame points to itself");
         FAIL;
     }
 
-    stack_py_push(origin, V_FIELD(void*, frame, py_frame, o_code), V_FIELD(int, frame, py_frame, o_lasti));
+    stack_py_push(origin, V_FIELD(raddr_t, frame, py_frame, o_code), V_FIELD(int, frame, py_frame, o_lasti));
 
     SUCCESS;
 }
@@ -146,13 +145,13 @@ static unsigned int _stack_chunk_misses = 0;
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_thread__push_iframe_from_addr(py_thread_t* self, void* iframe, void** prev) {
+_py_thread__push_local_iframe(py_thread_t* self, void* iframe, raddr_t* prev) {
     V_DESC(self->proc->py_v);
 
-    void* origin     = *prev;
-    void* code_raddr = V_FIELD_PTR(void*, iframe, py_iframe, o_code);
+    raddr_t origin     = *prev;
+    raddr_t code_raddr = V_FIELD_PTR(raddr_t, iframe, py_iframe, o_code);
 
-    *prev = V_FIELD_PTR(void*, iframe, py_iframe, o_previous);
+    *prev = V_FIELD_PTR(raddr_t, iframe, py_iframe, o_previous);
     if (unlikely(origin == *prev)) {
         set_error(PYOBJECT, "Interpreter frame points to itself");
         FAIL;
@@ -170,7 +169,7 @@ _py_thread__push_iframe_from_addr(py_thread_t* self, void* iframe, void** prev) 
 
     stack_py_push(
         origin, code_raddr,
-        (((int)(V_FIELD_PTR(void*, iframe, py_iframe, o_prev_instr) - code_raddr)) - py_v->py_code.o_code)
+        (((int)(V_FIELD_PTR(raddr_t, iframe, py_iframe, o_prev_instr) - code_raddr)) - py_v->py_code.o_code)
             / sizeof(_Py_CODEUNIT)
     );
 
@@ -186,29 +185,29 @@ _py_thread__push_iframe_from_addr(py_thread_t* self, void* iframe, void** prev) 
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_thread__push_iframe_from_raddr(py_thread_t* self, void** prev) {
+_py_thread__push_remote_iframe(py_thread_t* self, raddr_t* prev) {
     V_DESC(self->proc->py_v);
 
     V_ALLOCA(iframe, iframe);
 
-    if (fail(copy_py(self->raddr.pref, *prev, py_iframe, iframe)))
+    if (fail(copy_py(self->proc->ref, *prev, py_iframe, iframe)))
         FAIL;
 
-    return _py_thread__push_iframe_from_addr(self, &iframe, prev);
+    return _py_thread__push_local_iframe(self, &iframe, prev);
 }
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_thread__push_iframe(py_thread_t* self, void** prev) {
-    void* raddr = *prev;
+_py_thread__push_iframe(py_thread_t* self, raddr_t* prev) {
+    raddr_t raddr = *prev;
     if (isvalid(self->stack)) {
 #ifdef DEBUG
         _stack_chunk_count++;
 #endif
 
         void* resolved_addr = isvalid(self->stack) ? stack_chunk__resolve(self->stack, raddr) : NULL;
-        if (resolved_addr != NULL) {
-            return _py_thread__push_iframe_from_addr(self, resolved_addr, prev);
+        if (isvalid(resolved_addr)) {
+            return _py_thread__push_local_iframe(self, resolved_addr, prev);
         }
 
 #ifdef DEBUG
@@ -216,7 +215,7 @@ _py_thread__push_iframe(py_thread_t* self, void** prev) {
 #endif
     }
 
-    return _py_thread__push_iframe_from_raddr(self, prev);
+    return _py_thread__push_remote_iframe(self, prev);
 } /* _py_thread__push_iframe */
 
 // ----------------------------------------------------------------------------
@@ -224,12 +223,12 @@ static inline int
 _py_thread__unwind_frame_stack(py_thread_t* self) {
     stack_reset();
 
-    void* prev = self->top_frame;
-    if (fail(_py_thread__push_frame_from_raddr(self, &prev)))
+    raddr_t prev = self->top_frame;
+    if (fail(_py_thread__push_remote_frame(self, &prev)))
         FAIL;
 
     while (isvalid(prev)) {
-        if (fail(_py_thread__push_frame_from_raddr(self, &prev))) {
+        if (fail(_py_thread__push_remote_frame(self, &prev))) {
             log_d("Failed to retrieve frame #%d (from top).", stack_pointer());
             FAIL;
         }
@@ -248,8 +247,8 @@ _py_thread__unwind_frame_stack(py_thread_t* self) {
 
 // ----------------------------------------------------------------------------
 static inline int
-_py_thread__unwind_iframe_stack(py_thread_t* self, void* iframe_raddr) {
-    void* curr = iframe_raddr;
+_py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
+    raddr_t curr = iframe_raddr;
 
     while (isvalid(curr)) {
         if (fail(_py_thread__push_iframe(self, &curr))) {
@@ -280,10 +279,10 @@ _py_thread__unwind_cframe_stack(py_thread_t* self) {
 
     V_DESC(self->proc->py_v);
 
-    if (fail(copy_py(self->raddr.pref, self->top_frame, py_cframe, cframe)))
+    if (fail(copy_py(self->proc->ref, self->top_frame, py_cframe, cframe)))
         FAIL;
 
-    return fail(_py_thread__unwind_iframe_stack(self, V_FIELD(void*, cframe, py_cframe, o_current_frame)));
+    return fail(_py_thread__unwind_iframe_stack(self, V_FIELD(raddr_t, cframe, py_cframe, o_current_frame)));
 }
 
 #ifdef NATIVE
@@ -553,17 +552,19 @@ _py_thread__seize(py_thread_t* self) {
 
 // ----------------------------------------------------------------------------
 int
-py_thread__fill_from_raddr(py_thread_t* self, raddr_t* raddr, py_proc_t* proc) {
+py_thread__read_remote(py_thread_t* self, raddr_t addr) {
     if (!isvalid(self)) {
         set_error(NULL, "Invalid thread pointer");
         FAIL;
     }
 
+    py_proc_t* proc = self->proc;
+
     V_DESC(proc->py_v);
 
     V_ALLOCA(thread, ts);
 
-    if (fail(copy_from_raddr(raddr, ts))) {
+    if (fail(copy_remote(proc->ref, addr, ts))) {
         FAIL;
     }
 
@@ -571,20 +572,13 @@ py_thread__fill_from_raddr(py_thread_t* self, raddr_t* raddr, py_proc_t* proc) {
     if (V_MIN(3, 11)) {
         // This is destroyed in py_thread__next, so it is important that all threads
         // are traversed to avoid a memory leak!
-        self->stack = stack_chunk_new(proc->proc_ref, V_FIELD(void*, ts, py_thread, o_stack));
+        self->stack = stack_chunk_new(proc->ref, V_FIELD(raddr_t, ts, py_thread, o_stack));
     }
 
-    self->proc = proc;
-
-    self->raddr = *raddr;
-
-    self->top_frame = V_FIELD(void*, ts, py_thread, o_frame);
-
-    self->status = V_FIELD(tstate_status_t, ts, py_thread, o_status);
-
-    self->next_raddr = (raddr_t){raddr->pref, V_FIELD(void*, ts, py_thread, o_next) == raddr->addr
-                                                  ? NULL
-                                                  : V_FIELD(void*, ts, py_thread, o_next)};
+    self->addr      = addr;
+    self->top_frame = V_FIELD(raddr_t, ts, py_thread, o_frame);
+    self->status    = V_FIELD(tstate_status_t, ts, py_thread, o_status);
+    self->next      = V_FIELD(raddr_t, ts, py_thread, o_next) == addr ? NULL : V_FIELD(raddr_t, ts, py_thread, o_next);
 
 #if defined PL_MACOS
     self->tid = V_FIELD(long, ts, py_thread, o_thread_id);
@@ -626,7 +620,7 @@ py_thread__fill_from_raddr(py_thread_t* self, raddr_t* raddr, py_proc_t* proc) {
 #endif
 
     SUCCESS;
-} /* py_thread__fill_from_raddr */
+} /* py_thread__read_remote */
 
 // ----------------------------------------------------------------------------
 int
@@ -638,12 +632,12 @@ py_thread__next(py_thread_t* self) {
         self->stack = NULL;
     }
 
-    if (!isvalid(self->next_raddr.addr))
+    if (!isvalid(self->next))
         STOP(ITEREND);
 
     log_t("Found next thread");
 
-    return py_thread__fill_from_raddr(self, &(self->next_raddr), self->proc);
+    return py_thread__read_remote(self, self->next);
 }
 
 // ----------------------------------------------------------------------------
@@ -666,7 +660,7 @@ py_thread__unwind(py_thread_t* self) {
 
     // Update the thread state to improve guarantees that it will be in sync with
     // the native stack just collected
-    py_thread__fill_from_raddr(self, &self->raddr, self->proc);
+    py_thread__read_remote(self, self->addr);
 #endif
     V_DESC(self->proc->py_v);
 

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -36,21 +36,22 @@
 #define MAX_STACK_SIZE 2048
 
 typedef struct thread {
-    raddr_t raddr;
-    raddr_t next_raddr;
-
     py_proc_t* proc;
 
-    uintptr_t      tid;
-    struct thread* next;
+    raddr_t addr;
+    raddr_t next;
 
-    void* top_frame;
+    uintptr_t tid;
+
+    raddr_t top_frame;
 
     /* The per-thread datastack was introduced in Python 3.11 */
     stack_chunk_t* stack;
 
     tstate_status_t status;
 } py_thread_t;
+
+#define py_thread__init(_proc) {.proc = _proc}
 
 /**
  * Fill the thread structure from the given remote address.
@@ -60,7 +61,7 @@ typedef struct thread {
  * @param py_proc_t    the Python process the thread belongs to.
  */
 int
-py_thread__fill_from_raddr(py_thread_t*, raddr_t*, py_proc_t*);
+py_thread__read_remote(py_thread_t*, raddr_t);
 
 /**
  * Get the next thread, if any.

--- a/src/stack.h
+++ b/src/stack.h
@@ -82,7 +82,7 @@ stack_has_cycle(void) {
 }
 
 static inline void
-stack_py_push(void* origin, void* code, int lasti) {
+stack_py_push(raddr_t origin, raddr_t code, int lasti) {
     _stack->py_base[_stack->pointer++] = (py_frame_t){.origin = origin, .code = code, .lasti = lasti};
 }
 
@@ -132,14 +132,14 @@ stack_py_push(void* origin, void* code, int lasti) {
 
 // This is our representation of the linked list of stack chunks
 typedef struct stack_chunk {
-    void*               origin;
+    raddr_t             origin;
     _PyStackChunk*      data;
     struct stack_chunk* previous;
 } stack_chunk_t;
 
 // ----------------------------------------------------------------------------
 static inline stack_chunk_t*
-stack_chunk_new(proc_ref_t pref, void* origin) {
+stack_chunk_new(proc_ref_t pref, raddr_t origin) {
     _PyStackChunk original_chunk = {0};
 
     if (!isvalid(origin)) {
@@ -198,7 +198,7 @@ stack_chunk__destroy(stack_chunk_t* chunk) {
 
 // ----------------------------------------------------------------------------
 static inline void*
-stack_chunk__resolve(stack_chunk_t* self, void* address) {
+stack_chunk__resolve(stack_chunk_t* self, raddr_t address) {
     if (address >= self->origin && (char*)address < (char*)self->origin + self->data->size)
         return (char*)self->data + ((char*)address - (char*)self->origin);
 

--- a/src/version.h
+++ b/src/version.h
@@ -58,9 +58,9 @@
  * @return         the value of of the field of py_obj at the offset specified
  *                 by the field argument.
  */
-#define V_FIELD(ctype, py_obj, py_type, field) (*((ctype*)(((void*)&py_obj) + py_v->py_type.field)))
+#define V_FIELD(ctype, py_obj, py_type, field) (*((ctype*)(((raddr_t) & py_obj) + py_v->py_type.field)))
 
-#define V_FIELD_PTR(ctype, py_obj_ptr, py_type, field) (*((ctype*)(((void*)py_obj_ptr) + py_v->py_type.field)))
+#define V_FIELD_PTR(ctype, py_obj_ptr, py_type, field) (*((ctype*)(((raddr_t)py_obj_ptr) + py_v->py_type.field)))
 
 #define V_DESC(desc) python_v* py_v = (desc)
 

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -137,7 +137,7 @@ _py_proc__try_child_proc(py_proc_t* self) {
         FAIL;
     }
 
-    HANDLE orig_hproc = self->proc_ref;
+    HANDLE orig_hproc = self->ref;
     pid_t  orig_pid   = self->pid;
 
     for (;;) {
@@ -163,9 +163,9 @@ _py_proc__try_child_proc(py_proc_t* self) {
                 goto rollback;
             }
 
-            self->pid      = child_pid;
-            self->proc_ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, child_pid);
-            if (self->proc_ref == INVALID_HANDLE_VALUE) {
+            self->pid = child_pid;
+            self->ref = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, child_pid);
+            if (self->ref == INVALID_HANDLE_VALUE) {
                 log_e("Cannot open child process handle");
                 goto rollback;
             }
@@ -174,14 +174,14 @@ _py_proc__try_child_proc(py_proc_t* self) {
                 SUCCESS;
             } else {
                 log_d("Process has a single non-Python child with PID %d. Taking it as new parent", child_pid);
-                CloseHandle(self->proc_ref);
+                CloseHandle(self->ref);
             }
         }
     }
 
 rollback:
-    self->pid      = orig_pid;
-    self->proc_ref = orig_hproc;
+    self->pid = orig_pid;
+    self->ref = orig_hproc;
 
     set_error(OS, "Failed to find a single Python child process");
     FAIL;
@@ -213,7 +213,7 @@ _py_proc__get_modules(py_proc_t* self) {
     cu_char*          needle_path = NULL;
     struct vm_map*    map         = NULL;
 
-    if (GetModuleFileNameEx(self->proc_ref, NULL, pd->exe_path, sizeof(pd->exe_path)) == 0) {
+    if (GetModuleFileNameEx(self->ref, NULL, pd->exe_path, sizeof(pd->exe_path)) == 0) {
         set_error(OS, "Failed to get executable path from module");
         FAIL;
     }
@@ -344,7 +344,7 @@ static ssize_t
 _py_proc__get_resident_memory(py_proc_t* self) {
     PROCESS_MEMORY_COUNTERS mem_info;
 
-    return GetProcessMemoryInfo(self->proc_ref, &mem_info, sizeof(mem_info)) ? mem_info.WorkingSetSize : -1;
+    return GetProcessMemoryInfo(self->ref, &mem_info, sizeof(mem_info)) ? mem_info.WorkingSetSize : -1;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
We refactor the remote address data type to be a simple alias for void* instead of a structure. We also rename some functions referencing remote addresses in their name to be more readable.