### PR TITLE
ci: build libunwind from upstream and cache it

### DIFF
--- a/.github/actions/setup-libunwind/action.yml
+++ b/.github/actions/setup-libunwind/action.yml
@@ -1,0 +1,42 @@
+name: 'Setup libunwind'
+description: >
+  Build libunwind from source and cache it by upstream HEAD SHA.
+  Exports CPATH, LIBRARY_PATH, and PKG_CONFIG_PATH so subsequent
+  steps pick up the custom prefix without changes to ./configure calls.
+
+runs:
+  using: composite
+  steps:
+    - name: Get libunwind HEAD SHA
+      id: libunwind-sha
+      shell: bash
+      run: |
+        SHA=$(git ls-remote https://github.com/libunwind/libunwind.git HEAD | cut -f1)
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+    - name: Cache libunwind
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: /opt/libunwind
+        key: libunwind-${{ runner.os }}-${{ steps.libunwind-sha.outputs.sha }}
+
+    - name: Build and install libunwind
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        git clone --depth=1 https://github.com/libunwind/libunwind.git /tmp/libunwind
+        cd /tmp/libunwind
+        autoreconf -i
+        ./configure --prefix=/opt/libunwind CFLAGS="-fPIC"
+        make -j$(nproc)
+        sudo make install
+
+    - name: Activate libunwind
+      shell: bash
+      run: |
+        echo "CPATH=/opt/libunwind/include${CPATH:+:$CPATH}" >> "$GITHUB_ENV"
+        echo "LIBRARY_PATH=/opt/libunwind/lib${LIBRARY_PATH:+:$LIBRARY_PATH}" >> "$GITHUB_ENV"
+        echo "PKG_CONFIG_PATH=/opt/libunwind/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
+        echo "/opt/libunwind/lib" | sudo tee /etc/ld.so.conf.d/libunwind.conf
+        sudo ldconfig

--- a/.github/actions/setup-libunwind/action.yml
+++ b/.github/actions/setup-libunwind/action.yml
@@ -1,17 +1,22 @@
 name: 'Setup libunwind'
 description: >
-  Build libunwind from source and cache it by upstream HEAD SHA.
+  Build libunwind from source and cache it by tag SHA.
   Exports CPATH, LIBRARY_PATH, and PKG_CONFIG_PATH so subsequent
   steps pick up the custom prefix without changes to ./configure calls.
+
+inputs:
+  version:
+    description: 'libunwind git tag to build'
+    default: 'v1.8.3'
 
 runs:
   using: composite
   steps:
-    - name: Get libunwind HEAD SHA
+    - name: Get libunwind SHA
       id: libunwind-sha
       shell: bash
       run: |
-        SHA=$(git ls-remote https://github.com/libunwind/libunwind.git HEAD | cut -f1)
+        SHA=$(git ls-remote https://github.com/libunwind/libunwind.git refs/tags/${{ inputs.version }} | cut -f1)
         echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
     - name: Cache libunwind
@@ -25,7 +30,7 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        git clone --depth=1 https://github.com/libunwind/libunwind.git /tmp/libunwind
+        git clone --depth=1 --branch ${{ inputs.version }} https://github.com/libunwind/libunwind.git /tmp/libunwind
         cd /tmp/libunwind
         autoreconf -i
         ./configure --prefix=/opt/libunwind CFLAGS="-fPIC"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,10 +40,17 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v3
+        with:
+          path: austin
+
+      - name: Setup libunwind
+        uses: ./austin/.github/actions/setup-libunwind
+
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
+          sudo apt-get -y install binutils-dev libiberty-dev liblzma-dev zlib1g-dev libzstd-dev
 
       - uses: actions/checkout@v3
         with:
@@ -57,10 +64,6 @@ jobs:
           ./configure --enable-debug=symbols
           make
           cd -
-
-      - uses: actions/checkout@v3
-        with:
-          path: austin
 
       - name: Compile Austin from the PR
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,12 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup libunwind
+        uses: ./.github/actions/setup-libunwind
+
       - name: Install build dependencies
         run: |
           sudo add-apt-repository -y universe
           sudo add-apt-repository -y ppa:inkscape.dev/stable
           sudo apt-get update
-          sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev help2man inkscape
+          sudo apt-get -y install binutils-dev libiberty-dev liblzma-dev zlib1g-dev libzstd-dev \
+            help2man inkscape
 
       - name: Compile Austin
         run: |
@@ -128,10 +132,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup libunwind
+        uses: ./.github/actions/setup-libunwind
+
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
+          sudo apt-get -y install binutils-dev libiberty-dev liblzma-dev zlib1g-dev libzstd-dev
 
       - name: Compile Austin
         run: |

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -13,11 +13,16 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout Austin
 
-      - name: Generate artifacts
+      - name: Setup libunwind
+        uses: ./.github/actions/setup-libunwind
+
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install autoconf build-essential libunwind-dev binutils-dev libiberty-dev musl-tools zlib1g-dev
+          sudo apt-get -y install binutils-dev libiberty-dev liblzma-dev musl-tools zlib1g-dev libzstd-dev
 
+      - name: Generate artifacts
+        run: |
           # Build austin
           autoreconf --install
           ./configure

--- a/.github/workflows/pre_release_arch.yml
+++ b/.github/workflows/pre_release_arch.yml
@@ -29,28 +29,7 @@ jobs:
             export PREV_VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
             export VERSION=${{ github.ref_name }}
             sed -i "s/$PREV_VERSION/$VERSION/g" src/austin.h
-          run: |
-            apt-get update
-            apt-get -y install autoconf build-essential libunwind-dev binutils-dev libiberty-dev musl-tools zlib1g-dev
-
-            # Build austin
-            autoreconf --install
-            ./configure
-            make
-
-            export VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
-
-            pushd src
-            tar -Jcf austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austin
-            tar -Jcf austinp-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz austinp
-
-            musl-gcc -O3 -Os -s -Wall -pthread *.c -o austin -D__MUSL__
-            tar -Jcf austin-$VERSION-musl-linux-${{ matrix.arch }}.tar.xz austin
-
-            mv austin-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz /artifacts
-            mv austinp-$VERSION-gnu-linux-${{ matrix.arch }}.tar.xz /artifacts
-            mv austin-$VERSION-musl-linux-${{ matrix.arch }}.tar.xz /artifacts
-            popd
+          run: ARCH=${{ matrix.arch }} bash scripts/build_arch.sh
 
       - name: Show artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,20 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Setup libunwind
+        uses: ./.github/actions/setup-libunwind
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install binutils-dev libiberty-dev liblzma-dev musl-tools zlib1g-dev libzstd-dev
+
       - name: Generate artifacts
         run: |
           python3.10 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r scripts/requirements-bw.txt
-          
-          sudo apt-get update
-          sudo apt-get -y install autoconf build-essential libunwind-dev binutils-dev libiberty-dev musl-tools zlib1g-dev
 
           # Build austin
           autoreconf --install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup libunwind
+        uses: ./.github/actions/setup-libunwind
+
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install libunwind-dev binutils-dev libiberty-dev
+          sudo apt-get -y install binutils-dev libiberty-dev liblzma-dev zlib1g-dev libzstd-dev
 
       - name: Compile Austin
         run: |

--- a/scripts/build_arch.sh
+++ b/scripts/build_arch.sh
@@ -14,6 +14,7 @@ apt-get -y install \
     liblzma-dev \
     musl-tools \
     zlib1g-dev \
+    libzstd-dev \
     git
 
 # Compile and install libunwind from sources


### PR DESCRIPTION
Add a composite action `.github/actions/setup-libunwind` that builds libunwind from source (keyed by upstream commit SHA) and caches it via actions/cache. Update all workflow jobs that link against libunwind to use this action instead of installing the distro package, so that the build is done once per SHA and reused on subsequent runs.