### PR TITLE
Support C23 in GCC 15

### DIFF
--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -54,6 +54,7 @@ _header_head = r"""
 #define __GNUC_VA_LIST
 #define __gnuc_va_list char
 #define __thread
+#define __typeof__(nullptr) void*
 typedef struct __builtin_va_list { } __builtin_va_list;
 #define _Nullable
 #define __uint128_t unsigned long long


### PR DESCRIPTION
### Description of the Change

Add a fake define to allow pycparser to parse GCC 15 intermediate output containing `__typedef__(nullptr)`

Fixes: https://bugs.debian.org/1114057

### Verification Process

Tests pass with this patch on Debian unstable, with the new `stddef.h`.