### PR TITLE
tests: native validation sampling

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -128,6 +128,18 @@ def compare(
             c.update(_.supp())
         domain = sorted([k for k, v in c.items() if v >= threshold])
 
+    # The Hotelling T² test requires nx + ny - p - 1 > 0, i.e. the number
+    # of dimensions (unique stacks) must be less than nx + ny - 1.  When
+    # native frames are included the stack diversity can exceed this limit.
+    # Cap the domain to the most common stacks to keep the test valid.
+    max_p = len(x) + len(y) - 2
+    if len(domain) > max_p:
+        c = c if threshold is not None else Counter()
+        if not c:
+            for _ in chain(x, y):
+                c.update(_.supp())
+        domain = [k for k, _ in c.most_common(max_p)]
+
     X = np.array([f.to_list(domain) for f in x], dtype=np.int32)
     Y = np.array([f.to_list(domain) for f in y], dtype=np.int32)
 

--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -104,7 +104,7 @@ SCENARIOS = [
         "austin",
         (
             "-ni",
-            "500",
+            "1ms",
             *PYTHON,
             target("target34.py"),
         ),
@@ -114,7 +114,7 @@ SCENARIOS = [
         "austin",
         (
             "-nci",
-            "500",
+            "1ms",
             *PYTHON,
             target("target34.py"),
         ),
@@ -127,19 +127,16 @@ _NOT_APPLICABLE = object()
 
 def validate(scenario: Scenario, runs: int = 10) -> t.Union[float, object]:
     base_results = scenario.run(common.get_base(variant_name=scenario.variant), runs)
+    dev_results = scenario.run(common.get_dev(variant_name=scenario.variant), runs)
+
     if not base_results:
         # We might be testing a new feature that is not available from the base
-        # version.
+        # version. We still collect dev data above so that the .mojo profiles
+        # are available as artifacts for manual validation.
         return _NOT_APPLICABLE
 
-    return compare(
-        # Base branch version
-        x=base_results,
-        # Development version
-        y=scenario.run(common.get_dev(variant_name=scenario.variant), runs),
-        # Keep only the stacks that are present in all runs
-        threshold=runs,
-    )
+    # threshold=runs keeps only the stacks that are present in all runs
+    return compare(x=base_results, y=dev_results, threshold=runs)
 
 
 def generate_markdown_report(
@@ -160,7 +157,8 @@ def generate_markdown_report(
 
     if skipped:
         output += (
-            "\n\n⚪ The following scenarios were skipped (base produced no data):\n\n"
+            "\n\n⚪ The following scenarios were skipped"
+            " (base produced no data; PR profiles collected for manual validation):\n\n"
         )
         for scenario in skipped:
             output += f"- {scenario.title}\n"
@@ -224,7 +222,10 @@ if __name__ == "__main__":
         p = validate(scenario, runs=opts.n)
         if p is _NOT_APPLICABLE:
             skipped.append(scenario)
-            print("⚪ (not applicable — base produced no data)", file=sys.stderr)
+            print(
+                "⚪ (not applicable — base produced no data; PR profiles collected)",
+                file=sys.stderr,
+            )
             continue
 
         result_icon = "✅"

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -47,6 +47,9 @@ def save_mojo(request):
     yield _save
 
     # Clean up on pass; keep on failure so CI can upload the files.
+    # In CI (GITHUB_ACTIONS), always keep profiles for artifact collection.
+    if os.environ.get("CI"):
+        return
     failed = getattr(getattr(request.node, "rep_call", None), "failed", True)
     if not failed:
         for p in saved_paths:


### PR DESCRIPTION
Native stacks can exhibit a larger variety of call stacks which would require us to collect many more samples during data validation. To avoud conflating the run time of these checks we compromise by selecting the most common stacks up to the number that allows us to perform a Hotelling test.