### PR TITLE
fix: multiprocess sampling

### DIFF
--- a/src/austin.c
+++ b/src/austin.c
@@ -57,12 +57,33 @@ static int interrupt_signal = 0;
 
 static void
 signal_callback_handler(int signum) {
+    log_d("Caught signal %d", signum);
     switch (signum) {
     case SIGINT:
     case SIGTERM:
-        interrupt_signal = -signum;
+        interrupt_signal = signum;
     }
 } /* signal_callback_handler */
+
+#if defined PL_WIN
+BOOL WINAPI
+ConsoleHandler(DWORD signal) {
+    switch (signal) {
+    case CTRL_C_EVENT:
+        log_d("Caught Ctrl-C event");
+        interrupt_signal = SIGINT;
+        break;
+    case CTRL_CLOSE_EVENT:
+        log_d("Caught Ctrl-Close event");
+        interrupt_signal = SIGTERM;
+        break;
+    default:
+        log_d("Caught unknown console event %d", signal);
+        return FALSE;
+    }
+    return TRUE;
+}
+#endif // PL_WIN
 
 // ----------------------------------------------------------------------------
 
@@ -104,21 +125,22 @@ do_single_process(py_proc_t* py_proc) {
 #else
             stopwatch_pause(stopwatch_duration());
 #endif
+            if (pargs.where)
+                break;
 
-            if (end_time < gettime() || pargs.where)
-                interrupt_signal++;
+            if (end_time < gettime())
+                interrupt_signal = SIGINT; // Emulate Ctrl-C
         }
     }
 
     if (pargs.attach_pid == 0) {
-        if (interrupt_signal)
+        if (interrupt_signal) {
             // Propagate the signal to the parent if we spawned it.
-            py_proc__signal(py_proc, interrupt_signal < 0 ? -interrupt_signal : SIGTERM);
+            py_proc__signal(py_proc, interrupt_signal);
+        }
 
-#if defined PL_UNIX
         // If we spawned the process, we need to wait for it to terminate.
         py_proc__wait(py_proc);
-#endif
     }
 
     py_proc__destroy(py_proc);
@@ -173,7 +195,7 @@ do_child_processes(py_proc_t* py_proc) {
         py_proc__log_version(py_proc, true);
     }
 
-    if (!py_proc_list__is_empty(list) && interrupt_signal == false) {
+    if (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
         if (!pargs.pipe) {
             log_m("");
             log_m("\033[1mChild processes\033[0m");
@@ -185,7 +207,7 @@ do_child_processes(py_proc_t* py_proc) {
     }
 
     if (pargs.exposure == 0) {
-        while (!py_proc_list__is_empty(list) && interrupt_signal == false) {
+        while (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
 #ifndef NATIVE
             microseconds_t start_time = gettime();
 #endif
@@ -201,7 +223,7 @@ do_child_processes(py_proc_t* py_proc) {
         if (!pargs.pipe && !pargs.where)
             log_m("🕑 Sampling for %d second%s", pargs.exposure, pargs.exposure != 1 ? "s" : "");
         microseconds_t end_time = gettime() + pargs.exposure * 1000000;
-        while (!py_proc_list__is_empty(list) && interrupt_signal == false) {
+        while (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
 #ifndef NATIVE
             microseconds_t start_time = gettime();
 #endif
@@ -213,22 +235,25 @@ do_child_processes(py_proc_t* py_proc) {
             stopwatch_pause(gettime() - start_time);
 #endif
 
-            if (end_time < gettime() || pargs.where)
-                interrupt_signal++;
+            if (pargs.where)
+                break;
+
+            if (end_time < gettime())
+                interrupt_signal = SIGINT; // Emulate Ctrl-C
         }
     }
 
     if (pargs.attach_pid == 0) {
-        if (interrupt_signal)
-            // Propagate the signal to the child processes (via the parent) if we
-            // spawned them.
-            py_proc__signal(py_proc, interrupt_signal < 0 ? -interrupt_signal : SIGTERM);
+        if (interrupt_signal) {
+            // Propagate the signal to the child processes (via the parent) if
+            // we spawned them.
+            py_proc__signal(py_proc, interrupt_signal);
+        }
 
-        // If we spawned the child processes, we need to wait for them to terminate.
+        // If we spawned the child processes, we need to wait for them to
+        // terminate.
         py_proc_list__update(list);
-#if defined PL_UNIX
         py_proc_list__wait(list);
-#endif
     }
 
     SUCCESS; // TODO: Fix!
@@ -387,6 +412,9 @@ main(int argc, char** argv) {
     // Register signal handler for Ctrl+C and terminate signals.
     signal(SIGINT, signal_callback_handler);
     signal(SIGTERM, signal_callback_handler);
+#if defined PL_WIN
+    SetConsoleCtrlHandler(ConsoleHandler, TRUE);
+#endif
 
     if (fail(austin())) {
         retval = 1;
@@ -402,12 +430,14 @@ main(int argc, char** argv) {
 
     logger_close();
 
-    if (interrupt_signal < 0)
-        retval = interrupt_signal;
+    if (interrupt_signal)
+        retval = -interrupt_signal;
+    else if (fail(retval))
+        retval = austin_errno;
 
-    log_d("Exiting with code %d", fail(retval) ? austin_errno : retval);
+    log_d("Exiting with code %d", retval);
 
-    return fail(retval) ? austin_errno : retval;
+    return retval;
 } /* main */
 
 #endif

--- a/src/hints.h
+++ b/src/hints.h
@@ -63,6 +63,11 @@
         log_location(); \
         goto x;         \
     }
+#define FAIL_VOID       \
+    {                   \
+        log_location(); \
+        return;         \
+    }
 
 #define success(x) (!(x))
 #define fail(x)    (x)

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -923,7 +923,9 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
 
     log_t("Computed command line: %s", cmd_line);
 
-    BOOL process_created = CreateProcess(NULL, cmd_line, NULL, NULL, TRUE, 0, NULL, NULL, &siStartInfo, &piProcInfo);
+    BOOL process_created = CreateProcess(
+        NULL, cmd_line, NULL, NULL, TRUE, CREATE_NEW_PROCESS_GROUP, NULL, NULL, &siStartInfo, &piProcInfo
+    );
 
     sfree(cmd_line);
 
@@ -937,6 +939,25 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
     CloseHandle(hChildStdInRd);
     CloseHandle(hChildStdOutWr);
 
+    // Create a job for Austin
+    HANDLE hJob = self->extra->h_job = CreateJobObject(NULL, NULL);
+    if (!isvalid(hJob)) {
+        set_error(OS, "Failed to create job object");
+        FAIL;
+    }
+    // Set job limits to close all processes when Austin terminates
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = {0};
+    jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK;
+    if (!SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli))) {
+        set_error(OS, "Failed to set job information");
+        FAIL;
+    }
+    // Assign the child process to the job
+    if (!AssignProcessToJobObject(hJob, self->ref)) {
+        set_error(OS, "Failed to assign process to job");
+        FAIL;
+    }
+
 #else  /* UNIX */
     self->pid = fork();
     if (self->pid == 0) {
@@ -947,6 +968,10 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
             if (freopen(NULL_DEVICE, "w", stdout) == NULL)
                 set_error(IO, "Cannot redirect child's STDOUT to " NULL_DEVICE);
         }
+
+        // Create a new process group so that we can send signals to the parent
+        // process we spawned without affecting any of our parents.
+        setpgid(0, 0);
 
         execvpe(exec, argv, environ);
 
@@ -1365,10 +1390,18 @@ py_proc__log_version(py_proc_t* self, int parent) {
 void
 py_proc__signal(py_proc_t* self, int signal) {
 #if defined PL_WIN /* WIN */
+    log_d("Sending signal %d to process %d", signal, self->pid);
     switch (signal) {
     case SIGINT:
-        GenerateConsoleCtrlEvent(CTRL_C_EVENT, self->pid);
-        break;
+        // The child process will be closed when the parent terminates via
+        // the job object.
+        if (isvalid(self->extra->h_job)) {
+            if (!CloseHandle(self->extra->h_job)) {
+                set_error(OS, "Failed to close job handle");
+                FAIL_VOID;
+            }
+            self->extra->h_job = NULL;
+        }
     case SIGTERM:
         TerminateProcess(self->ref, signal);
         break;
@@ -1377,7 +1410,11 @@ py_proc__signal(py_proc_t* self, int signal) {
         break;
     }
 #else /* UNIX */
-    kill(self->pid, signal);
+    // We send the SIGINT signal to the process group, so that we also
+    // interrupt child processes, as if we were sending from a terminal with
+    // Ctrl-C.
+    log_d("Sending signal %d to process %d", signal, signal == SIGINT ? -getpgid(self->pid) : self->pid);
+    kill(signal == SIGINT ? -getpgid(self->pid) : self->pid, signal);
 #endif
 }
 

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -168,16 +168,23 @@ void
 py_proc_list__sample(py_proc_list_t* self) {
     log_t("Sampling from process list");
 
-    for (py_proc_item_t* item = self->first; item != NULL; /* item = item->next */) {
+    if (!isvalid(self->first))
+        return;
+
+    py_proc_item_t* item = self->first;
+    py_proc_item_t* next = item->next;
+    for (; isvalid(item); item = next, next = isvalid(item) ? item->next : NULL) {
         log_t("Sampling process with PID %d", item->py_proc->pid);
         stopwatch_start();
-        if (!isvalid(item->py_proc->py_v) || fail(py_proc__sample(item->py_proc))) {
-            py_proc__wait(item->py_proc);
-            py_proc_item_t* next = item->next;
+        if (!py_proc__is_python(item->py_proc))
+            // Not a Python process that we can sample, but we need to keep it
+            // to continue traversing the process tree.
+            continue;
+        if (fail(py_proc__sample(item->py_proc))) {
+            if (!error_is(PYOBJECT))
+                py_proc__wait(item->py_proc);
             _py_proc_list__remove(self, item);
-            item = next;
-        } else
-            item = item->next;
+        }
         stopwatch_duration();
     }
 } /* py_proc_list__sample */

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -34,6 +34,7 @@
 
 struct _proc_extra_info {
     HANDLE h_reader_thread;
+    HANDLE h_job;
 };
 
 // ----------------------------------------------------------------------------

--- a/test/functional/test_attach.py
+++ b/test/functional/test_attach.py
@@ -22,9 +22,11 @@
 
 import os
 import platform
+import signal
+import sys
+import time
 from collections import Counter
 from shutil import rmtree
-import time
 from test.utils import allpythons
 from test.utils import austin
 from test.utils import austinp
@@ -39,8 +41,8 @@ from test.utils import threads
 from test.utils import variants
 from time import sleep
 
-from flaky import flaky
 import pytest
+from flaky import flaky
 
 
 @requires_sudo
@@ -78,8 +80,15 @@ def test_attach_wall_time(austin, py, mode, mode_meta):
 @allpythons()
 def test_attach_exposure(py, exposure):
     with run_python(py, target("sleepy.py"), "3") as p:
-        result = austin("-i", "1ms", "-x", str(exposure), "-p", str(p.pid))
-        assert result.returncode == 0
+        result = austin(
+            "-i",
+            "100ms",
+            "-x",
+            str(exposure),
+            "-p",
+            str(p.pid),
+            expect_fail=True if sys.platform == "win32" else 256 - signal.SIGINT,
+        )
 
         assert has_pattern(result.stdout, "sleepy.py:<module>:"), compress(
             result.stdout

--- a/test/functional/test_fork.py
+++ b/test/functional/test_fork.py
@@ -21,7 +21,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import platform
+import signal
 from pathlib import Path
+import sys
 from test.utils import allpythons
 from test.utils import austin
 from test.utils import compress
@@ -202,9 +204,15 @@ def test_fork_full_metrics(py):
 @allpythons()
 def test_fork_exposure(py, exposure):
     result = austin(
-        "-i", "1ms", "-x", str(exposure), *python(py), target("sleepy.py"), "1"
+        "-i",
+        "100ms",
+        "-x",
+        str(exposure),
+        *python(py),
+        target("sleepy.py"),
+        "1",
+        expect_fail=True if sys.platform == "win32" else 256 - signal.SIGINT,
     )
-    assert result.returncode == 0, result.stderr or result.stdout
 
     assert has_pattern(result.stdout, "sleepy.py:<module>:"), compress(result.stdout)
 
@@ -213,7 +221,7 @@ def test_fork_exposure(py, exposure):
     assert meta["mode"] == "wall"
 
     d = int(meta["duration"])
-    assert 900000 * exposure < d < 1100000 * exposure
+    assert 900000 * exposure < d < 1200000 * exposure
 
 
 @variants

--- a/test/support/test_uwsgi.py
+++ b/test/support/test_uwsgi.py
@@ -89,7 +89,9 @@ def test_uwsgi(py):
         with uwsgi(env=env) as uw:
             request_thread.start()
 
-            result = austin("-x", "2", "-Cp", str(uw.pid))
+            result = austin(
+                "-x", "2", "-i", "100ms", "-Cp", str(uw.pid), expect_fail=True
+            )
             assert has_pattern(result.stdout, "app.py:application:5"), compress(
                 result.stdout
             )
@@ -108,7 +110,9 @@ def test_uwsgi_multiprocess(py):
         ) as uw:
             request_thread.start()
 
-            result = austin("-x", "2", "-Cp", str(uw.pid))
+            result = austin(
+                "-x", "2", "-i", "100ms", "-Cp", str(uw.pid), expect_fail=True
+            )
             assert has_pattern(result.stdout, "app.py:application:5"), compress(
                 result.stdout
             )

--- a/test/utils.py
+++ b/test/utils.py
@@ -51,6 +51,10 @@ from typing import TypeVar
 from typing import Union
 
 
+if sys.platform == "win32":
+    from subprocess import CREATE_NEW_PROCESS_GROUP
+
+
 try:
     import pytest
 except ImportError:
@@ -294,10 +298,15 @@ class Variant:
         extra_args = ["-b"] if "-b, --binary" in self.help else []
 
         try:
+            flags = 0
+            if sys.platform == "win32":
+                flags = CREATE_NEW_PROCESS_GROUP
+
             result = run(
                 [str(self.path)] + extra_args + list(args),
                 capture_output=True,
                 timeout=timeout,
+                creationflags=flags,
             )
         except Exception as exc:
             if (pid := getattr(exc, "pid", None)) is not None:
@@ -322,15 +331,18 @@ class Variant:
         logs = collect_logs(self.name, result.pid)
         result.logs = logs
 
-        if result.returncode != int(expect_fail):
-            print_logs(logs)
-            raise RuntimeError(
-                f"Command {self.name} returned {result.returncode} "
-                f"while expecting {expect_fail}. Output:\n{result.stdout}\n"
-                f"Error:\n{result.stderr}"
-            )
+        if isinstance(expect_fail, bool) and expect_fail is bool(result.returncode):
+            return result
 
-        return result
+        if isinstance(expect_fail, int) and result.returncode == expect_fail:
+            return result
+
+        print_logs(logs)
+        raise RuntimeError(
+            f"Command {self.name} returned {result.returncode} "
+            f"while expecting {expect_fail}. Output:\n{result.stdout}\n"
+            f"Error:\n{result.stderr}"
+        )
 
     def __repr__(self) -> str:
         return f"Variant({self.name!r})"


### PR DESCRIPTION
We fix an issue with multiprocess sampling that caused Austin to fail to collect samples if the parent process was not a Python process. We also make sure that the interrupt signal is propagated to the process group to emulate a Ctrl-C sent directly to the process.