### PR TITLE
chore: improve duration metric computation

### DIFF
--- a/src/austin.c
+++ b/src/austin.c
@@ -137,6 +137,11 @@ do_single_process(py_proc_t* py_proc) {
         }
     }
 
+    // Freeze the duration clock at the end of the sampling loop so that the
+    // signal/terminate/wait/destroy sequence below is not counted against the
+    // reported sampling duration.
+    stats_end();
+
     if (pargs.attach_pid == 0) {
         if (interrupt_signal) {
             // Propagate the signal to the parent if we spawned it.
@@ -228,6 +233,11 @@ do_child_processes(py_proc_t* py_proc) {
                 interrupt_signal = SIGINT; // Emulate Ctrl-C
         }
     }
+
+    // Freeze the duration clock at the end of the sampling loop so that the
+    // signal/terminate/wait sequence below is not counted against the
+    // reported sampling duration.
+    stats_end();
 
     if (pargs.attach_pid == 0) {
         if (interrupt_signal) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -56,6 +56,7 @@ microseconds_t _max_sampling_time;
 microseconds_t _avg_sampling_time;
 
 microseconds_t _start_time;
+microseconds_t _end_time;
 
 ustat_t _sample_cnt;
 ustat_t _tick_cnt;
@@ -131,11 +132,17 @@ stats_get_avg_sampling_time() {
 void
 stats_start() {
     _start_time = gettime();
+    _end_time   = 0;
+}
+
+void
+stats_end() {
+    _end_time = gettime();
 }
 
 microseconds_t
 stats_duration() {
-    return gettime() - _start_time;
+    return (_end_time ? _end_time : gettime()) - _start_time;
 }
 
 #define STAT_INDENT "      "

--- a/src/stats.h
+++ b/src/stats.h
@@ -123,7 +123,16 @@ void
 stats_start();
 
 /**
- * Return the current sampling duration.
+ * Freeze the duration clock at the current time.  Call when the sampling loop
+ * exits, so that subsequent teardown work (signalling / reaping / cleanup) is
+ * not counted against the reported duration.
+ */
+void
+stats_end();
+
+/**
+ * Return the current sampling duration.  If stats_end() has been called, the
+ * duration is frozen at that point; otherwise it is gettime() - start.
  */
 microseconds_t
 stats_duration();


### PR DESCRIPTION
We improve the computation of the duration metric by excluding any potential time spent tearing down Austin and only account for the pure sampling duration time.