### PR TITLE
bm: parallelize runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,18 +9,41 @@ on:
       - src/**
 
 jobs:
-  benchmarks:
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.groups.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
+      - name: Install benchmark dependencies
+        run: |
+          python3.13 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          pip install -r scripts/requirements-bm.txt
+
+      - name: Generate benchmark group matrix
+        id: groups
+        env:
+          PYTHONPATH: .
+        run: |
+          source .venv/bin/activate
+          matrix=$(python scripts/benchmark.py --list-groups)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
     runs-on: ubuntu-24.04
     steps:
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
-
-      - name: Install Python 3.13
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.13"
 
       - uses: actions/checkout@v3
         with:
@@ -47,6 +70,46 @@ jobs:
           make
           cd -
 
+      - name: Package binaries
+        run: |
+          mkdir -p dist
+          cp austin-base/src/austin dist/austin-base
+          cp austin/src/austin       dist/austin
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: austin-binaries
+          path: dist/
+          retention-days: 1
+
+  benchmark:
+    needs: [setup, build]
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: austin
+
+      - name: Install Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: austin-binaries
+          path: dist/
+
+      - name: Install binaries
+        run: |
+          chmod +x dist/austin dist/austin-base
+          cp dist/austin      austin/src/austin
+          cp dist/austin-base austin/src/austin-base
+
       - name: Install runtime dependencies
         run: |
           python3.13 -m venv .venv
@@ -56,22 +119,71 @@ jobs:
           pip install -r scripts/requirements-bm.txt
           cd -
 
-      - name: Run benchmarks
+      - name: Run benchmark group
         shell: bash
         env:
-          PYTHONPATH: "."
+          PYTHONPATH: austin
         run: |
           set -eo pipefail
           ulimit -c unlimited
           echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
           source .venv/bin/activate
-          mv ${{ github.workspace}}/austin-base/src/austin ${{ github.workspace}}/austin/src/austin-base
           cd austin
-          python scripts/benchmark.py --format markdown | tee ${{ github.workspace}}/comment.txt
+          python scripts/benchmark.py \
+            -k "${{ matrix.filter }}" \
+            --format json \
+            > ../results-${{ matrix.name }}.json
+          cd -
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-${{ matrix.name }}
+          path: results-${{ matrix.name }}.json
+          retention-days: 1
+
+  report:
+    needs: benchmark
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: austin
+
+      - name: Install Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: bench-results-*
+          path: results/
+          merge-multiple: true
+
+      - name: Install runtime dependencies
+        run: |
+          python3.13 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          cd austin
+          pip install -r scripts/requirements-bm.txt
+          cd -
+
+      - name: Merge results and render report
+        shell: bash
+        env:
+          PYTHONPATH: austin
+        run: |
+          source .venv/bin/activate
+          cd austin
+          python scripts/benchmark.py \
+            --merge ../results/*.json \
+            --format markdown \
+            > ${{ github.workspace }}/comment.txt
           cd -
 
       - name: Post results on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: benchmarks
-          path: ${{ github.workspace}}/comment.txt
+          path: ${{ github.workspace }}/comment.txt

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -2,10 +2,12 @@
 # Ensure dependencies from requirements-bm.txt are installed.
 
 import abc
+import json
 import re
 import sys
 import typing as t
 from argparse import ArgumentParser
+from dataclasses import dataclass
 from math import floor, log
 from pathlib import Path
 from textwrap import wrap
@@ -16,48 +18,65 @@ from scipy.stats import ttest_ind
 from test.utils import target
 
 VERSIONS = ("base", "dev")
-SCENARIOS = [
+
+
+@dataclass(frozen=True)
+class Scenario:
+    group: str
+    title: str
+    args: t.List[str]
+    variant: str = "austin"
+
+    @property
+    def group_slug(self) -> str:
+        return self.group.lower().replace(" ", "-")
+
+
+SCENARIOS: t.List[Scenario] = [
     *[
-        (
-            "austin",
-            f"Wall time [sampling interval: {i}]",
-            ["-i", str(i), sys.executable, target("target34.py")],
+        Scenario(
+            group="Wall time",
+            title=f"Wall time [sampling interval: {i}]",
+            args=["-i", str(i), sys.executable, target("target34.py")],
         )
         for i in (1, 10, 100, 1000)
     ],
     *[
-        (
-            "austin",
-            f"CPU time [sampling interval: {i}]",
-            ["-ci", str(i), sys.executable, target("target34.py")],
+        Scenario(
+            group="CPU time",
+            title=f"CPU time [sampling interval: {i}]",
+            args=["-ci", str(i), sys.executable, target("target34.py")],
         )
         for i in (1, 10, 100, 1000)
     ],
     *[
-        (
-            "austin",
-            f"RSA keygen [sampling interval: {i}]",
-            ["-ci", str(i), sys.executable, "-m", "test.bm.rsa_key_generator"],
+        Scenario(
+            group="RSA keygen",
+            title=f"RSA keygen [sampling interval: {i}]",
+            args=["-ci", str(i), sys.executable, "-m", "test.bm.rsa_key_generator"],
         )
         for i in (1, 10, 100, 1000)
     ],
     *[
-        (
-            "austin",
-            f"Full metrics [sampling interval: {i}]",
-            ["-fi", str(i), sys.executable, target("target34.py")],
+        Scenario(
+            group="Full metrics",
+            title=f"Full metrics [sampling interval: {i}]",
+            args=["-fi", str(i), sys.executable, target("target34.py")],
         )
         for i in (1, 10, 100, 1000)
     ],
     *[
-        (
-            "austin",
-            f"Multiprocess wall time [sampling interval: {i}]",
-            ["-Cfi", str(i), sys.executable, target("target_mp.py"), "16"],
+        Scenario(
+            group="Multiprocess wall time",
+            title=f"Multiprocess wall time [sampling interval: {i}]",
+            args=["-Cfi", str(i), sys.executable, target("target_mp.py"), "16"],
         )
         for i in (1, 10, 100, 1000)
     ],
 ]
+
+# Ordered unique groups, derived from SCENARIOS (preserves definition order).
+SCENARIO_GROUPS: t.List[str] = list(dict.fromkeys(s.group for s in SCENARIOS))
 
 
 # The metrics we evaluate and whether they are to be maximised or minimised.
@@ -238,10 +257,7 @@ class MarkdownRenderer(TerminalRenderer):
     def render_table(self, table: t.List[t.Tuple[str, t.List[Results]]]) -> None:
         _, row = table[0]
         cols = list(row.keys())
-        max_vh = max(len(e[0]) for e in table)
-
         col_widths = [max(max(len(r[col]), len(col)) for _, r in table) for col in cols]
-        div_len = sum(col_widths) + (len(cols) + 1) * 2 + max_vh
 
         print("|     |" + "|".join(f" {col} " for col in cols) + "|")
         print("| --- |" + "|".join(f":{'-' * len(col)}:" for col in cols) + "|")
@@ -283,34 +299,68 @@ def summarize(results: t.List[t.Tuple[str, t.List[Results]]]):
     return summary
 
 
+def results_to_json(results: t.List[t.Tuple[str, t.List[Results]]]) -> str:
+    """Serialise results to JSON."""
+    serialisable = []
+    for title, table in results:
+        rows = []
+        for version, metrics in table:
+            rows.append(
+                {
+                    "version": version,
+                    "metrics": {k: v.data for k, v in metrics.items()},
+                }
+            )
+        serialisable.append({"title": title, "table": rows})
+    return json.dumps(serialisable, indent=2)
+
+
+def results_from_json(raw: str) -> t.List[t.Tuple[str, t.List[Results]]]:
+    """Deserialise results produced by results_to_json."""
+    results = []
+    for entry in json.loads(raw):
+        table = []
+        for row in entry["table"]:
+            metrics = {k: Outcome(v) for k, v in row["metrics"].items()}
+            table.append((row["version"], metrics))
+        results.append((entry["title"], table))
+    return results
+
+
+def merge_results(
+    parts: t.List[t.List[t.Tuple[str, t.List[Results]]]]
+) -> t.List[t.Tuple[str, t.List[Results]]]:
+    """Merge partial result lists into one, preserving the SCENARIOS order."""
+    order = {s.title: i for i, s in enumerate(SCENARIOS)}
+    merged: t.Dict[str, t.List[Results]] = {}
+    for part in parts:
+        for title, table in part:
+            merged[title] = table
+    return sorted(merged.items(), key=lambda x: order.get(x[0], len(order)))
+
+
 def benchmark(opts: ArgumentParser) -> None:
     Outcome.__critical_p__ = opts.pvalue
 
-    renderer = {"terminal": TerminalRenderer, "markdown": MarkdownRenderer}[
-        opts.format
-    ]()
-
-    renderer.render_header("Austin Benchmarks")
-    renderer.render_paragraph(
-        f"Running Austin benchmarks with Python {'.'.join(str(_) for _ in sys.version_info[:3])}",
-    )
-
     results: t.List[t.Tuple[str, t.List[Results]]] = []
 
-    for variant, title, args in SCENARIOS:
-        if opts.k is not None and not opts.k.match(title):
+    for scenario in SCENARIOS:
+        if opts.k is not None and not opts.k.search(scenario.title):
             continue
 
-        print(f"Running scenario {title} with {variant} ...", file=sys.stderr)
+        print(f"Running scenario {scenario.title} ...", file=sys.stderr)
 
         table: t.List[Results] = []
         for version in VERSIONS:
             print(f"> Running with Austin {version} ...    ", end="\r", file=sys.stderr)
             try:
-                austin = download_release(version, Path("/tmp"), variant_name=variant)
+                austin = download_release(
+                    version, Path("/tmp"), variant_name=scenario.variant
+                )
             except RuntimeError:
                 print(
-                    f"WARNING: Could not download {variant} {version}", file=sys.stderr
+                    f"WARNING: Could not download {scenario.variant} {version}",
+                    file=sys.stderr,
                 )
                 continue
 
@@ -318,13 +368,14 @@ def benchmark(opts: ArgumentParser) -> None:
                 _
                 for _ in (
                     get_stats(run.metadata)
-                    for run in (austin(*args) for _ in range(opts.n))
+                    for run in (austin(*scenario.args) for _ in range(opts.n))
                 )
                 if _ is not None
             ]
             if not stats:
                 print(
-                    f"WARNING: No valid stats for {variant} {version} with args {args}",
+                    f"WARNING: No valid stats for {scenario.variant} {version} "
+                    f"with args {scenario.args}",
                     file=sys.stderr,
                 )
                 continue
@@ -338,7 +389,26 @@ def benchmark(opts: ArgumentParser) -> None:
                 )
             )
 
-        results.append((title, table))
+        results.append((scenario.title, table))
+
+    if opts.format == "json":
+        print(results_to_json(results))
+        return
+
+    render(results, opts)
+
+
+def render(
+    results: t.List[t.Tuple[str, t.List[Results]]], opts: ArgumentParser
+) -> None:
+    renderer = {"terminal": TerminalRenderer, "markdown": MarkdownRenderer}[
+        opts.format
+    ]()
+
+    renderer.render_header("Austin Benchmarks")
+    renderer.render_paragraph(
+        f"Running Austin benchmarks with Python {'.'.join(str(_) for _ in sys.version_info[:3])}",
+    )
 
     summary = summarize(results)
 
@@ -355,7 +425,7 @@ def main():
     argp.add_argument(
         "-k",
         type=re.compile,
-        help="Run benchmark scenarios that match the given regular expression",
+        help="Run benchmark scenarios matching the given regular expression",
     )
 
     argp.add_argument(
@@ -369,7 +439,7 @@ def main():
         "-f",
         "--format",
         type=str,
-        choices=["terminal", "markdown"],
+        choices=["terminal", "markdown", "json"],
         default="terminal",
         help="The output format",
     )
@@ -382,7 +452,37 @@ def main():
         help="The p-value to use when testing for statistical significance",
     )
 
+    argp.add_argument(
+        "--merge",
+        nargs="+",
+        metavar="FILE",
+        help="Merge JSON result files produced by --format json and render a report",
+    )
+
+    argp.add_argument(
+        "--list-groups",
+        action="store_true",
+        help="Print the benchmark groups as a GitHub Actions matrix JSON and exit",
+    )
+
     opts = argp.parse_args()
+
+    if opts.list_groups:
+        matrix = [
+            {"name": g.lower().replace(" ", "-"), "filter": g}
+            for g in SCENARIO_GROUPS
+        ]
+        print(json.dumps({"include": matrix}))
+        return
+
+    if opts.merge:
+        parts = [results_from_json(Path(f).read_text()) for f in opts.merge]
+        results = merge_results(parts)
+        if opts.format == "json":
+            print(results_to_json(results))
+        else:
+            render(results, opts)
+        return
 
     benchmark(opts)
 


### PR DESCRIPTION
We make each scenario group run in its own runner for parallelism in order to speed up the overall job execution and have a quicker feedback on each PR.