### PR TITLE
tests: handle new features in benchmarks and data validation

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -165,7 +165,9 @@ class Renderer(abc.ABC):
 
     @abc.abstractmethod
     def render_summary(
-        self, summary: t.List[t.Tuple[str, t.List[t.Tuple[str, bool, int]]]]
+        self,
+        summary: t.List[t.Tuple[str, t.List[t.Tuple[str, bool, int]]]],
+        skipped: t.List[str],
     ) -> None: ...
 
 
@@ -177,7 +179,7 @@ class TerminalRenderer(Renderer):
         self.render_table(table)
         print()
 
-    def render_summary(self, summary):
+    def render_summary(self, summary, skipped):
         self.render_header("Benchmark Summary", level=2)
         self.render_paragraph(
             f"Comparison of **{VERSIONS[-1]}** against **{VERSIONS[-2]}**."
@@ -187,25 +189,31 @@ class TerminalRenderer(Renderer):
             self.render_paragraph(
                 "No significant difference in performance between versions."
             )
-            return
+        else:
+            self.render_paragraph(
+                "The following scenarios show a statistically significant difference "
+                "in performance between the two versions."
+            )
 
-        self.render_paragraph(
-            "The following scenarios show a statistically significant difference "
-            "in performance between the two versions."
-        )
+            self.render_table(
+                [
+                    (
+                        title,
+                        {
+                            m: {1: self.BETTER, -1: self.WORSE}[s] if c else self.SAME
+                            for m, c, s in tests
+                        },
+                    )
+                    for title, tests in summary
+                ]
+            )
 
-        self.render_table(
-            [
-                (
-                    title,
-                    {
-                        m: {1: self.BETTER, -1: self.WORSE}[s] if c else self.SAME
-                        for m, c, s in tests
-                    },
-                )
-                for title, tests in summary
-            ]
-        )
+        if skipped:
+            self.render_paragraph(
+                "The following scenarios were skipped because the base version "
+                "produced no data (e.g. unsupported flag or new Python version):\n"
+                + "".join(f"\n- {t}" for t in skipped)
+            )
 
     def render_table(self, table: t.List[t.Tuple[str, t.List[Results]]]) -> None:
         _, row = table[0]
@@ -328,7 +336,7 @@ def results_from_json(raw: str) -> t.List[t.Tuple[str, t.List[Results]]]:
 
 
 def merge_results(
-    parts: t.List[t.List[t.Tuple[str, t.List[Results]]]]
+    parts: t.List[t.List[t.Tuple[str, t.List[Results]]]],
 ) -> t.List[t.Tuple[str, t.List[Results]]]:
     """Merge partial result lists into one, preserving the SCENARIOS order."""
     order = {s.title: i for i, s in enumerate(SCENARIOS)}
@@ -343,6 +351,7 @@ def benchmark(opts: ArgumentParser) -> None:
     Outcome.__critical_p__ = opts.pvalue
 
     results: t.List[t.Tuple[str, t.List[Results]]] = []
+    skipped: t.List[str] = []
 
     for scenario in SCENARIOS:
         if opts.k is not None and not opts.k.search(scenario.title):
@@ -389,17 +398,28 @@ def benchmark(opts: ArgumentParser) -> None:
                 )
             )
 
+        if len(table) < 2:
+            print(
+                f"WARNING: Skipping scenario {scenario.title!r} — "
+                "insufficient data (base may not support this scenario)",
+                file=sys.stderr,
+            )
+            skipped.append(scenario.title)
+            continue
+
         results.append((scenario.title, table))
 
     if opts.format == "json":
         print(results_to_json(results))
         return
 
-    render(results, opts)
+    render(results, skipped, opts)
 
 
 def render(
-    results: t.List[t.Tuple[str, t.List[Results]]], opts: ArgumentParser
+    results: t.List[t.Tuple[str, t.List[Results]]],
+    skipped: t.List[str],
+    opts: ArgumentParser,
 ) -> None:
     renderer = {"terminal": TerminalRenderer, "markdown": MarkdownRenderer}[
         opts.format
@@ -412,7 +432,7 @@ def render(
 
     summary = summarize(results)
 
-    renderer.render_summary(summary)
+    renderer.render_summary(summary, skipped)
 
     renderer.render_header("Benchmark Results", level=2)
     for title, table in results:
@@ -469,8 +489,7 @@ def main():
 
     if opts.list_groups:
         matrix = [
-            {"name": g.lower().replace(" ", "-"), "filter": g}
-            for g in SCENARIO_GROUPS
+            {"name": g.lower().replace(" ", "-"), "filter": g} for g in SCENARIO_GROUPS
         ]
         print(json.dumps({"include": matrix}))
         return
@@ -481,7 +500,7 @@ def main():
         if opts.format == "json":
             print(results_to_json(results))
         else:
-            render(results, opts)
+            render(results, [], opts)
         return
 
     benchmark(opts)

--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -32,22 +32,23 @@ class Scenario:
     def run(
         self, austin: common.VersionedVariant, n: int = 10
     ) -> t.List[AustinFlameGraph]:
-        try:
-            return [
-                AustinFlameGraph.from_mojo(
-                    tee(
-                        austin(
-                            *scenario.args,
-                            convert=False,
-                        ).stdout,
-                        f"{scenario.title}-{austin.version}-{i}",
+        results = []
+        for i in range(n):
+            try:
+                data = austin(*self.args, convert=False).stdout
+                if data:
+                    results.append(
+                        AustinFlameGraph.from_mojo(
+                            tee(data, f"{self.title}-{austin.version}-{i}")
+                        )
                     )
+            except Exception as e:
+                print(
+                    f"WARNING: run {i} of scenario {self.title!r} with {austin} "
+                    f"failed: {e}",
+                    file=sys.stderr,
                 )
-                for i in range(n)
-            ]
-        except Exception as e:
-            msg = f"Error running scenario {self.title} with {austin} and arguments {self.args}: {e}"
-            raise RuntimeError(msg) from e
+        return results
 
 
 if (PYTHON_VERSION := os.getenv("AUSTIN_TESTS_PYTHON_VERSIONS")) is None:
@@ -101,10 +102,19 @@ SCENARIOS = [
 ]
 
 
-def validate(scenario: Scenario, runs: int = 10) -> float:
+_NOT_APPLICABLE = object()
+
+
+def validate(scenario: Scenario, runs: int = 10) -> t.Union[float, object]:
+    base_results = scenario.run(common.get_base(variant_name=scenario.variant), runs)
+    if not base_results:
+        # We might be testing a new feature that is not available from the base
+        # version.
+        return _NOT_APPLICABLE
+
     return compare(
         # Base branch version
-        x=scenario.run(common.get_base(variant_name=scenario.variant), runs),
+        x=base_results,
         # Development version
         y=scenario.run(common.get_dev(variant_name=scenario.variant), runs),
         # Keep only the stacks that are present in all runs
@@ -113,7 +123,9 @@ def validate(scenario: Scenario, runs: int = 10) -> float:
 
 
 def generate_markdown_report(
-    failures: t.List[tuple[Scenario, float]], path: Path
+    failures: t.List[tuple[Scenario, float]],
+    skipped: t.List[Scenario],
+    path: Path,
 ) -> None:
     output = f"### Python {PYTHON_VERSION}\n\n"
 
@@ -125,6 +137,13 @@ def generate_markdown_report(
         output += "|----------|---------|\n"
         for scenario, p in failures:
             output += f"| {scenario.title} | {p:.2%} |\n"
+
+    if skipped:
+        output += (
+            "\n\n⚪ The following scenarios were skipped (base produced no data):\n\n"
+        )
+        for scenario in skipped:
+            output += f"- {scenario.title}\n"
 
     path.write_text(output)
 
@@ -175,21 +194,28 @@ if __name__ == "__main__":
     print("# Austin Data Validation\n")
 
     failures: t.List[tuple[Scenario, float]] = []
+    skipped: t.List[Scenario] = []
     for scenario in SCENARIOS:
         if opts.k is not None and not opts.k.search(scenario.title):
             continue
 
         print(f"Validating {scenario.title} ...", flush=True, file=sys.stderr, end=" ")
 
+        p = validate(scenario, runs=opts.n)
+        if p is _NOT_APPLICABLE:
+            skipped.append(scenario)
+            print("⚪ (not applicable — base produced no data)", file=sys.stderr)
+            continue
+
         result_icon = "✅"
-        if (p := validate(scenario, runs=opts.n)) < opts.p_value:
+        if p < opts.p_value:
             failures.append((scenario, p))
             result_icon = "❌"
 
         print(result_icon, file=sys.stderr)
 
     if opts.report:
-        generate_markdown_report(failures, opts.report)
+        generate_markdown_report(failures, skipped, opts.report)
 
     if failures:
         print("💥 The following scenarios failed to validate:\n")


### PR DESCRIPTION
We make the benchmark and data validation scripts handle the case when the base version does not support a new feature that is being introduced by the PR the checks run on. This way we get a more informative message instead of a failure.