### PR TITLE
fix: terminate the child on failure before waiting

### DIFF
--- a/src/austin.c
+++ b/src/austin.c
@@ -141,6 +141,7 @@ do_single_process(py_proc_t* py_proc) {
         }
 
         // If we spawned the process, we need to wait for it to terminate.
+        py_proc__terminate(py_proc);
         py_proc__wait(py_proc);
     }
 

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -181,8 +181,10 @@ py_proc_list__sample(py_proc_list_t* self) {
             // to continue traversing the process tree.
             continue;
         if (fail(py_proc__sample(item->py_proc))) {
-            if (!error_is(PYOBJECT))
+            if (!error_is(PYOBJECT)) {
+                py_proc__terminate(item->py_proc);
                 py_proc__wait(item->py_proc);
+            }
             _py_proc_list__remove(self, item);
         }
         stopwatch_duration();


### PR DESCRIPTION
We make sure to terminate the child process when Austin is about to finish to ensure that the wait hangs indefinitely.