### PR TITLE
refactor: decouple sampling rate from metrics

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -98,12 +98,9 @@ METRICS = [
 
 def get_stats(meta: dict[str, str]) -> t.Optional[dict]:
     try:
-        raw_saturation = meta["saturation"]
-        _, _, raw_samples = raw_saturation.partition("/")
-
         duration = float(meta["duration"]) / 1e6
-        samples = int(raw_samples)
-        saturation = eval(raw_saturation)
+        samples = int(meta["count"])
+        saturation = eval(meta["saturation"])
         error_rate = eval(meta["errors"])
         sampling = int(meta["sampling"].split(",")[1])
 

--- a/src/austin.c
+++ b/src/austin.c
@@ -96,9 +96,12 @@ do_single_process(py_proc_t* py_proc) {
 
     py_proc__log_version(py_proc, /*is_parent*/ true);
 
+    pacer_t pacer;
+    pacer_init(&pacer);
+
     if (pargs.exposure == 0) {
         while (interrupt_signal == 0) {
-            stopwatch_start();
+            sample_timer_start();
 
             if (fail(result = py_proc__sample(py_proc))) {
                 // Try to re-initialise
@@ -106,7 +109,8 @@ do_single_process(py_proc_t* py_proc) {
                     FAIL_BREAK;
             }
 
-            stopwatch_pause(pargs_native ? 0 : stopwatch_duration());
+            stats_check_duration(sample_timer_elapsed());
+            pacer_next(&pacer);
         }
     } else {
         if (!pargs.where) {
@@ -115,7 +119,7 @@ do_single_process(py_proc_t* py_proc) {
         }
         microseconds_t end_time = gettime() + pargs.exposure * 1000000;
         while (interrupt_signal == 0) {
-            stopwatch_start();
+            sample_timer_start();
 
             if (fail(result = py_proc__sample(py_proc))) {
                 // Try to re-initialise
@@ -123,7 +127,8 @@ do_single_process(py_proc_t* py_proc) {
                     FAIL_BREAK;
             }
 
-            stopwatch_pause(pargs_native ? 0 : stopwatch_duration());
+            stats_check_duration(sample_timer_elapsed());
+            pacer_next(&pacer);
             if (pargs.where)
                 break;
 
@@ -192,12 +197,16 @@ do_child_processes(py_proc_t* py_proc) {
 
     log_meta_header();
 
+    pacer_t pacer;
+    pacer_init(&pacer);
+
     if (pargs.exposure == 0) {
         while (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
-            microseconds_t start_time = pargs_native ? 0 : gettime();
+            sample_timer_start();
             py_proc_list__update(list);
             py_proc_list__sample(list);
-            stopwatch_pause(pargs_native ? 0 : gettime() - start_time);
+            stats_check_duration(sample_timer_elapsed());
+            pacer_next(&pacer);
         }
     } else {
         if (!pargs.pipe && !pargs.where) {
@@ -206,10 +215,11 @@ do_child_processes(py_proc_t* py_proc) {
         }
         microseconds_t end_time = gettime() + pargs.exposure * 1000000;
         while (!py_proc_list__is_empty(list) && interrupt_signal == 0) {
-            microseconds_t start_time = pargs_native ? 0 : gettime();
+            sample_timer_start();
             py_proc_list__update(list);
             py_proc_list__sample(list);
-            stopwatch_pause(pargs_native ? 0 : gettime() - start_time);
+            stats_check_duration(sample_timer_elapsed());
+            pacer_next(&pacer);
 
             if (pargs.where)
                 break;

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1337,15 +1337,8 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
 // Orchestrate a single interpreter sample: read the thread state head,
 // interrupt all threads (native mode), sample, then resume.
 //
-// time_delta semantics:
-//   non-native — gettime() - self->timestamp, measured before any work
-//   native     — gettime() - self->timestamp, measured AFTER the interrupt
-//                so that suspension overhead is excluded from the sample
-//
-// The computed time_delta is written back through *time_delta_out so that
-// the caller can update self->timestamp consistently.
 static inline int
-_py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t* time_delta_out) {
+_py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t time_delta) {
     V_DESC(self->py_v);
 
     raddr_t tstate_head = NULL;
@@ -1366,11 +1359,6 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t* ti
         }
     }
 
-    // Compute the time delta AFTER the interrupt so that the suspension
-    // overhead is not attributed to the profiled code.
-    microseconds_t time_delta = gettime() - self->timestamp;
-    *time_delta_out           = time_delta;
-
     int result = _py_proc__sample_threads(self, interp, tstate_head, time_delta);
 
     if (pargs_native)
@@ -1382,16 +1370,25 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t* ti
 // ----------------------------------------------------------------------------
 int
 py_proc__sample(py_proc_t* self) {
-    microseconds_t time_delta     = 0;
-    raddr_t        current_interp = self->istate_raddr;
+    raddr_t current_interp = self->istate_raddr;
 
     V_DESC(self->py_v);
+
+    // Compute the time delta once for all interpreters. In native mode this is
+    // done BEFORE the interrupt so we capture the wall time the threads were
+    // actually running (the suspension time will be excluded via the timestamp
+    // update after resume below).
+    // In non-native mode threads are still running while they are being
+    // sampled, so this is computing the difference between now and the
+    // beginning of the last sample. So the time delta includes both the
+    // sampling time and the eventual sleep time from the pacer.
+    microseconds_t time_delta = gettime() - self->timestamp;
 
     do {
         if (fail(_py_proc__prefetch_interpreter_state(self, current_interp))) // GCOV_EXCL_LINE
             FAIL;                                                             // GCOV_EXCL_LINE
 
-        int result = _py_proc__sample_interpreter(self, current_interp, &time_delta);
+        int result = _py_proc__sample_interpreter(self, current_interp, time_delta);
 
         if (fail(result))
             continue;
@@ -1400,10 +1397,14 @@ py_proc__sample(py_proc_t* self) {
             FAIL;                                                                                    // GCOV_EXCL_LINE
     } while (isvalid(current_interp));
 
+    // In non-native mode, advance the timestamp by the measured delta so that
+    // the next time_delta captures the full interval (sample work + sleep).
+    // In native mode, reset to now (after resume) so that suspension time is
+    // excluded from the next delta.
     if (pargs_native)
         self->timestamp = gettime();
     else
-        self->timestamp += time_delta;
+        self->timestamp += time_delta; // This is now the timestamp at the start of this sample
 
     SUCCESS;
 } /* py_proc__sample */

--- a/src/py_proc_list.c
+++ b/src/py_proc_list.c
@@ -41,7 +41,6 @@
 #include "hints.h"
 #include "logging.h"
 #include "resources.h"
-#include "timing.h"
 
 #include "py_proc_list.h"
 
@@ -175,7 +174,6 @@ py_proc_list__sample(py_proc_list_t* self) {
     py_proc_item_t* next = item->next;
     for (; isvalid(item); item = next, next = isvalid(item) ? item->next : NULL) {
         log_t("Sampling process with PID %d", item->py_proc->pid);
-        stopwatch_start();
         if (!py_proc__is_python(item->py_proc))
             // Not a Python process that we can sample, but we need to keep it
             // to continue traversing the process tree.
@@ -190,7 +188,6 @@ py_proc_list__sample(py_proc_list_t* self) {
                 _py_proc_list__remove(self, item);
             }
         }
-        stopwatch_duration();
     }
 } /* py_proc_list__sample */
 

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -38,7 +38,6 @@
 #include "mem.h"
 #include "platform.h"
 #include "stack.h"
-#include "timing.h"
 #include "version.h"
 
 #include "py_thread.h"
@@ -447,7 +446,6 @@ py_thread__unwind(py_thread_t* self) {
     stats_count_sample();
     if (error)
         stats_count_error();
-    stats_check_duration(stopwatch_duration());
 }
 
 // ----------------------------------------------------------------------------

--- a/src/stats.c
+++ b/src/stats.c
@@ -58,6 +58,7 @@ microseconds_t _avg_sampling_time;
 microseconds_t _start_time;
 
 ustat_t _sample_cnt;
+ustat_t _tick_cnt;
 ustat_t _error_cnt;
 ustat_t _long_cnt;
 
@@ -94,6 +95,7 @@ gettime() {
 void
 stats_reset() {
     _sample_cnt = 0;
+    _tick_cnt   = 0;
     _error_cnt  = 0;
 
     _min_sampling_time = MICROSECONDS_MAX;
@@ -123,7 +125,7 @@ stats_get_min_sampling_time() {
 
 microseconds_t
 stats_get_avg_sampling_time() {
-    return _avg_sampling_time / _sample_cnt;
+    return _avg_sampling_time / _tick_cnt;
 }
 
 void
@@ -150,7 +152,7 @@ stats_log_metrics() {
             "sampling", MICROSECONDS_FMT "," MICROSECONDS_FMT "," MICROSECONDS_FMT, stats_get_min_sampling_time(),
             stats_get_avg_sampling_time(), stats_get_max_sampling_time()
         );
-        event_handler__emit_metadata("saturation", "%ld/%ld", _long_cnt, _sample_cnt);
+        event_handler__emit_metadata("saturation", "%ld/%ld", _long_cnt, _tick_cnt);
         event_handler__emit_metadata("errors", "%ld/%ld", _error_cnt, _sample_cnt);
         if (pargs.gc)
             event_handler__emit_metadata("gc", MICROSECONDS_FMT, _gc_time);

--- a/src/stats.h
+++ b/src/stats.h
@@ -30,6 +30,7 @@ typedef unsigned long ustat_t; /* non-negative statistics metric */
 
 #ifndef STATS_C
 extern unsigned long _sample_cnt;
+extern unsigned long _tick_cnt;
 
 extern microseconds_t _min_sampling_time;
 extern microseconds_t _max_sampling_time;
@@ -99,6 +100,7 @@ stats_get_avg_sampling_time();
  */
 #define stats_check_duration(delta)            \
     {                                          \
+        _tick_cnt++;                           \
         if (delta > pargs.t_sampling_interval) \
             _long_cnt++;                       \
         if (_min_sampling_time > delta)        \

--- a/src/timing.h
+++ b/src/timing.h
@@ -31,21 +31,58 @@
 #ifndef AUSTIN_C
 extern
 #endif
-    microseconds_t _sample_timestamp;
+    microseconds_t _sample_timer_start;
 
 static inline void
-stopwatch_start(void) {
-    _sample_timestamp = gettime();
-} /* timer_start */
+sample_timer_start(void) {
+    _sample_timer_start = gettime();
+}
 
 static inline microseconds_t
-stopwatch_duration(void) {
-    return gettime() - _sample_timestamp;
-} /* timer_stop */
+sample_timer_elapsed(void) {
+    return gettime() - _sample_timer_start;
+}
+
+// ----------------------------------------------------------------------------
+// Pacer — controls the sleep between sampling ticks.
+//
+// Non-native mode (deadline-based): threads run during sampling, so the
+// sampling work counts towards the interval. A deadline is advanced by the
+// interval each tick; we sleep only the remaining time. This is
+// self-correcting: if one tick overruns, subsequent sleeps shorten to
+// compensate.
+//
+// Native mode (fixed-sleep): threads are suspended during sampling, so the
+// sampling duration is dead time for the target. After resuming we sleep
+// the full interval to give threads the requested running time.
+
+typedef struct {
+    microseconds_t deadline;
+} pacer_t;
 
 static inline void
-stopwatch_pause(microseconds_t delta) {
-    // Pause if sampling took less than the sampling interval.
-    if (delta < pargs.t_sampling_interval)
-        usleep(pargs.t_sampling_interval - delta);
+pacer_init(pacer_t* p) {
+    p->deadline = gettime() + pargs.t_sampling_interval;
+}
+
+// Sleep until the next sample is due.  Returns the actual sleep duration in
+// microseconds, or 0 when the sampler is saturated (behind schedule).
+static inline microseconds_t
+pacer_next(pacer_t* p) {
+    if (pargs_native) {
+        // Sleep the full interval — sampling time was dead time for the target.
+        usleep((useconds_t)pargs.t_sampling_interval);
+        return pargs.t_sampling_interval;
+    }
+
+    microseconds_t now = gettime();
+
+    if (p->deadline > now) {
+        microseconds_t delay = p->deadline - now;
+        usleep((useconds_t)delay);
+        p->deadline += pargs.t_sampling_interval;
+        return delay;
+    }
+    p->deadline += pargs.t_sampling_interval;
+    return 0;
 }


### PR DESCRIPTION
We refactor the timing logic to decouple the sampling rate pacing from the time metric evaluation. As a result, some sampling stats have changed their meaning. In particular, the sampling speed now accounts the whole sampling operation, which in general spans across multiple processes, and their interpreters and threads therein.

We expect this change to have an impact on how the sampling speed is computed. Value should now be higher because they account for the whole sampling operation of all the interpreters within a process. We also expect larger variations in multiprocessing profiles because we also affect how metrics are computed in this case.