### PR TITLE
ci: add base branch cache fallback for libunwind

### DIFF
--- a/.github/actions/setup-libunwind/action.yml
+++ b/.github/actions/setup-libunwind/action.yml
@@ -25,9 +25,10 @@ runs:
       with:
         path: /opt/libunwind
         key: libunwind-${{ runner.os }}-${{ steps.libunwind-sha.outputs.sha }}
+        restore-keys: libunwind-${{ runner.os }}-
 
     - name: Build and install libunwind
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-matched-key == ''
       shell: bash
       run: |
         git clone --depth=1 --branch ${{ inputs.version }} https://github.com/libunwind/libunwind.git /tmp/libunwind


### PR DESCRIPTION
We add a base branch cache fallback for the libunwind dependency to allow all branches to find the cached result of previous runs.