### PR TITLE
chore: increase timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ requires no instrumentation and has practically no impact on the tracee.
   -p, --pid=PID              Attach to the process with the given PID.
   -P, --pipe                 Pipe mode. Use when piping Austin output.
   -t, --timeout=n_ms         Start up wait time in milliseconds (default is
-                             100). Accepted units: s, ms.
+                             3000). Accepted units: s, ms.
   -w, --where=PID            Dump the stacks of all the threads within the
                              process with the given PID.
   -x, --exposure=n_sec       Sample for n_sec seconds only.

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -45,7 +45,7 @@
 #else
 #define DEFAULT_SAMPLING_INTERVAL 100
 #endif
-#define DEFAULT_INIT_TIMEOUT_MS 1000 // 1 second
+#define DEFAULT_INIT_TIMEOUT_MS 3000 // 3 second
 
 // Globals for command line arguments
 parsed_args_t pargs = {
@@ -185,7 +185,7 @@ static struct argp_option options[] = {
   },
   {
     "timeout",      't', "n_ms",        0,
-    "Start up wait time in milliseconds (default is 100). Accepted units: s, ms."
+    "Start up wait time in milliseconds (default is 3000). Accepted units: s, ms."
   },
   {
     "cpu",          'c', NULL,          0,
@@ -486,7 +486,7 @@ print(";")
 "  -p, --pid=PID              Attach to the process with the given PID.\n"
 "  -P, --pipe                 Pipe mode. Use when piping Austin output.\n"
 "  -t, --timeout=n_ms         Start up wait time in milliseconds (default is\n"
-"                             100). Accepted units: s, ms.\n"
+"                             3000). Accepted units: s, ms.\n"
 "  -w, --where=PID            Dump the stacks of all the threads within the\n"
 "                             process with the given PID.\n"
 "  -x, --exposure=n_sec       Sample for n_sec seconds only.\n"

--- a/src/austin.1
+++ b/src/austin.1
@@ -40,7 +40,7 @@ Pipe mode. Use when piping Austin output.
 .TP
 \fB\-t\fR, \fB\-\-timeout\fR=\fI\,n_ms\/\fR
 Start up wait time in milliseconds (default is
-100). Accepted units: s, ms.
+3000). Accepted units: s, ms.
 .TP
 \fB\-w\fR, \fB\-\-where\fR=\fI\,PID\/\fR
 Dump the stacks of all the threads within the


### PR DESCRIPTION
We increase the timeout to give better chances to detect the Python runtime on systems where it might be a bit slow