### PR TITLE
ci: no full crash report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -607,22 +607,12 @@ jobs:
           {
             echo "## :rotating_light: Austin crashed during CI"
             echo ""
-            echo "Crash artefacts were collected in the following jobs:"
+            echo "Crash artefacts were collected in the following jobs (see the workflow run artifacts for full backtraces):"
             echo ""
             for dir in crash-reports/*/; do
               label="${dir#crash-reports/}"
               label="${label%/}"
-              echo "### \`${label}\`"
-              echo ""
-              for f in "$dir"*; do
-                echo "<details><summary><code>$(basename $f)</code></summary>"
-                echo ""
-                echo '```'
-                cat "$f"
-                echo '```'
-                echo "</details>"
-                echo ""
-              done
+              echo "- \`${label}\`: $(ls "$dir" | tr '\n' ' ')"
             done
           } > crash-comment.md
 


### PR DESCRIPTION
We prevent giving a full crash report on a PR because it might be too long to be handled.