### PR TITLE
perf: reduce fputc calls

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -43,13 +43,16 @@ base_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sam
 
 static inline void
 mojo_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sample) {
+    char thread_name[64];
+
     base_event_handler__handle_stack_begin(self, sample);
+
+    sprintf(thread_name, FORMAT_TID, sample->tid);
 
     mojo_event(MOJO_STACK);
     mojo_integer(sample->pid, 0);
     mojo_integer(sample->iid, 0);
-    fprintf(pargs.output_file, FORMAT_TID, sample->tid);
-    fputc('\0', pargs.output_file);
+    mojo_string(thread_name);
 }
 
 static inline void

--- a/src/mojo.h
+++ b/src/mojo.h
@@ -67,9 +67,7 @@ typedef unsigned long long mojo_int_t;
 #define mojo_event(event)                \
     { fputc(event, pargs.output_file); }
 
-#define mojo_string(string)           \
-    fputs(string, pargs.output_file); \
-    fputc('\0', pargs.output_file);
+#define mojo_string(string) fwrite(string, strlen(string) + 1, 1, pargs.output_file);
 
 static inline void
 mojo_integer(mojo_int_t integer, int sign) {


### PR DESCRIPTION
We reduce the number of calls to fputc to avoid the overhead of extra function calls for writing a null terminator to the stream.