### PR TITLE
fix(austinp): libunwind usage

### DIFF
--- a/src/linux/common.h
+++ b/src/linux/common.h
@@ -47,27 +47,71 @@ struct _proc_extra_info {
 
 #ifdef NATIVE
 #include <sched.h>
+#include <sys/wait.h>
 
+// General ptrace wrapper. Does NOT retry on ESRCH because that error is
+// terminal for most requests (thread doesn't exist or isn't traced).
 static inline int
 wait_ptrace(enum __ptrace_request request, pid_t pid, void* addr, void* data) {
-    int            outcome = 0;
-    microseconds_t end     = gettime() + 100000; // Wait for 100ms
+    int outcome = ptrace(request, pid, addr, data);
 
-    while (gettime() < end && (outcome = ptrace(request, pid, addr, data)) && errno == 3)
+    if (fail(outcome)) {
+        set_error(OS, "ptrace request failed");
+        FAIL;
+    }
+
+    SUCCESS;
+}
+
+// PTRACE_SEIZE wrapper that retries briefly on ESRCH. A thread that was just
+// created may be momentarily invisible to ptrace while the kernel is setting up
+// its task struct, so a short retry is warranted here (and only here).
+static inline int
+wait_ptrace_seize(pid_t pid) {
+    int            outcome = 0;
+    microseconds_t end     = gettime() + 100000; // 100ms
+
+    while (gettime() < end && (outcome = ptrace(PTRACE_SEIZE, pid, 0, 0)) && errno == ESRCH)
         sched_yield();
 
 #ifdef DEBUG
     microseconds_t wait = gettime() - end + 100000;
     if (wait > 1000)
-        log_d("ptrace long wait for request %d: " MICROSECONDS_FMT " microseconds", request, wait);
+        log_d("ptrace SEIZE long wait for pid %d: " MICROSECONDS_FMT " microseconds", pid, wait);
 #endif
 
     if (fail(outcome)) {
-        set_error(OS, "wait for ptrace request failed");
+        set_error(OS, "PTRACE_SEIZE failed");
         FAIL;
     }
 
     SUCCESS;
+}
+
+// Wait for a thread to enter ptrace-stop after PTRACE_INTERRUPT.
+// PTRACE_INTERRUPT is asynchronous: it only queues the stop request; the thread
+// enters ptrace-stop at the next safe point. The kernel delivers this as a
+// waitpid notification, which must be consumed before any ptrace register-read
+// (e.g. via libunwind _UPT_accessors) will succeed on the thread.
+static inline int
+wait_thread_stop(pid_t tid) {
+    int            status;
+    microseconds_t end = gettime() + 100000; // 100ms timeout, same as wait_ptrace
+
+    for (;;) {
+        pid_t r = waitpid(tid, &status, __WALL | WNOHANG);
+        if (r == tid) {
+            if (WIFSTOPPED(status))
+                return 0;
+            // Thread exited or was killed while we were waiting
+            return -1;
+        }
+        if (r == -1 && errno != EINTR)
+            return -1;
+        if (gettime() >= end)
+            return -1;
+        sched_yield();
+    }
 }
 
 #endif

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -66,11 +66,13 @@ union {
 } ehdr_v;
 
 // ----------------------------------------------------------------------------
+#ifndef NATIVE
 static void*
 wait_thread(void* py_proc) {
     waitpid(((py_proc_t*)py_proc)->pid, 0, 0);
     return NULL;
 }
+#endif
 
 // ----------------------------------------------------------------------------
 static ssize_t

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -995,10 +995,15 @@ py_proc__start(py_proc_t* self, const char* exec, char* argv[]) {
 #if defined PL_LINUX
     self->ref = self->pid;
 
+#ifndef NATIVE
     // On Linux we need to wait for the forked process or otherwise it will
     // become a zombie and we cannot tell with kill if it has terminated.
+    // In NATIVE mode, py_proc__wait handles this with a ptrace-stop draining
+    // loop instead (the process may be in signal-delivery-stop and won't exit
+    // until the tracer delivers the signal via ptrace(PTRACE_CONT)).
     pthread_create(&(self->extra->wait_thread_id), NULL, wait_thread, (void*)self);
     log_d("Wait thread created with ID %x", self->extra->wait_thread_id);
+#endif
 #endif
 
     log_d("New process created with PID %d", self->pid);
@@ -1026,7 +1031,7 @@ void
 py_proc__wait(py_proc_t* self) {
     log_d("Waiting for process %d to terminate", self->pid);
 
-#if defined PL_LINUX
+#if defined PL_LINUX && !defined NATIVE
     if (self->extra->wait_thread_id) {
         pthread_join(self->extra->wait_thread_id, NULL);
     }
@@ -1041,7 +1046,33 @@ py_proc__wait(py_proc_t* self) {
     CloseHandle(self->ref);
 #else /* UNIX */
 #ifdef NATIVE
-    wait(NULL);
+    // In NATIVE mode, threads are ptrace-seized. A signal sent to the process
+    // (e.g. SIGTERM) is intercepted by ptrace as a signal-delivery-stop: the
+    // signal is NOT delivered until the tracer calls ptrace(PTRACE_CONT) with
+    // the signal number. Loop here draining ptrace-stops and forwarding signals
+    // until the main process exits; otherwise the process hangs forever.
+    {
+        int status;
+        for (;;) {
+            pid_t r = waitpid(-1, &status, __WALL);
+            if (r <= 0)
+                break; // ECHILD or error: no more traced children
+            if (WIFEXITED(status) || WIFSIGNALED(status)) {
+                if (r == (pid_t)self->pid)
+                    break; // Main process exited
+                continue;  // A thread exited; keep waiting for the main process
+            }
+            if (WIFSTOPPED(status)) {
+                // Resume the thread, forwarding any pending signal.
+                // Do not forward SIGTRAP (ptrace events) or SIGSTOP (ptrace
+                // interrupt stops) — pass 0 for those to avoid spurious signals.
+                int sig = WSTOPSIG(status);
+                if (sig == SIGTRAP || sig == SIGSTOP)
+                    sig = 0;
+                ptrace(PTRACE_CONT, r, 0, (void*)(intptr_t)sig);
+            }
+        }
+    }
 #else
     waitpid(self->pid, 0, 0);
 #endif
@@ -1154,6 +1185,18 @@ _py_proc__interrupt_threads(py_proc_t* self, raddr_t tstate_head) {
         if (fail(wait_ptrace(PTRACE_INTERRUPT, py_thread.tid, 0, 0))) // GCOV_EXCL_LINE
             FAIL;                                                     // GCOV_EXCL_LINE
 
+        // Consume the ptrace-stop notification so that the thread is fully
+        // stopped before libunwind tries to read its registers. Without this
+        // waitpid the thread may still be running when unw_init_remote is
+        // called, causing UNW_EBADREG failures and inconsistent stack data.
+        if (fail(wait_thread_stop(py_thread.tid))) { // GCOV_EXCL_START
+            log_d("ptrace: thread %d did not stop in time, resuming", py_thread.tid);
+            if (fail(wait_ptrace(PTRACE_CONT, py_thread.tid, 0, 0))) {
+                log_d("ptrace: failed to resume thread %d (errno: %d)", py_thread.tid, errno);
+            }
+            FAIL;
+        } // GCOV_EXCL_STOP
+
         if (fail(py_thread__set_interrupted(&py_thread, true))) { // GCOV_EXCL_START
             if (fail(wait_ptrace(PTRACE_CONT, py_thread.tid, 0, 0))) {
                 log_d("ptrace: failed to resume interrupted thread %d (errno: %d)", py_thread.tid, errno);
@@ -1170,32 +1213,6 @@ _py_proc__interrupt_threads(py_proc_t* self, raddr_t tstate_head) {
     SUCCESS;
 }
 
-// ----------------------------------------------------------------------------
-static int
-_py_proc__resume_threads(py_proc_t* self, raddr_t tstate_head) {
-    py_thread_t py_thread = py_thread__init(self);
-
-    if (fail(py_thread__read_remote(&py_thread, tstate_head))) { // GCOV_EXCL_START
-        FAIL;
-    } // GCOV_EXCL_STOP
-
-    do {
-        if (py_thread__is_interrupted(&py_thread)) {
-            if (fail(wait_ptrace(PTRACE_CONT, py_thread.tid, 0, 0))) // GCOV_EXCL_LINE
-                FAIL;                                                // GCOV_EXCL_LINE
-
-            log_t("ptrace: thread %d resumed", py_thread.tid);
-            if (fail(py_thread__set_interrupted(&py_thread, false))) { // GCOV_EXCL_START
-                FAIL;
-            } // GCOV_EXCL_STOP
-        }
-    } while (success(py_thread__next(&py_thread)));
-
-    if (!error_is(ITEREND)) // GCOV_EXCL_LINE
-        FAIL;               // GCOV_EXCL_LINE
-
-    SUCCESS;
-}
 #endif
 
 // ----------------------------------------------------------------------------
@@ -1380,16 +1397,20 @@ py_proc__sample(py_proc_t* self) {
             SUCCESS;
 
 #ifdef NATIVE
-        if (fail(_py_proc__interrupt_threads(self, tstate_head))) // GCOV_EXCL_LINE
-            FAIL;                                                 // GCOV_EXCL_LINE
+        if (fail(_py_proc__interrupt_threads(self, tstate_head))) { // GCOV_EXCL_LINE
+            // Interrupt failed partway through: some threads may already be in
+            // ptrace-stop. Resume them via the interrupted bitmap to avoid leaving
+            // the target application hanging, then bail out of this sample.
+            py_thread__resume_all_interrupted(); // GCOV_EXCL_LINE
+            FAIL;                                // GCOV_EXCL_LINE
+        }
 
         time_delta = gettime() - self->timestamp;
 #endif
         int result = _py_proc__sample_interpreter(self, current_interp, time_delta);
 
 #ifdef NATIVE
-        if (fail(_py_proc__resume_threads(self, tstate_head))) // GCOV_EXCL_LINE
-            FAIL;                                              // GCOV_EXCL_LINE
+        py_thread__resume_all_interrupted();
 #endif
 
         if (fail(result))

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -326,6 +326,34 @@ py_thread__is_interrupted(py_thread_t* self) {
 }
 
 // ----------------------------------------------------------------------------
+// Resume every thread whose interrupted bit is set by scanning the bitmap
+// directly rather than re-traversing the Python linked list. This correctly
+// handles threads that were removed from the list between the interrupt and
+// resume phases (e.g. a thread that exited mid-sample), which a linked-list
+// walk would silently miss, leaving those threads stuck in ptrace-stop.
+void
+py_thread__resume_all_interrupted(void) {
+    size_t bmsize = (max_pid >> 3) + 1;
+
+    for (size_t i = 0; i < bmsize; i++) {
+        if (!_tids_int[i])
+            continue;
+        for (int b = 0; b < 8; b++) {
+            unsigned char bit = (unsigned char)(1 << b);
+            if (!(_tids_int[i] & bit))
+                continue;
+            pid_t tid = (pid_t)((i << 3) | b);
+            if (ptrace(PTRACE_CONT, tid, 0, 0)) {
+                log_d("ptrace: failed to resume thread %d (errno: %d)", tid, errno);
+            } else {
+                log_t("ptrace: thread %d resumed", tid);
+            }
+            _tids_int[i] &= ~bit; // always clear so the thread isn't stuck
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
 #define MAX_STACK_FILE_SIZE 2048
 
 int
@@ -396,10 +424,7 @@ static char _native_buf[MAXLEN];
 
 static inline int
 wait_unw_init_remote(unw_cursor_t* c, unw_addr_space_t as, void* arg) {
-    int            outcome = 0;
-    microseconds_t end     = gettime() + 1000;
-    while (gettime() <= end && (outcome = unw_init_remote(c, as, arg)) == -UNW_EBADREG)
-        sched_yield();
+    int outcome = unw_init_remote(c, as, arg);
     if (fail(outcome))
         log_e("unwind: failed to initialize cursor (%d)", outcome);
     return outcome;
@@ -527,20 +552,36 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
 // ----------------------------------------------------------------------------
 static inline int
 _py_thread__seize(py_thread_t* self) {
-    // TODO: If a TID is reused we will never seize it!
-    if (!isvalid(_tids[self->tid])) {
-        if (fail(wait_ptrace(PTRACE_SEIZE, self->tid, 0, 0))) { // GCOV_EXCL_START
-            set_error(OS, "Failed to seize thread");
-            FAIL;
-        } else { // GCOV_EXCL_STOP
-            log_d("ptrace: thread %d seized", self->tid);
-        }
-        _tids[self->tid] = _UPT_create(self->tid);
-        if (!isvalid(_tids[self->tid])) { // GCOV_EXCL_START
-            set_error(OS, "Failed to create libunwind context");
-            FAIL;
-        } // GCOV_EXCL_STOP
+    if (isvalid(_tids[self->tid])) {
+        // A context already exists for this TID. Verify the thread is still
+        // alive to detect TID reuse: if the original thread exited and a new
+        // thread was assigned the same TID, the old libunwind context is stale
+        // and must be replaced before we can safely unwind the new thread.
+        char task_path[48];
+        sprintf(task_path, "/proc/%d/task/%" PRIuPTR, self->proc->pid, self->tid);
+        if (access(task_path, F_OK) == 0)
+            SUCCESS; // Same thread still alive; context is valid
+
+        // Thread exited — tear down the stale context and re-seize the new one.
+        log_d("ptrace: TID %" PRIuPTR " reused, releasing stale context", self->tid);
+        _UPT_destroy(_tids[self->tid]);
+        _tids[self->tid]            = NULL;
+        _tids_int[self->tid >> 3]  &= ~(1 << (self->tid & 7));
+        _tids_idle[self->tid >> 3] &= ~(1 << (self->tid & 7));
     }
+
+    if (fail(wait_ptrace_seize(self->tid))) { // GCOV_EXCL_START
+        set_error(OS, "Failed to seize thread");
+        FAIL;
+    } // GCOV_EXCL_STOP
+
+    log_d("ptrace: thread %" PRIuPTR " seized", self->tid);
+    _tids[self->tid] = _UPT_create(self->tid);
+    if (!isvalid(_tids[self->tid])) { // GCOV_EXCL_START
+        set_error(OS, "Failed to create libunwind context");
+        FAIL;
+    } // GCOV_EXCL_STOP
+
     SUCCESS;
 }
 
@@ -644,21 +685,23 @@ py_thread__unwind(py_thread_t* self) {
     bool error = false;
 
 #ifdef NATIVE
-
-    // We sample the kernel frame stack BEFORE interrupting because otherwise
-    // we would see the ptrace syscall call stack, which is not very interesting.
-    // The downside is that the kernel stack might not be in sync with the other
-    // ones.
-    if (pargs.kernel) {
-        _py_thread__unwind_kernel_frame_stack(self);
+    // Only unwind the native stack if this thread was stopped during the
+    // interrupt phase. A thread that appears in the Python linked list but
+    // was NOT interrupted (i.e. it was created after we finished interrupting)
+    // is still running — unwinding its registers would produce garbage or
+    // crash libunwind.
+    if (py_thread__is_interrupted(self)) {
+        // We sample the kernel frame stack BEFORE interrupting because
+        // otherwise we would see the ptrace syscall call stack, which is not
+        // very interesting. The downside is that the kernel stack might not be
+        // in sync with the other ones.
+        if (pargs.kernel) {
+            _py_thread__unwind_kernel_frame_stack(self);
+        }
+        if (fail(_py_thread__unwind_native_frame_stack(self))) {
+            error = true;
+        }
     }
-    if (fail(_py_thread__unwind_native_frame_stack(self))) {
-        error = true;
-    }
-
-    // Update the thread state to improve guarantees that it will be in sync with
-    // the native stack just collected
-    py_thread__read_remote(self, self->addr);
 #endif
     V_DESC(self->proc->py_v);
 

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -105,6 +105,9 @@ py_thread__set_interrupted(py_thread_t*, bool);
 int
 py_thread__is_interrupted(py_thread_t* self);
 
+void
+py_thread__resume_all_interrupted(void);
+
 int
 py_thread__save_kernel_stack(py_thread_t*);
 #endif


### PR DESCRIPTION
We fix our usage of libunwind to respect the underlying use of ptrace. In particular we make sure that we wait for asynchronous signals sent to a process when trying to stop threads. This way we have a more consistent way of determining when we are ready to sample the native stack of a thread. We also make sure that we don't leave threads stopped in case we fail throughout the process and cause potential hangs in the target application.