### PR TITLE
chore(win): remove ARM64 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -471,17 +471,9 @@ jobs:
           deactivate
 
   build-win:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x64
-            runs-on: windows-latest
-          - arch: arm64
-            runs-on: windows-11-arm
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: windows-latest
 
-    name: Build Austin on Windows (${{ matrix.arch }})
+    name: Build Austin on Windows
     steps:
       - uses: actions/checkout@v3
 
@@ -493,46 +485,32 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: austin-binary-${{ runner.os }}-${{ matrix.arch }}
+          name: austin-binary-${{ runner.os }}
           overwrite: true
           path: |
             src/austin.exe
 
   tests-win:
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x64, arm64]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          # Pre-3.12 Python lacks native Windows ARM64 builds in the
-          # setup-python manifest.
-          - arch: arm64
-            python-version: "3.9"
-          - arch: arm64
-            python-version: "3.10"
-          - arch: arm64
-            python-version: "3.11"
-        include:
-          - arch: x64
-            runs-on: windows-latest
-          - arch: arm64
-            runs-on: windows-11-arm
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: windows-latest
     if: needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.result == 'skipped'
 
     needs: [changes, build-win]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
 
-    name: Tests on Windows (${{ matrix.arch }}) with Python ${{ matrix.python-version }}
+    name: Tests on Windows with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binary-${{ runner.os }}-${{ matrix.arch }}
+          name: austin-binary-${{ runner.os }}
           path: src
 
       - name: Install Python
@@ -573,7 +551,7 @@ jobs:
       - name: Collect native profiles
         uses: actions/upload-artifact@v4
         with:
-          name: native-profiles-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.python-version }}
+          name: native-profiles-${{ runner.os }}-${{ matrix.python-version }}
           path: test-profiles\
         if: always()
 
@@ -585,7 +563,7 @@ jobs:
       - name: Store dumps
         uses: actions/upload-artifact@v4
         with:
-          name: dumps-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.python-version }}
+          name: dumps-${{ runner.os }}-${{ matrix.python-version }}
           path: ${{ github.workspace }}\dumps
         if: failure()
 
@@ -601,7 +579,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: austin-binary-${{ runner.os }}-x64
+          name: austin-binary-${{ runner.os }}
           path: src
 
       - uses: actions/setup-python@v4

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -655,7 +655,7 @@ cb(const int opt, const char* arg, const int index, char** argv) {
             stderr, PROGRAM_NAME ": warning: native mode is not supported on this architecture "
                                  "and will be ignored (consider using austinp instead)\n"
         );
-#elif defined(PL_WIN) && !defined(_M_X64) && !defined(_M_ARM64)
+#elif defined(PL_WIN) && !defined(_M_X64)
         fprintf(
             stderr, PROGRAM_NAME ": warning: native mode is not supported on this architecture "
                                  "and will be ignored\n"

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -190,17 +190,6 @@ _py_thread__suspend(py_thread_t* self) {
     regs->pc = (uintptr_t)ctx.Rip;
     regs->fp = (uintptr_t)ctx.Rbp;
     regs->sp = (uintptr_t)ctx.Rsp;
-#elif defined(_M_ARM64)
-    ctx.ContextFlags = CONTEXT_CONTROL;
-    if (!GetThreadContext(h, &ctx)) {
-        free(regs);
-        ResumeThread(h);
-        set_error(OS, "GetThreadContext failed during suspend");
-        FAIL;
-    }
-    regs->pc = (uintptr_t)ctx.Pc;
-    regs->fp = (uintptr_t)ctx.Fp;
-    regs->sp = (uintptr_t)ctx.Sp;
 #else
 #error "Unsupported architecture for native mode on Windows"
 #endif
@@ -366,19 +355,11 @@ _unwind_stackwalk64(py_thread_t* self) {
 
     CONTEXT ctx;
     memset(&ctx, 0, sizeof(ctx));
-#if defined(_M_X64)
     DWORD machine    = IMAGE_FILE_MACHINE_AMD64;
     ctx.ContextFlags = CONTEXT_FULL;
     ctx.Rip          = (DWORD64)regs->pc;
     ctx.Rbp          = (DWORD64)regs->fp;
     ctx.Rsp          = (DWORD64)regs->sp;
-#elif defined(_M_ARM64)
-    DWORD machine    = IMAGE_FILE_MACHINE_ARM64;
-    ctx.ContextFlags = CONTEXT_FULL;
-    ctx.Pc           = (DWORD64)regs->pc;
-    ctx.Fp           = (DWORD64)regs->fp;
-    ctx.Sp           = (DWORD64)regs->sp;
-#endif
 
     STACKFRAME64 sf;
     memset(&sf, 0, sizeof(sf));


### PR DESCRIPTION
We remove the experimental ARM64 support for Windows for now until we can put in place more through testing.