### PR TITLE
chore: pin CI dependencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install codespell
-        run: pip install codespell
+        run: pip install codespell~=2.4
 
       - name: Check source code spelling
         run: codespell -I .github/workflows/wordlist.txt -S "src/python/*" src
@@ -117,7 +117,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install flake8
-        run: pip install flake8
+        run: pip install flake8~=7.3
 
       - name: Lint code
         run: flake8 --config test/.flake8 test/
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install cog
-        run: pip install cogapp
+        run: pip install cogapp~=3.6
 
       - name: Compile Austin
         run: |

--- a/scripts/requirements-bw.txt
+++ b/scripts/requirements-bw.txt
@@ -1,2 +1,2 @@
-wheel
-twine
+wheel~=0.46
+twine~=6.2

--- a/scripts/requirements-val.txt
+++ b/scripts/requirements-val.txt
@@ -1,3 +1,3 @@
 austin-python~=2.1
-numpy
-scipy
+numpy~=2.4
+scipy~=1.17

--- a/test/cunit/__init__.py
+++ b/test/cunit/__init__.py
@@ -64,6 +64,7 @@ typedef struct __builtin_va_list { } __builtin_va_list;
 #  undef __LDBL_MANT_DIG__
 #  define __LDBL_MANT_DIG__ __DBL_MANT_DIG__
 #endif
+typedef int bool;
 """
 
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,11 +1,11 @@
 austin-python~=2.1
-flaky
-pytest
-pytest-xdist
+flaky~=3.8
+pytest~=9.0
+pytest-xdist~=3.8
 
 # C unit tests
-pycparser
+pycparser~=2.23
 
 # Support tests
-psutil
-requests
+psutil~=7.2
+requests~=2.32

--- a/test/support/requirements-uwsgi.txt
+++ b/test/support/requirements-uwsgi.txt
@@ -1,1 +1,1 @@
-uwsgi; sys_platform != 'win32'
+uwsgi~=2.0; sys_platform != 'win32'


### PR DESCRIPTION
We pin all the remaining unpinned dependencies used in CI jobs to prevent workflows from breaking when new major versions are released.