### PR TITLE
ci: add crash report

### DIFF
--- a/.github/actions/collect-crashes/action.yml
+++ b/.github/actions/collect-crashes/action.yml
@@ -1,0 +1,64 @@
+name: 'Collect crash reports'
+description: >
+  Collect any Austin crash artefacts produced during a test run (core dumps on
+  Linux, diagnostic reports on macOS), generate a GDB/lldb backtrace where
+  possible, and upload everything as a workflow artefact.
+
+inputs:
+  austin-bin:
+    description: 'Path to the austin binary (used for GDB symbolisation on Linux)'
+    default: 'src/austin'
+  label:
+    description: 'Unique label suffix for the artefact name'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Collect core dumps (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        shopt -s nullglob
+        cores=(core.*)
+        if [ ${#cores[@]} -eq 0 ]; then
+          echo "No core dumps found."
+          exit 0
+        fi
+
+        mkdir -p crash-reports
+        for core in "${cores[@]}"; do
+          echo "=== Backtrace for $core ===" | tee crash-reports/$core.txt
+          gdb -batch \
+            -ex "set pagination off" \
+            -ex "thread apply all bt full" \
+            -ex "quit" \
+            "${{ inputs.austin-bin }}" "$core" 2>&1 | tee -a crash-reports/$core.txt || true
+          mv "$core" crash-reports/
+        done
+
+    - name: Collect diagnostic reports (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        shopt -s nullglob
+        reports=(~/Library/Logs/DiagnosticReports/austin*.ips \
+                 ~/Library/Logs/DiagnosticReports/austin*.crash)
+        if [ ${#reports[@]} -eq 0 ]; then
+          echo "No diagnostic reports found."
+          exit 0
+        fi
+
+        mkdir -p crash-reports
+        for report in "${reports[@]}"; do
+          cp "$report" crash-reports/
+        done
+
+    - name: Upload crash reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: crash-reports-${{ inputs.label }}
+        path: crash-reports/
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - .github/workflows/tests.yml
       - .github/actions/setup-libunwind/action.yml
+      - .github/actions/collect-crashes/action.yml
       - scripts/build-wheel.py
       - scripts/requirements-bw.txt
       - src/**
@@ -230,6 +231,12 @@ jobs:
           sudo -E env PATH="$PATH" .venv/bin/pytest -n 0 -sv test/support
         if: always()
 
+      - name: Collect crash reports
+        uses: ./.github/actions/collect-crashes
+        if: always()
+        with:
+          label: linux-${{ matrix.arch }}-py${{ matrix.python-version }}
+
   wheels-linux:
     strategy:
       fail-fast: false
@@ -400,6 +407,12 @@ jobs:
           pytest --pastebin=failed -svr a -k "_darwin" test/functional
         if: always()
 
+      - name: Collect crash reports
+        uses: ./.github/actions/collect-crashes
+        if: always()
+        with:
+          label: macos-py${{ matrix.python-version }}
+
   wheels-osx:
     runs-on: macos-latest
     if: needs.changes.outputs.src == 'true' || needs.changes.outputs.wheel-scripts == 'true' || needs.changes.result == 'skipped'
@@ -560,3 +573,69 @@ jobs:
             --version=$VERSION \
             --platform=win_amd64 \
             --files austin.exe:src/austin.exe
+
+  crash-report:
+    runs-on: ubuntu-24.04
+    needs: [tests-linux, tests-osx, tests-win]
+    if: always() && github.event_name == 'pull_request'
+    name: Crash report
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download crash reports
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: crash-reports-*
+          path: crash-reports/
+          merge-multiple: false
+
+      - name: Generate crash report
+        id: report
+        shell: bash
+        run: |
+          mkdir -p crash-reports
+          files=$(find crash-reports/ -type f | sort)
+          if [ -z "$files" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## :rotating_light: Austin crashed during CI"
+            echo ""
+            echo "Crash artefacts were collected in the following jobs:"
+            echo ""
+            for dir in crash-reports/*/; do
+              label="${dir#crash-reports/}"
+              label="${label%/}"
+              echo "### \`${label}\`"
+              echo ""
+              for f in "$dir"*; do
+                echo "<details><summary><code>$(basename $f)</code></summary>"
+                echo ""
+                echo '```'
+                cat "$f"
+                echo '```'
+                echo "</details>"
+                echo ""
+              done
+            done
+          } > crash-comment.md
+
+      - name: Post crash report on PR
+        if: steps.report.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: crash-report
+          path: crash-comment.md
+
+      - name: Clear stale crash comment
+        if: steps.report.outputs.found == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: crash-report
+          delete: true

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/validation.yml
       - .github/actions/setup-libunwind/action.yml
+      - .github/actions/collect-crashes/action.yml
       - scripts/requirements-val.txt
       - scripts/validation.py
       - src/**
@@ -95,6 +96,13 @@ jobs:
           cd -
           deactivate
 
+      - name: Collect crash reports
+        uses: ./austin/.github/actions/collect-crashes
+        if: always()
+        with:
+          austin-bin: austin/src/austin
+          label: validation-py${{ matrix.python-version }}
+
       - name: List collected samples
         run: ls austin/*.mojo
         if: always()
@@ -148,3 +156,58 @@ jobs:
         with:
           header: validation
           path: validation.txt
+
+      - name: Download crash reports
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: crash-reports-validation-*
+          path: crash-reports/
+          merge-multiple: false
+
+      - name: Generate crash report
+        id: crash
+        shell: bash
+        run: |
+          mkdir -p crash-reports
+          files=$(find crash-reports/ -type f | sort)
+          if [ -z "$files" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## :rotating_light: Austin crashed during data validation"
+            echo ""
+            for dir in crash-reports/*/; do
+              label="${dir#crash-reports/}"
+              label="${label%/}"
+              echo "### \`${label}\`"
+              echo ""
+              for f in "$dir"*; do
+                echo "<details><summary><code>$(basename $f)</code></summary>"
+                echo ""
+                echo '```'
+                cat "$f"
+                echo '```'
+                echo "</details>"
+                echo ""
+              done
+            done
+          } > crash-comment.md
+
+      - name: Post crash report on PR
+        if: steps.crash.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: validation-crash-report
+          path: crash-comment.md
+
+      - name: Clear stale crash comment
+        if: steps.crash.outputs.found == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: validation-crash-report
+          delete: true


### PR DESCRIPTION
We add an action to collect any crashes from CI jobs and report them on the PR as a comment to immediately highlight their occurrence for further investigation.