### PR TITLE
refactor: terminal output

### DIFF
--- a/src/ansi.h
+++ b/src/ansi.h
@@ -1,0 +1,87 @@
+/*
+ * This is free and unencumbered software released into the public domain.
+ *
+ * For more information, please refer to <https://unlicense.org>
+ */
+
+#pragma once
+
+// Regular text
+#define BLK "\e[0;30m"
+#define RED "\e[0;31m"
+#define GRN "\e[0;32m"
+#define YEL "\e[0;33m"
+#define BLU "\e[0;34m"
+#define MAG "\e[0;35m"
+#define CYN "\e[0;36m"
+#define WHT "\e[0;37m"
+
+// Regular bold text
+#define BOLD "\e[1m"
+#define BBLK "\e[1;30m"
+#define BRED "\e[1;31m"
+#define BGRN "\e[1;32m"
+#define BYEL "\e[1;33m"
+#define BBLU "\e[1;34m"
+#define BMAG "\e[1;35m"
+#define BCYN "\e[1;36m"
+#define BWHT "\e[1;37m"
+
+// Regular underline text
+#define UBLK "\e[4;30m"
+#define URED "\e[4;31m"
+#define UGRN "\e[4;32m"
+#define UYEL "\e[4;33m"
+#define UBLU "\e[4;34m"
+#define UMAG "\e[4;35m"
+#define UCYN "\e[4;36m"
+#define UWHT "\e[4;37m"
+
+// Regular background
+#define BLKB "\e[40m"
+#define REDB "\e[41m"
+#define GRNB "\e[42m"
+#define YELB "\e[43m"
+#define BLUB "\e[44m"
+#define MAGB "\e[45m"
+#define CYNB "\e[46m"
+#define WHTB "\e[47m"
+
+// High intensty background
+#define BLKHB "\e[0;100m"
+#define REDHB "\e[0;101m"
+#define GRNHB "\e[0;102m"
+#define YELHB "\e[0;103m"
+#define BLUHB "\e[0;104m"
+#define MAGHB "\e[0;105m"
+#define CYNHB "\e[0;106m"
+#define WHTHB "\e[0;107m"
+
+// High intensty text
+#define HBLK "\e[0;90m"
+#define HRED "\e[0;91m"
+#define HGRN "\e[0;92m"
+#define HYEL "\e[0;93m"
+#define HBLU "\e[0;94m"
+#define HMAG "\e[0;95m"
+#define HCYN "\e[0;96m"
+#define HWHT "\e[0;97m"
+
+// Bold high intensity text
+#define BHBLK "\e[1;90m"
+#define BHRED "\e[1;91m"
+#define BHGRN "\e[1;92m"
+#define BHYEL "\e[1;93m"
+#define BHBLU "\e[1;94m"
+#define BHMAG "\e[1;95m"
+#define BHCYN "\e[1;96m"
+#define BHWHT "\e[1;97m"
+
+// 256-color support (used in events.c)
+#define HBLK256  "\033[38;5;246m"
+#define BBLK256  "\033[38;5;248;1m"
+#define BHBLU256 "\033[38;5;159m"
+
+// Reset
+#define CRESET      "\e[0m"
+#define COLOR_RESET "\e[0m"

--- a/src/austin.c
+++ b/src/austin.c
@@ -92,10 +92,9 @@ int
 do_single_process(py_proc_t* py_proc) {
     int result = 0;
 
-    if (!pargs.where)
-        log_meta_header();
+    log_meta_header();
 
-    py_proc__log_version(py_proc, true);
+    py_proc__log_version(py_proc, /*is_parent*/ true);
 
     if (pargs.exposure == 0) {
         while (interrupt_signal == 0) {
@@ -111,8 +110,10 @@ do_single_process(py_proc_t* py_proc) {
 #endif
         }
     } else {
-        if (!pargs.where && !pargs.pipe)
-            log_m("🕑 Sampling for %d second%s", pargs.exposure, pargs.exposure != 1 ? "s" : "");
+        if (!pargs.where && !pargs.pipe) {
+            log_m("");
+            log_m("🕑 Sampling for %d second%s ...", pargs.exposure, pargs.exposure != 1 ? "s" : "");
+        }
         microseconds_t end_time = gettime() + pargs.exposure * 1000000;
         while (interrupt_signal == 0) {
             stopwatch_start();
@@ -163,13 +164,8 @@ do_child_processes(py_proc_t* py_proc) {
         FAIL;
     }
 
-    // If the parent process is not a Python process, its children might be, so we
-    // attempt to attach Austin to them.
-
-    if (!pargs.pipe) {
-        log_m("");
-        log_m("\033[1mParent process\033[0m");
-    }
+    // If the parent process is not a Python process, its children might be, so
+    // we attempt to attach Austin to them.
     if (!py_proc__is_python(py_proc)) {
         log_m("👽 Parent is not a Python process.");
 
@@ -192,19 +188,10 @@ do_child_processes(py_proc_t* py_proc) {
             FAIL;
         }
     } else {
-        py_proc__log_version(py_proc, true);
+        py_proc__log_version(py_proc, /*is_parent*/ true);
     }
 
-    if (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
-        if (!pargs.pipe) {
-            log_m("");
-            log_m("\033[1mChild processes\033[0m");
-        }
-    }
-
-    if (!pargs.where) {
-        log_meta_header();
-    }
+    log_meta_header();
 
     if (pargs.exposure == 0) {
         while (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
@@ -220,8 +207,10 @@ do_child_processes(py_proc_t* py_proc) {
 #endif
         }
     } else {
-        if (!pargs.pipe && !pargs.where)
-            log_m("🕑 Sampling for %d second%s", pargs.exposure, pargs.exposure != 1 ? "s" : "");
+        if (!pargs.pipe && !pargs.where) {
+            log_m("");
+            log_m("🕑 Sampling for %d second%s ...", pargs.exposure, pargs.exposure != 1 ? "s" : "");
+        }
         microseconds_t end_time = gettime() + pargs.exposure * 1000000;
         while (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
 #ifndef NATIVE
@@ -300,7 +289,7 @@ austin() {
 
     if (!pargs.where && is_tty(pargs.output_file)) {
         printf(
-            "\n⚠️  \033[1;33mWARNING\033[0m  Austin is about to generate binary output to terminal.\n\n"
+            "\n⚠️  " BYEL "WARNING" CRESET "  Austin is about to generate binary output to terminal.\n\n"
             "Do you want to continue without specifying an output file? [y/N] "
         );
         char answer[2];

--- a/src/events.c
+++ b/src/events.c
@@ -23,6 +23,7 @@
 #define EVENTS_C
 
 #include "events.h"
+#include "ansi.h"
 #include "argparse.h"
 #include "frame.h"
 #include "platform.h"
@@ -188,17 +189,17 @@ mojo_event_handler_new(void) {
 // ----------------------------------------------------------------------------
 // Where event handler
 
-const char* WHERE_SAMPLE_FORMAT = "    \033[33;1m%2$s\033[0m (\033[36;1m%1$s\033[0m:\033[32;1m%3$d\033[0m)\n";
+const char* WHERE_SAMPLE_FORMAT = "    " BYEL "%2$s" CRESET " (" BCYN "%1$s" CRESET ":" BGRN "%3$d" CRESET ")\n";
 #ifdef NATIVE
 const char* WHERE_SAMPLE_FORMAT_NATIVE
-    = "    \033[38;5;246m%2$s\033[0m (\033[38;5;248;1m%1$s\033[0m:\033[38;5;246m%3$d\033[0m)\n";
-const char* WHERE_SAMPLE_FORMAT_KERNEL = "    \033[38;5;159m%s\033[0m 🐧\n";
+    = "    " HBLK256 "%2$s" CRESET " (" BBLK256 "%1$s" CRESET ":" HBLK256 "%3$d" CRESET ")\n";
+const char* WHERE_SAMPLE_FORMAT_KERNEL = "    " BHBLU256 "%s" CRESET " 🐧\n";
 #endif
 #if defined PL_WIN
 const char* WHERE_HEAD_FORMAT
-    = "\n\n%4$s Process \033[35;1m%1$I64d\033[0m 🧵 Thread \033[34;1m%2$I64d:%3$I64d\033[0m\n\n";
+    = "\n\n%4$s Process " BMAG "%1$I64d" CRESET " 🧵 Thread " BBLU "%2$I64d:%3$I64d" CRESET "\n\n";
 #else
-const char* WHERE_HEAD_FORMAT = "\n\n%4$s Process \033[35;1m%1$d\033[0m 🧵 Thread \033[34;1m%2$ld:%3$ld\033[0m\n\n";
+const char* WHERE_HEAD_FORMAT = "\n\n%4$s Process " BMAG "%1$d" CRESET " 🧵 Thread " BBLU "%2$ld:%3$ld" CRESET "\n\n";
 #endif
 
 // ----------------------------------------------------------------------------

--- a/src/logging.c
+++ b/src/logging.c
@@ -147,6 +147,9 @@ void
 log_m(const char* fmt, ...) {
     va_list args;
 
+    if (pargs.pipe)
+        return;
+
     va_start(args, fmt);
     vfprintf(stderr, fmt, args);
     fputc('\n', stderr);
@@ -199,6 +202,9 @@ logger_close(void) {
 
 void
 log_meta_header(void) {
+    if (pargs.where)
+        return;
+
     event_handler__emit_metadata("austin", VERSION);
     event_handler__emit_metadata("interval", MICROSECONDS_FMT, pargs.t_sampling_interval);
 
@@ -212,30 +218,12 @@ log_meta_header(void) {
         event_handler__emit_metadata("mode", "wall");
     }
 
-    if (pargs.memory || pargs.full) {
+    if (pargs.memory || pargs.full)
         event_handler__emit_metadata("memory", MEM_VALUE, get_total_memory());
-    }
-    if (pargs.children) {
-        event_handler__emit_metadata("multiprocess", "on");
-    }
 
-    if (pargs.pipe) {
-        log_m("# austin: " VERSION);
-        log_m("# interval: " MICROSECONDS_FMT, pargs.t_sampling_interval);
-        if (pargs.full) {
-            log_m("# mode: full");
-        } else if (pargs.memory) {
-            log_m("# mode: memory");
-        } else if (pargs.cpu) {
-            log_m("# mode: cpu");
-        } else {
-            log_m("# mode: wall");
-        }
-        if (pargs.memory || pargs.full) {
-            log_m("# memory: " MEM_VALUE, get_total_memory());
-        }
-        if (pargs.children) {
-            log_m("# multiprocess: on");
-        }
-    }
+    if (pargs.children)
+        event_handler__emit_metadata("multiprocess", "on");
+
+    if (pargs.gc)
+        event_handler__emit_metadata("gc", "on");
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -28,6 +28,7 @@
 
 #include <inttypes.h>
 
+#include "ansi.h"
 #include "argparse.h"
 #include "austin.h"
 
@@ -56,29 +57,29 @@
 #define MICROSECONDS_FMT "%" PRIu64
 
 #ifdef NATIVE
-#define log_header()                                                                                               \
-    {                                                                                                              \
-        log_m("\033[1m              _   _      \033[0m");                                                          \
-        log_m("\033[1m __ _ _  _ __| |_(_)_ _  \033[0m");                                                          \
-        log_m("\033[1m/ _` | || (_-<  _| | ' \\ \033[0m");                                                         \
-        log_m(                                                                                                     \
-            "\033[1m\\__,_|\\_,_/__/\\__|_|_||_|\033[0m\033[31;1mp\033[0m \033[36;1m" VERSION "\033[0m [" COMPILER \
-            " %d.%d.%d]",                                                                                          \
-            COMPILER_MAJOR, COMPILER_MINOR, COMPILER_PATCH                                                         \
-        );                                                                                                         \
-        log_i("====[ AUSTINP ]====");                                                                              \
+#define log_header()                                                                                         \
+    {                                                                                                        \
+        log_m(BOLD "              _   _      " CRESET);                                                      \
+        log_m(BOLD " __ _ _  _ __| |_(_)_ _  " CRESET);                                                      \
+        log_m(BOLD "/ _` | || (_-<  _| | ' \\ " CRESET);                                                     \
+        log_m(                                                                                               \
+            BOLD "\\__,_|\\_,_/__/\\__|_|_||_|" CRESET BRED "p" CRESET " " BCYN VERSION CRESET " [" COMPILER \
+                 " %d.%d.%d]",                                                                               \
+            COMPILER_MAJOR, COMPILER_MINOR, COMPILER_PATCH                                                   \
+        );                                                                                                   \
+        log_i("====[ AUSTINP ]====");                                                                        \
     }
 #else
-#define log_header()                                                                                           \
-    {                                                                                                          \
-        log_m("\033[1m              _   _      \033[0m ");                                                     \
-        log_m("\033[1m __ _ _  _ __| |_(_)_ _  \033[0m");                                                      \
-        log_m("\033[1m/ _` | || (_-<  _| | ' \\ \033[0m");                                                     \
-        log_m(                                                                                                 \
-            "\033[1m\\__,_|\\_,_/__/\\__|_|_||_|\033[0m \033[36;1m" VERSION "\033[0m [" COMPILER " %d.%d.%d]", \
-            COMPILER_MAJOR, COMPILER_MINOR, COMPILER_PATCH                                                     \
-        );                                                                                                     \
-        log_i("====[ AUSTIN ]====");                                                                           \
+#define log_header()                                                                                       \
+    {                                                                                                      \
+        log_m(BOLD "              _   _      " CRESET);                                                    \
+        log_m(BOLD " __ _ _  _ __| |_(_)_ _  " CRESET);                                                    \
+        log_m(BOLD "/ _` | || (_-<  _| | ' \\ " CRESET);                                                   \
+        log_m(                                                                                             \
+            BOLD "\\__,_|\\_,_/__/\\__|_|_||_|" CRESET " " BCYN VERSION CRESET " [" COMPILER " %d.%d.%d]", \
+            COMPILER_MAJOR, COMPILER_MINOR, COMPILER_PATCH                                                 \
+        );                                                                                                 \
+        log_i("====[ AUSTIN ]====");                                                                       \
     }
 #endif
 #define log_footer() \

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1354,30 +1354,39 @@ py_proc__sample(py_proc_t* self) {
 
 // ----------------------------------------------------------------------------
 void
-py_proc__log_version(py_proc_t* self, int parent) {
+py_proc__log_version(py_proc_t* self, bool is_parent) {
     int major = self->py_v->major;
     int minor = self->py_v->minor;
     int patch = self->py_v->patch;
 
-    if (parent) {
+    if (is_parent) {
         if (patch == 0xFF) {
             event_handler__emit_metadata("python", "%d.%d.?", major, minor);
         } else
             event_handler__emit_metadata("python", "%d.%d.%d", major, minor, patch);
     }
 
-    if (pargs.pipe) {
+    if (pargs.pipe)
+        return;
+
+    log_m("");
+
+    if (pargs.children) {
         if (patch == 0xFF)
-            log_m("# python: %d.%d.?", major, minor);
+            log_m(
+                "🐍 %s process [" CYN "%zd" CRESET "] " BOLD "Python" CRESET " version: " BYEL "%d.%d" CRESET,
+                is_parent ? "Parent" : "Child", self->pid, major, minor
+            );
         else
-            log_m("# python: %d.%d.%d", major, minor, patch);
+            log_m(
+                "🐍 %s process [" CYN "%zd" CRESET "] " BOLD "Python" CRESET " version: " BYEL "%d.%d.%d" CRESET,
+                is_parent ? "Parent" : "Child", self->pid, major, minor, patch
+            );
     } else {
-        log_m("");
         if (patch == 0xFF)
-            log_m("🐍 \033[1mPython\033[0m version: \033[33;1m%d.%d.?\033[0m (from shared library)", major, minor);
+            log_m("🐍 " BOLD "Python" CRESET " version: " BYEL "%d.%d" CRESET, major, minor);
         else
-            log_m("🐍 \033[1mPython\033[0m version: \033[33;1m%d.%d.%d\033[0m", major, minor, patch);
-        log_m("");
+            log_m("🐍 " BOLD "Python" CRESET " version: " BYEL "%d.%d.%d" CRESET, major, minor, patch);
     }
 }
 

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -230,7 +230,7 @@ py_proc__sample(py_proc_t*);
  * @param bool  whether the process is the parent process.
  */
 void
-py_proc__log_version(py_proc_t*, int);
+py_proc__log_version(py_proc_t*, bool);
 
 /**
  * Send a signal to the process.

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -150,7 +150,7 @@ py_proc_list__add_proc_children(py_proc_list_t* self, uintptr_t ppid) {
             }
 
             _py_proc_list__add(self, child_proc);
-            py_proc__log_version(child_proc, false);
+            py_proc__log_version(child_proc, /*is_parent*/ false);
             py_proc_list__add_proc_children(self, pid);
         }
     }

--- a/src/stats.c
+++ b/src/stats.c
@@ -136,10 +136,13 @@ stats_duration() {
     return gettime() - _start_time;
 }
 
+#define STAT_INDENT "      "
+
 void
 stats_log_metrics() {
     microseconds_t duration = stats_duration();
 
+    event_handler__emit_metadata("count", "%ld", _sample_cnt);
     if (_sample_cnt) {
         event_handler__emit_metadata(
             "sampling", MICROSECONDS_FMT "," MICROSECONDS_FMT "," MICROSECONDS_FMT, stats_get_min_sampling_time(),
@@ -148,57 +151,46 @@ stats_log_metrics() {
         event_handler__emit_metadata("saturation", "%ld/%ld", _long_cnt, _sample_cnt);
         event_handler__emit_metadata("errors", "%ld/%ld", _error_cnt, _sample_cnt);
         event_handler__emit_metadata("duration", MICROSECONDS_FMT, duration);
-        if (pargs.gc) {
+        if (pargs.gc)
             event_handler__emit_metadata("gc", MICROSECONDS_FMT, _gc_time);
-        }
-    }
 
-    if (pargs.pipe && _sample_cnt) {
-        log_m(
-            "# sampling: " MICROSECONDS_FMT "," MICROSECONDS_FMT "," MICROSECONDS_FMT, stats_get_min_sampling_time(),
-            stats_get_avg_sampling_time(), stats_get_max_sampling_time()
-        );
-        log_m("# saturation: %ld/%ld", _long_cnt, _sample_cnt);
-        log_m("# errors: %ld/%ld", _error_cnt, _sample_cnt);
-        log_m("# duration: " MICROSECONDS_FMT, duration);
-        if (pargs.gc) {
-            log_m("# gc: " MICROSECONDS_FMT, _gc_time);
-        }
-    } else {
+        if (pargs.pipe)
+            goto release; // Saves a few computations
+
         log_m("");
-        if (!_sample_cnt) {
-            log_m("😣 No samples collected.");
-            goto release;
+        log_m("📈 " BOLD "Sampling Statistics" CRESET);
+        log_m("");
+
+        log_m(STAT_INDENT "Total duration" BLK " . . . . . . " CRESET BOLD "%.2fs" CRESET, duration / 1000000.);
+
+        double      avg_rate   = (double)_sample_cnt / (duration / 1000000.);
+        const char* rate_unit  = "Hz";
+        double      rate_value = avg_rate;
+        if (avg_rate >= 1e6) {
+            rate_unit  = "MHz";
+            rate_value = avg_rate / 1e6;
+        } else if (avg_rate >= 1e3) {
+            rate_unit  = "kHz";
+            rate_value = avg_rate / 1e3;
         }
-
-        log_m("\033[1mStatistics\033[0m");
-
-        log_m("⌛ Sampling duration : \033[1m%.2f s\033[0m", duration / 1000000.);
+        log_m(STAT_INDENT "Average sampling rate" BLK "  . . " CRESET BOLD "%.2f %s" CRESET, rate_value, rate_unit);
 
         if (pargs.gc) {
             log_m(
-                "🗑️  Garbage collector : \033[1m%.2f s\033[0m (\033[1m%.2f %%\033[0m)", _gc_time / 1000000.,
-                (float)_gc_time / duration * 100
+                STAT_INDENT "Garbage collector" BLK "  . . . . " CRESET BOLD "%.2fs" CRESET " (" BOLD "%.2f%%" CRESET
+                            ")",
+                _gc_time / 1000000., (float)_gc_time / duration * 100
             );
         }
 
         log_m(
-            "⏱️  Frame sampling (min/avg/max) : \033[1m" MICROSECONDS_FMT "/" MICROSECONDS_FMT "/" MICROSECONDS_FMT " "
-            "μs\033[0m",
-            stats_get_min_sampling_time(), stats_get_avg_sampling_time(), stats_get_max_sampling_time()
+            STAT_INDENT "Error rate" BLK " . . . . . . . . " CRESET BOLD "%d/%d" CRESET " (" BOLD "%.2f%%" CRESET ")",
+            _error_cnt, _sample_cnt, (float)_error_cnt / _sample_cnt * 100
         );
-
-        log_m(
-            "🐢 Long sampling rate : \033[1m%d/%d\033[0m (\033[1m%.2f %%\033[0m) samples took longer than the sampling "
-            "interval to collect",
-            _long_cnt, _sample_cnt, (float)_long_cnt / _sample_cnt * 100
-        );
-
-        log_m(
-            "💀 Error rate : \033[1m%d/%d\033[0m (\033[1m%.2f %%\033[0m) invalid samples", _error_cnt, _sample_cnt,
-            (float)_error_cnt / _sample_cnt * 100
-        );
-    };
+    } else {
+        log_m("");
+        log_m("😣 No samples collected.");
+    }
 
 release:
 #if defined PL_MACOS

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -32,6 +32,12 @@ ROOT = TEST.parent
 SRC = ROOT / "src"
 
 
+# ANSI color codes for print
+RESET = "\033[0m"
+BOLD_YELLOW = "\033[1;33m"
+BOLD_RED = "\033[1;31m"
+
+
 restrict_re = re.compile(r"__restrict \w+")
 
 _header_head = r"""
@@ -355,8 +361,8 @@ class DeclCollector(c_ast.NodeVisitor):
                 if i != line:
                     print(f"{i + 1:5d}  {lines[i]}")
                 else:
-                    print(f"{i + 1:5d}  \033[33;1m{lines[line]}\033[0m")
-                    print(" " * (col + 5) + "\033[31;1m<<^\033[0m")
+                    print(f"{i + 1:5d}  {BOLD_YELLOW}{lines[line]}{RESET}")
+                    print(" " * (col + 5) + f"{BOLD_RED}<<^{RESET}")
             raise
 
         self.visit(ast)

--- a/test/functional/test_pipe.py
+++ b/test/functional/test_pipe.py
@@ -89,14 +89,12 @@ def test_pipe_wall_time_multiprocess(py):
 
 @allpythons()
 def test_pipe_wall_time_multiprocess_output(py, tmp_path):
-    datafile = tmp_path / "test_pipe.austin"
-
-    result = austin("-CPi", "1ms", "-o", str(datafile), *python(py), target())
+    result = austin("-CPi", "1ms", *python(py), target(), convert=True)
     assert result.returncode == 0
 
-    meta = metadata(result.stderr)
+    meta = metadata(result.stdout)
 
-    assert meta, meta
+    assert meta, result.stdout
     assert meta["mode"] == "wall", meta
     assert int(meta["duration"]) > 100000, meta
     assert meta["interval"] == "1000", meta

--- a/test/utils.py
+++ b/test/utils.py
@@ -270,7 +270,8 @@ class Variant:
         self.name = name
         self.path = path
 
-        self.ALL.append(self)
+        if self.path.is_file():
+            self.ALL.append(self)
 
     @cached_property
     def help(self) -> str:


### PR DESCRIPTION
We refactor the code around terminal output. We make the code more readable by using macros for the ANSI escape sequences. We also re-arrange the layout of some of the terminal output, such as the sampling statistics to convey more user-relevant information. We also include some extra metadata that can be useful for tools that will process the output after collection.

<img width="360" height="214" alt="Screenshot 2025-09-02 at 16 45 53" src="https://github.com/user-attachments/assets/cd9f5f7e-c640-4402-a57b-0ce1e20a4ef5" />
