### PR TITLE
chore: pin black version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install black
-        run: pip install black
+        run: pip install black~=26.3.1
 
       - name: Check formatting
         run: black --check --exclude=test/targets test/

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -25,7 +25,6 @@ from pycparser import c_ast
 from pycparser import c_parser
 from pycparser.plyparser import ParseError
 
-
 HERE = Path(__file__).resolve().parent
 TEST = HERE.parent
 ROOT = TEST.parent

--- a/test/cunit/argparse.py
+++ b/test/cunit/argparse.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from test.cunit import SRC
 from test.cunit import CModule
 
-
 CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 EXTRA_SOURCES = [

--- a/test/cunit/cache.py
+++ b/test/cunit/cache.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from test.cunit import SRC
 from test.cunit import CModule
 
-
 CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 EXTRA_SOURCES = [

--- a/test/cunit/env.py
+++ b/test/cunit/env.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from test.cunit import SRC
 from test.cunit import CModule
 
-
 CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 EXTRA_SOURCES = [

--- a/test/cunit/error.py
+++ b/test/cunit/error.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from test.cunit import SRC
 from test.cunit import CModule
 
-
 CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 sys.modules[__name__] = CModule.compile(SRC / Path(__file__).stem, cflags=CFLAGS)

--- a/test/cunit/platform.py
+++ b/test/cunit/platform.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from test.cunit import SRC
 from test.cunit import CModule
 
-
 CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 sys.modules[__name__] = CModule.compile(SRC / Path(__file__).stem, cflags=CFLAGS)

--- a/test/cunit/stats.py
+++ b/test/cunit/stats.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from test.cunit import SRC
 from test.cunit import CModule
 
-
 CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
 
 EXTRA_SOURCES = [

--- a/test/cunit/test_cache.py
+++ b/test/cunit/test_cache.py
@@ -9,7 +9,6 @@ from test.cunit.cache import QueueItem
 
 import pytest
 
-
 NULL = 0
 C.free.argtypes = [c_void_p]
 C.malloc.restype = c_void_p

--- a/test/support/test_uwsgi.py
+++ b/test/support/test_uwsgi.py
@@ -19,7 +19,6 @@ import psutil
 import pytest
 from requests import get
 
-
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32", reason="Not supported on Windows"
 )

--- a/test/utils.py
+++ b/test/utils.py
@@ -51,7 +51,6 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-
 if sys.platform == "win32":
     from subprocess import CREATE_NEW_PROCESS_GROUP
 
@@ -63,7 +62,6 @@ except ImportError:
 
 from austin.events import AustinSample
 from austin.format.mojo import MojoStreamReader
-
 
 HERE = Path(__file__).parent
 


### PR DESCRIPTION
We pin the version of black used for formatting test sources to prevent accidental failures in CI.