### PR TITLE
Fix test failure with pycparser 3.0

### DIFF
--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -23,7 +23,7 @@ from typing import Type
 
 from pycparser import c_ast
 from pycparser import c_parser
-from pycparser.plyparser import ParseError
+from pycparser.c_parser import ParseError
 
 
 HERE = Path(__file__).resolve().parent


### PR DESCRIPTION
### Description of the Change

See https://github.com/eliben/pycparser/commit/58a302bf7f3ae82538605dc2be64ff23c903698c.  This change should work with both old and new versions of pycparser.

### Verification Process

Ran tests with pycparser 3.0, in response to https://bugs.debian.org/1127499.