### PR TITLE
refactor: process running check

### DIFF
--- a/src/linux/common.h
+++ b/src/linux/common.h
@@ -30,16 +30,22 @@
 
 #include "../error.h"
 #include "../hints.h"
+#include "../resources.h"
 #include "../stats.h"
 
 #define PTHREAD_BUFFER_ITEMS 200
 
 struct _proc_extra_info {
-    unsigned int page_size;
-    char         statm_file[24];
-    pthread_t    wait_thread_id;
-    unsigned int pthread_tid_offset;
-    uintptr_t    _pthread_buffer[PTHREAD_BUFFER_ITEMS];
+    unsigned int       page_size;
+    char               statm_file[24];
+    pthread_t          wait_thread_id;
+    unsigned int       pthread_tid_offset;
+    // Process creation time in clock ticks since boot (field 22 of
+    // /proc/<pid>/stat).  Captured on the first liveness check and
+    // compared on subsequent ones to detect PID reuse; a different value
+    // means a new process now owns the PID and our target is gone.
+    unsigned long long starttime;
+    uintptr_t          _pthread_buffer[PTHREAD_BUFFER_ITEMS];
 };
 
 #define read_pthread_t(py_proc, addr)                                                                           \
@@ -111,6 +117,56 @@ wait_thread_stop(pid_t tid) {
         if (gettime() >= end)
             return -1;
     }
+}
+
+// ----------------------------------------------------------------------------
+// Side-effect-free /proc/<pid>/stat reader.  Returns false if the file cannot
+// be opened (process gone) or the content is malformed.  On success, fills any
+// non-NULL out parameter.  Callers care about two fields: the state code (for
+// zombie/dead detection) and the starttime (a lifetime-unique value used to
+// detect PID reuse).
+//
+// /proc/<pid>/stat format: "PID (comm) state ppid ..." with starttime at
+// field 22 (1-indexed).  comm (field 2) may contain spaces and parens, so we
+// scan to the last ')' to reliably locate the state field.
+static inline bool
+proc_stat_read(pid_t pid, char* state_out, unsigned long long* starttime_out) {
+    char buffer[32];
+    sprintf(buffer, "/proc/%d/stat", pid);
+
+    cu_FILE* fp = fopen(buffer, "rb");
+    if (!isvalid(fp))
+        return false;
+
+    char   line[512];
+    size_t n = fread(line, 1, sizeof(line) - 1, fp);
+    if (n == 0)
+        return false; // cppcheck-suppress [resourceLeak]
+    line[n] = '\0';
+
+    char* p = strrchr(line, ')');
+    if (!isvalid(p) || p[1] != ' ')
+        return false; // cppcheck-suppress [resourceLeak]
+    p += 2;           // state char
+
+    if (state_out)
+        *state_out = *p;
+
+    if (starttime_out) {
+        // p is at the state char (field 3); starttime is field 22.  Advance
+        // across 18 inter-field spaces so that p + 1 lands at field 22.
+        if (p[1] != ' ')
+            return false; // cppcheck-suppress [resourceLeak]
+        p++;              // space between field 3 and field 4
+        for (int i = 0; i < 18; i++) {
+            p = strchr(p + 1, ' ');
+            if (!isvalid(p))
+                return false; // cppcheck-suppress [resourceLeak]
+        }
+        *starttime_out = strtoull(p + 1, NULL, 10);
+    }
+
+    return true; // cppcheck-suppress [resourceLeak]
 }
 
 // ----------------------------------------------------------------------------

--- a/src/linux/py_proc.h
+++ b/src/linux/py_proc.h
@@ -617,6 +617,32 @@ _py_proc__init(py_proc_t* self) {
 } /* _py_proc__init */
 
 // ----------------------------------------------------------------------------
+// Liveness check with zombie and PID-reuse detection.  kill(pid, 0) alone
+// returns success for zombies and for any process that happens to reuse the
+// PID after the target has been reaped; both cases would keep the py_proc__init
+// retry loop spinning for its full timeout on target exit.  /proc/<pid>/stat
+// yields both the state code (to reject Zombie/Dead) and starttime (to detect
+// PID reuse across reaping).  starttime is captured on the first successful
+// call and compared on subsequent ones.
+static inline bool
+_py_proc__is_running(py_proc_t* self) {
+    char               state;
+    unsigned long long starttime;
+    if (!proc_stat_read(self->pid, &state, &starttime))
+        return false;
+
+    if (state == 'Z' || state == 'X')
+        return false;
+
+    if (self->extra->starttime == 0)
+        self->extra->starttime = starttime;
+    else if (self->extra->starttime != starttime)
+        return false; // PID has been reused by a different process
+
+    return true;
+}
+
+// ----------------------------------------------------------------------------
 pid_t
 _get_nspid(pid_t pid) {
     cu_char* line  = NULL;

--- a/src/mac/py_proc.h
+++ b/src/mac/py_proc.h
@@ -57,7 +57,11 @@
 #define sw32(f, v) (f ? bswap_32(v) : v)
 
 struct _proc_extra_info {
-    // void
+    // Process start time, derived from pbi_start_tvsec/pbi_start_tvusec in
+    // proc_bsdinfo.  Captured on the first liveness check and compared on
+    // subsequent ones to detect PID reuse; a different value means a new
+    // process now owns the PID and our target is gone.
+    uint64_t starttime;
 };
 
 // ----------------------------------------------------------------------------
@@ -368,6 +372,32 @@ check_pid(pid_t pid) {
     }
 
     SUCCESS;
+}
+
+// ----------------------------------------------------------------------------
+// Liveness check with zombie and PID-reuse detection.  check_pid() accepts
+// SZOMB (zombie) as alive, which would otherwise keep the py_proc__init retry
+// loop spinning for its full timeout after the target exits.  proc_pidinfo
+// also gives us pbi_start_tvsec/pbi_start_tvusec, which uniquely identify the
+// process across its lifetime; capturing and comparing these detects the case
+// where the original target was reaped and a new process reused the PID.
+static inline bool
+_py_proc__is_running(py_proc_t* self) {
+    struct proc_bsdinfo info;
+    if (proc_pidinfo(self->pid, PROC_PIDTBSDINFO, 0, &info, PROC_PIDTBSDINFO_SIZE) != PROC_PIDTBSDINFO_SIZE)
+        return false;
+
+    // SIDL: process is being created; SZOMB: exited, awaiting reap.
+    if (info.pbi_status == SIDL || info.pbi_status == SZOMB || info.pbi_status == 32767)
+        return false;
+
+    uint64_t start = ((uint64_t)info.pbi_start_tvsec * 1000000ull) + info.pbi_start_tvusec;
+    if (self->extra->starttime == 0)
+        self->extra->starttime = start;
+    else if (self->extra->starttime != start)
+        return false; // PID has been reused by a different process
+
+    return true;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1120,16 +1120,7 @@ _py_proc__find_current_thread_offset(py_proc_t* self, raddr_t thread_raddr) {
 // ----------------------------------------------------------------------------
 bool
 py_proc__is_running(py_proc_t* self) {
-#if defined PL_WIN /* WIN */
-    DWORD ec = 0;
-    return GetExitCodeProcess(self->ref, &ec) ? ec == STILL_ACTIVE : 0;
-
-#elif defined PL_MACOS /* MACOS */
-    return success(check_pid(self->pid));
-
-#else /* LINUX */
-    return !(kill(self->pid, 0) == -1 && errno == ESRCH);
-#endif
+    return _py_proc__is_running(self);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/win/py_proc.h
+++ b/src/win/py_proc.h
@@ -346,6 +346,13 @@ _py_proc__get_resident_memory(py_proc_t* self) {
 }
 
 // ----------------------------------------------------------------------------
+static inline bool
+_py_proc__is_running(py_proc_t* self) {
+    DWORD ec = 0;
+    return GetExitCodeProcess(self->ref, &ec) ? ec == STILL_ACTIVE : false;
+}
+
+// ----------------------------------------------------------------------------
 static int
 _py_proc__init(py_proc_t* self) {
     if (!isvalid(self)) {


### PR DESCRIPTION
We improve the process running state check on Linux and MacOS. This allows us to perform more efficient checks when the process Austin started or attached to terminates, skipping a recovery loop when clearly impossible to recover from.