### PR TITLE
chore(linux): check for remote read permissions

### DIFF
--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -594,6 +594,15 @@ _py_proc__init(py_proc_t* self) {
         FAIL;
     }
 
+    // We try to copy some remote memory to check that we have the permissions
+    // to do so.
+    char    c;
+    raddr_t addr = self->symbols[DYNSYM_RUNTIME];
+    if (!isvalid(addr))
+        addr = self->map.bss.base;
+    if (!isvalid(addr) || fail(copy_memory(self->ref, self->symbols[DYNSYM_RUNTIME], sizeof(c), &c)))
+        FAIL;
+
     self->extra->page_size = get_page_size();
     log_d("Page size: %u", self->extra->page_size);
 

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -696,8 +696,11 @@ _py_proc__run(py_proc_t* self) {
 
     if (!init) {
         log_d("Interpreter state search timed out");
-        if (error_is(VERSION)) {
-            // Nothing more we can do if we don't have a version
+        // Nothing more we can do if we don't have a version or permissions
+        if (error_is(VERSION) || error_is(PERM))
+            FAIL;
+        if (!isvalid(self->py_v)) {
+            set_error(VERSION, "No valid Python version detected");
             FAIL;
         }
 #if defined PL_LINUX

--- a/test/functional/test_cli.py
+++ b/test/functional/test_cli.py
@@ -54,16 +54,9 @@ def test_cli_no_python():
         assert result.returncode == 0
         dest.chmod(0o755)
 
-    result = austin(
-        str(dest),
-        expect_fail=(
-            AustinError.VERSION if sys.platform == "linux" else AustinError.BINARY
-        ),
-    )
+    result = austin(str(dest), expect_fail=AustinError.VERSION)
 
-    assert (
-        "Cannot determine" if sys.platform == "linux" else "not a Python"
-    ) in result.stderr
+    assert "Cannot determine" in result.stderr
 
 
 def test_cli_short_lived():


### PR DESCRIPTION
We check for the permissions to read remote memory on Linux, after we have successfully detected that the target process is a Python process.