### PR TITLE
tests: lower data validation p-value threshold

### DIFF
--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
         "-p",
         "--p-value",
         type=float,
-        default=0.01,
+        default=0.001,
         help="p-value threshold",
     )
 


### PR DESCRIPTION
Based on the analysis of past data validation test runs we have concluded that a lower threshold of the order of 0.1% can reduce the rate of false positive while still allowing us to detect any regressions in the correctness in the data produced by changes.