### PR TITLE
Cope with ieee128 long double redirection on ppc64el

### DIFF
--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -60,6 +60,11 @@ typedef struct __builtin_va_list { } __builtin_va_list;
 #define __uint128_t unsigned long long
 #define _Nonnull
 #define __float128 long double
+// Avoid redirection to float128 ABI on ppc64el.
+#if __LDBL_MANT_DIG__ == 113
+#  undef __LDBL_MANT_DIG__
+#  define __LDBL_MANT_DIG__ __DBL_MANT_DIG__
+#endif
 """
 
 


### PR DESCRIPTION
### Description of the Change

GCC 15 in Debian testing is configured with
`--with-long-double-format=ieee`, resulting in obscure test failures (see
https://buildd.debian.org/status/fetch.php?pkg=austin&arch=ppc64el&ver=3.7.0-6&stamp=1757674632&raw=0). Nearly all ways I can see to work around this would involve pycparser being significantly smarter; this is horrible, but it gets the job done.

### Verification Process

This is a test-only change.  Tests pass on Debian unstable for both amd64 and ppc64el with this change.