### PR TITLE
ci: fix arch builds

### DIFF
--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout sources
 
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v3
         name: Build Austin on ${{ matrix.arch }}
         id: build-on-arch
         with:

--- a/.github/workflows/pre_release_arch.yml
+++ b/.github/workflows/pre_release_arch.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout sources
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v3
         name: Generate artifacts on ${{ matrix.arch }}
         id: run-tests-on-arch
         with:

--- a/.github/workflows/release_arch.yml
+++ b/.github/workflows/release_arch.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout sources
       
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v3
         name: Run tests on ${{ matrix.arch }}
         id: run-tests-on-arch
         with:

--- a/scripts/build_arch.sh
+++ b/scripts/build_arch.sh
@@ -8,11 +8,22 @@ apt-get update
 apt-get -y install \
     autoconf \
     build-essential \
-    libunwind-dev \
+    libtool \
     binutils-dev \
     libiberty-dev \
+    liblzma-dev \
     musl-tools \
-    zlib1g-dev
+    zlib1g-dev \
+    git
+
+# Compile and install libunwind from sources
+git clone https://github.com/libunwind/libunwind.git
+cd libunwind
+autoreconf -i
+./configure CFLAGS="-fPIC"
+make
+make install
+cd -
 
 # Build Austin
 autoreconf --install


### PR DESCRIPTION
We fix the build jobs for Linux on other non-GHA-native archs by bumping the GHA version and by compiling libunwind from source.