### PR TITLE
perf: detect repeated stacks 

### DIFF
--- a/scripts/requirements-bm.txt
+++ b/scripts/requirements-bm.txt
@@ -1,2 +1,2 @@
-austin-python~=2.1
+austin-python~=2.2
 scipy~=1.10

--- a/scripts/requirements-val.txt
+++ b/scripts/requirements-val.txt
@@ -1,3 +1,3 @@
-austin-python~=2.1
+austin-python~=2.2
 numpy~=2.4
 scipy~=1.17

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,7 +61,8 @@ austin_SOURCES = \
   platform.c     \
   py_proc_list.c \
   py_proc.c      \
-  py_thread.c
+  py_thread.c    \
+  thread_tracker.c
 
 
 # ---- Austin P ----

--- a/src/events.c
+++ b/src/events.c
@@ -107,9 +107,10 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
         bool             is_frame_eval
             = (scope == UNKNOWN_SCOPE) ? false : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
         if (!stack_is_empty() && is_frame_eval) {
-            // TODO: if the py stack is empty we have a mismatch.
             frame_t* frame = stack_pop();
-            if (has_cframes) {
+            if (frame == PYSTACK_REPEAT_MAGIC) {
+                mojo_stack_repeat();
+            } else if (has_cframes) {
                 while (frame != CFRAME_MAGIC) {
                     mojo_frame_ref(frame);
 
@@ -133,6 +134,10 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
     if (!pargs_native) {
         while (!stack_is_empty()) {
             frame_t* frame = stack_pop();
+            if (frame == PYSTACK_REPEAT_MAGIC) {
+                mojo_stack_repeat();
+                break;
+            }
             if (frame != CFRAME_MAGIC) {
                 mojo_frame_ref(frame);
             }
@@ -149,25 +154,8 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
         free(scope);
     }
 
-    if (self->sample_data.gc_state == GC_STATE_COLLECTING) {
-        mojo_event(MOJO_GC);
-    }
-
     // Finish off sample with the metric(s)
-    sample_t* sample = &self->sample_data;
-    if (pargs.full) {
-        mojo_metric_time(sample->time);
-        if (sample->is_idle) {
-            mojo_event(MOJO_IDLE);
-        }
-        mojo_metric_memory(sample->memory);
-    } else {
-        if (pargs.memory) {
-            mojo_metric_memory(sample->memory);
-        } else {
-            mojo_metric_time(sample->time);
-        }
-    }
+    mojo_emit_metrics(&self->sample_data);
 
     _mojo_flush();
 

--- a/src/events.c
+++ b/src/events.c
@@ -92,8 +92,10 @@ mojo_event_handler__handle_new_frame(base_event_handler_t* self, frame_t* frame)
 static inline void
 mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
     bool py_repeat = stack_top() == PYSTACK_REPEAT_MAGIC;
-    if (py_repeat)
+    if (py_repeat) {
         (void)stack_pop();
+        mojo_stack_repeat();
+    }
 
     bool has_cframes = false;
     if (stack_top() == CFRAME_MAGIC) {
@@ -102,10 +104,6 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
     }
 
     if (pargs_native) {
-        bool native_repeat = py_repeat && stack_native_top() == EVAL_FRAME_MAGIC;
-        if (native_repeat)
-            (void)stack_native_pop();
-
         while (!stack_native_is_empty()) {
             frame_t* native_frame = stack_native_pop();
             if (!isvalid(native_frame)) {
@@ -113,10 +111,9 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
                 break;                         // GCOV_EXCL_STOP
             }
 
-            if (native_repeat) {
-                // If the Python stack is repeated, we have unwound the native stack
-                // up to PyEval_EvalFrameDefault, so we can emit these frames
-                // unconditionally.
+            if (py_repeat) {
+                // Python stack is repeated; native frames above the eval boundary
+                // are always emitted unconditionally.
                 mojo_frame_ref(native_frame);
                 continue;
             }
@@ -154,10 +151,6 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
             mojo_frame_kernel(scope);
             free(scope);
         }
-
-        if (native_repeat) {
-            mojo_stack_repeat();
-        }
     }
 
     // In non-native mode the native stack is always empty so the interleaving
@@ -168,9 +161,6 @@ mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
             if (frame != CFRAME_MAGIC) {
                 mojo_frame_ref(frame);
             }
-        }
-        if (py_repeat) {
-            mojo_stack_repeat();
         }
     }
 

--- a/src/events.c
+++ b/src/events.c
@@ -91,67 +91,87 @@ mojo_event_handler__handle_new_frame(base_event_handler_t* self, frame_t* frame)
 
 static inline void
 mojo_event_handler__handle_stack_end(base_event_handler_t* self) {
+    bool py_repeat = stack_top() == PYSTACK_REPEAT_MAGIC;
+    if (py_repeat)
+        (void)stack_pop();
+
     bool has_cframes = false;
     if (stack_top() == CFRAME_MAGIC) {
         has_cframes = true;
         (void)stack_pop();
     }
 
-    while (!stack_native_is_empty()) {
-        frame_t* native_frame = stack_native_pop();
-        if (!isvalid(native_frame)) {
-            log_e("Invalid native frame"); // GCOV_EXCL_START
-            break;                         // GCOV_EXCL_STOP
-        }
-        cached_string_t* scope = native_frame->scope;
-        bool             is_frame_eval
-            = (scope == UNKNOWN_SCOPE) ? false : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
-        if (!stack_is_empty() && is_frame_eval) {
-            frame_t* frame = stack_pop();
-            if (frame == PYSTACK_REPEAT_MAGIC) {
-                mojo_stack_repeat();
-            } else if (has_cframes) {
-                while (frame != CFRAME_MAGIC) {
-                    mojo_frame_ref(frame);
+    if (pargs_native) {
+        bool native_repeat = py_repeat && stack_native_top() == EVAL_FRAME_MAGIC;
+        if (native_repeat)
+            (void)stack_native_pop();
 
-                    if (stack_is_empty())
-                        break;
+        while (!stack_native_is_empty()) {
+            frame_t* native_frame = stack_native_pop();
+            if (!isvalid(native_frame)) {
+                log_e("Invalid native frame"); // GCOV_EXCL_START
+                break;                         // GCOV_EXCL_STOP
+            }
 
-                    frame = stack_pop();
+            if (native_repeat) {
+                // If the Python stack is repeated, we have unwound the native stack
+                // up to PyEval_EvalFrameDefault, so we can emit these frames
+                // unconditionally.
+                mojo_frame_ref(native_frame);
+                continue;
+            }
+
+            if (native_frame == (frame_t*)EVAL_FRAME_MAGIC) {
+                if (!stack_is_empty()) {
+                    frame_t* frame = stack_pop();
+                    if (has_cframes) {
+                        while (frame != CFRAME_MAGIC) {
+                            mojo_frame_ref(frame);
+
+                            if (stack_is_empty())
+                                break;
+
+                            frame = stack_pop();
+                        }
+                    } else {
+                        if (frame != CFRAME_MAGIC) {
+                            mojo_frame_ref(frame);
+                        }
+                    }
                 }
             } else {
-                if (frame != CFRAME_MAGIC) {
-                    mojo_frame_ref(frame);
-                }
+                mojo_frame_ref(native_frame);
             }
-        } else {
-            mojo_frame_ref(native_frame);
+        }
+
+#ifdef DEBUG
+        if (!stack_is_empty()) {
+            log_d("Stack mismatch: left with %d Python frames after interleaving", stack_pointer());
+        }
+#endif
+        while (!stack_kernel_is_empty()) {
+            char* scope = stack_kernel_pop();
+            mojo_frame_kernel(scope);
+            free(scope);
+        }
+
+        if (native_repeat) {
+            mojo_stack_repeat();
         }
     }
 
     // In non-native mode the native stack is always empty so the interleaving
     // loop above never runs.  Drain Python frames directly in that case.
-    if (!pargs_native) {
+    else {
         while (!stack_is_empty()) {
             frame_t* frame = stack_pop();
-            if (frame == PYSTACK_REPEAT_MAGIC) {
-                mojo_stack_repeat();
-                break;
-            }
             if (frame != CFRAME_MAGIC) {
                 mojo_frame_ref(frame);
             }
         }
-    }
-#ifdef DEBUG
-    if (!stack_is_empty()) {
-        log_d("Stack mismatch: left with %d Python frames after interleaving", stack_pointer());
-    }
-#endif
-    while (!stack_kernel_is_empty()) {
-        char* scope = stack_kernel_pop();
-        mojo_frame_kernel(scope);
-        free(scope);
+        if (py_repeat) {
+            mojo_stack_repeat();
+        }
     }
 
     // Finish off sample with the metric(s)
@@ -231,28 +251,23 @@ where_event_handler__handle_stack_end(base_event_handler_t* self) {
             log_e("Invalid native frame"); // GCOV_EXCL_START
             break;                         // GCOV_EXCL_STOP
         }
-        cached_string_t* scope = native_frame->scope;
-        if (!isvalid(scope)) {
-            scope = UNKNOWN_SCOPE; // GCOV_EXCL_LINE
-        }
-
-        bool is_frame_eval
-            = (scope == UNKNOWN_SCOPE) ? false : isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
-        if (!stack_is_empty() && is_frame_eval) {
+        if (native_frame == (frame_t*)EVAL_FRAME_MAGIC) {
             // TODO: if the py stack is empty we have a mismatch.
-            frame_t* frame = stack_pop();
-            if (has_cframes) {
-                while (frame != CFRAME_MAGIC) {
-                    format_frame_ref(WHERE_SAMPLE_FORMAT, frame);
+            if (!stack_is_empty()) {
+                frame_t* frame = stack_pop();
+                if (has_cframes) {
+                    while (frame != CFRAME_MAGIC) {
+                        format_frame_ref(WHERE_SAMPLE_FORMAT, frame);
 
-                    if (stack_is_empty())
-                        break;
+                        if (stack_is_empty())
+                            break;
 
-                    frame = stack_pop();
-                }
-            } else {
-                if (frame != CFRAME_MAGIC) {
-                    format_frame_ref(WHERE_SAMPLE_FORMAT, frame);
+                        frame = stack_pop();
+                    }
+                } else {
+                    if (frame != CFRAME_MAGIC) {
+                        format_frame_ref(WHERE_SAMPLE_FORMAT, frame);
+                    }
                 }
             }
         } else {

--- a/src/frame.h
+++ b/src/frame.h
@@ -79,7 +79,8 @@ frame__destroy(frame_t* self) {
     sfree(self);
 }
 
-#define CFRAME_MAGIC ((void*)0xCF)
+#define CFRAME_MAGIC         ((void*)0xCF)
+#define PYSTACK_REPEAT_MAGIC ((void*)0xB4)
 
 #include "code.h"
 #include "mojo.h"

--- a/src/frame.h
+++ b/src/frame.h
@@ -81,6 +81,7 @@ frame__destroy(frame_t* self) {
 
 #define CFRAME_MAGIC         ((void*)0xCF)
 #define PYSTACK_REPEAT_MAGIC ((void*)0xB4)
+#define EVAL_FRAME_MAGIC     ((void*)0xEF)
 
 #include "code.h"
 #include "mojo.h"

--- a/src/linux/py_thread.h
+++ b/src/linux/py_thread.h
@@ -411,6 +411,9 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
         }
 
         stack_native_push(frame);
+
+        if (self->is_repeat && _py_thread__is_pyeval_frame(self, frame->scope))
+            break;
     } while (!stack_native_full() && unw_step(&cursor) > 0);
 
     SUCCESS;
@@ -610,6 +613,9 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
         }
 
         stack_native_push(frame);
+
+        if (self->is_repeat && _py_thread__is_pyeval_frame(self, frame->scope))
+            break;
 
         if (use_cfi) {
             // CFI mode: use .eh_frame unwinding.  fp still holds the current

--- a/src/linux/py_thread.h
+++ b/src/linux/py_thread.h
@@ -410,10 +410,12 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
             event_handler__emit_new_frame(frame);
         }
 
-        stack_native_push(frame);
-
-        if (self->is_repeat && _py_thread__is_pyeval_frame(self, frame->scope))
-            break;
+        if (unlikely(is_pyeval_frame(frame->scope))) {
+            stack_native_push((frame_t*)EVAL_FRAME_MAGIC);
+            if (self->is_repeat)
+                break;
+        } else
+            stack_native_push(frame);
     } while (!stack_native_full() && unw_step(&cursor) > 0);
 
     SUCCESS;
@@ -612,10 +614,12 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
             event_handler__emit_new_frame(frame);
         }
 
-        stack_native_push(frame);
-
-        if (self->is_repeat && _py_thread__is_pyeval_frame(self, frame->scope))
-            break;
+        if (unlikely(is_pyeval_frame(frame->scope))) {
+            stack_native_push((frame_t*)EVAL_FRAME_MAGIC);
+            if (self->is_repeat)
+                break;
+        } else
+            stack_native_push(frame);
 
         if (use_cfi) {
             // CFI mode: use .eh_frame unwinding.  fp still holds the current
@@ -783,7 +787,7 @@ _py_thread__unwind_native(py_thread_t* self, bool* error) {
     }
 #elif defined(__x86_64__) || defined(__aarch64__)
     // fp-walk: only unwind when native mode is explicitly enabled.
-    if (pargs_native && fail(_py_thread__unwind_native_frame_stack(self))) {
+    if (fail(_py_thread__unwind_native_frame_stack(self))) {
         *error = true;
     }
 #endif

--- a/src/mac/py_thread.h
+++ b/src/mac/py_thread.h
@@ -460,6 +460,9 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
 
         stack_native_push(frame);
 
+        if (self->is_repeat && _py_thread__is_pyeval_frame(self, frame->scope))
+            break;
+
         if (fp == 0)
             break;
 

--- a/src/mac/py_thread.h
+++ b/src/mac/py_thread.h
@@ -458,10 +458,12 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
             event_handler__emit_new_frame(frame);
         }
 
-        stack_native_push(frame);
-
-        if (self->is_repeat && _py_thread__is_pyeval_frame(self, frame->scope))
-            break;
+        if (unlikely(is_pyeval_frame(frame->scope))) {
+            stack_native_push((frame_t*)EVAL_FRAME_MAGIC);
+            if (self->is_repeat)
+                break;
+        } else
+            stack_native_push(frame);
 
         if (fp == 0)
             break;
@@ -509,7 +511,7 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
 
 static inline void
 _py_thread__unwind_native(py_thread_t* self, bool* error) {
-    if (pargs_native && fail(_py_thread__unwind_native_frame_stack(self))) {
+    if (fail(_py_thread__unwind_native_frame_stack(self))) {
         *error = true;
     }
     // No re-read here: the thread is suspended (thread_suspend) so its

--- a/src/mojo.h
+++ b/src/mojo.h
@@ -29,7 +29,7 @@
 #include "cache.h"
 #include "platform.h"
 
-#define MOJO_VERSION 3
+#define MOJO_VERSION 4
 
 enum {
     MOJO_RESERVED,
@@ -45,6 +45,7 @@ enum {
     MOJO_METRIC_MEMORY,
     MOJO_STRING,
     MOJO_STRING_REF,
+    MOJO_STACK_REPEAT,
     MOJO_MAX,
 };
 
@@ -151,6 +152,8 @@ mojo_integer(mojo_int_t integer, int sign) {
     mojo_event(MOJO_FRAME_REF);  \
     mojo_integer(frame->key, 0);
 
+#define mojo_stack_repeat() mojo_event(MOJO_STACK_REPEAT);
+
 #define mojo_frame_kernel(scope)   \
     mojo_event(MOJO_FRAME_KERNEL); \
     mojo_string(scope);
@@ -171,3 +174,25 @@ mojo_integer(mojo_int_t integer, int sign) {
 #define mojo_string_ref(key)     \
     mojo_event(MOJO_STRING_REF); \
     mojo_ref(key);
+
+// Emit the metric tail shared by MOJO_STACK and MOJO_STACK_REPEAT.
+// Assumes pargs is in scope (always true inside the sampler/event handlers).
+#define mojo_emit_metrics(sample)                        \
+    {                                                    \
+        if ((sample)->gc_state == GC_STATE_COLLECTING) { \
+            mojo_event(MOJO_GC);                         \
+        }                                                \
+        if (pargs.full) {                                \
+            mojo_metric_time((sample)->time);            \
+            if ((sample)->is_idle) {                     \
+                mojo_event(MOJO_IDLE);                   \
+            }                                            \
+            mojo_metric_memory((sample)->memory);        \
+        } else {                                         \
+            if (pargs.memory) {                          \
+                mojo_metric_memory((sample)->memory);    \
+            } else {                                     \
+                mojo_metric_time((sample)->time);        \
+            }                                            \
+        }                                                \
+    }

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1316,6 +1316,7 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
 
         py_thread__unwind(&py_thread);
 
+        // TODO: Now the stack repeat frame might be at the top!
         if (pargs_native && V_MIN(3, 11) && V_MAX(3, 12)) {
             // We expect a CFrame to sit at the top of the stack
             if (!stack_is_empty() && stack_top() != CFRAME_MAGIC) { // GCOV_EXCL_START

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -429,7 +429,7 @@ _py_proc__check_interp_state(py_proc_t* self, raddr_t interp) {
         if (!error_is(OS)) // GCOV_EXCL_START
             FAIL;
 
-        if (fail(py_thread__next(&thread))) {
+        if (fail(py_thread__next(&thread, NULL))) {
             log_d("Failed to get next thread while inferring TID field offset");
             FAIL;
         }
@@ -784,6 +784,13 @@ py_proc_new(bool child) {
     py_proc->py_v           = NULL;
 
     _prehash_symbols();
+
+    // Tracking information about seen threads. Threads that have disappeared
+    // are evicted on a generation basis.
+    py_proc->thread_tracker = thread_tracker_new();
+    if (!isvalid(py_proc->thread_tracker)) { // GCOV_EXCL_START
+        FAIL_GOTO(error);
+    } // GCOV_EXCL_STOP
 
     py_proc->frame_cache = lru_cache_new(MAX_FRAME_CACHE_SIZE, (void (*)(value_t))frame__destroy);
     if (!isvalid(py_proc->frame_cache)) { // GCOV_EXCL_START
@@ -1167,7 +1174,7 @@ _py_proc__interrupt_threads(py_proc_t* self, raddr_t tstate_head) {
     do {
         if (fail(py_thread__interrupt(&py_thread)))
             FAIL;
-    } while (success(py_thread__next(&py_thread)));
+    } while (success(py_thread__next(&py_thread, NULL)));
 
     if (!error_is(ITEREND))
         FAIL;
@@ -1183,11 +1190,13 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
     ssize_t mem_delta      = 0;
     raddr_t current_thread = NULL;
 
+    self->thread_tracker->sample_gen++;
+
     V_DESC(self->py_v);
 
     py_thread_t py_thread = py_thread__init(self);
 
-    if (fail(py_thread__read_with_stack_remote(&py_thread, tstate_head))) {
+    if (fail(py_thread__read_with_stack_remote(&py_thread, tstate_head, self->thread_tracker))) {
         if (is_fatal(austin_errno)) {
             FAIL;
         }
@@ -1315,7 +1324,12 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
         }
 
         event_handler__emit_stack_end();
-    } while (success(py_thread__next(&py_thread)));
+
+        stats_count_sample();
+    } while (success(py_thread__next(&py_thread, self->thread_tracker)));
+
+    // Evict cache entries for threads that disappeared this sweep.
+    thread_tracker__evict_stale(self->thread_tracker);
 
     if (!error_is(ITEREND)) { // GCOV_EXCL_START
         FAIL;
@@ -1502,6 +1516,8 @@ py_proc__destroy(py_proc_t* self) {
     sfree(self->lib_path);
     sfree(self->interpreter_state_com.data);
     sfree(self->extra);
+
+    thread_tracker__destroy(self->thread_tracker);
 
     lru_cache__destroy(self->string_cache);
     lru_cache__destroy(self->frame_cache);

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 
 #include "cache.h"
+#include "thread_tracker.h"
 #ifdef PL_LINUX
 #include "linux/vm-range-tree.h"
 #ifdef AUSTINP
@@ -77,10 +78,12 @@ typedef struct {
 
     raddr_t istate_raddr;
 
-    lru_cache_t* frame_cache;
-    lru_cache_t* string_cache;
-    lru_cache_t* code_cache;
-    lru_cache_t* interpreter_state_cache;
+    lru_cache_t*      frame_cache;
+    lru_cache_t*      string_cache;
+    lru_cache_t*      code_cache;
+    lru_cache_t*      interpreter_state_cache;
+    thread_tracker_t* thread_tracker;
+    cached_string_t*  pyeval_scope;
 
     // Temporal profiling support
     microseconds_t timestamp;

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -83,10 +83,8 @@ typedef struct {
     lru_cache_t*      code_cache;
     lru_cache_t*      interpreter_state_cache;
     thread_tracker_t* thread_tracker;
-    cached_string_t*  pyeval_scope;
-
     // Temporal profiling support
-    microseconds_t timestamp;
+    microseconds_t    timestamp;
 
     // Memory profiling support
     ssize_t last_resident_memory;

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -47,6 +47,11 @@ typedef struct _string {
 static cached_string_t _unknown_scope __attribute__((unused)) = {.key = 1, .value = "<unknown>"};
 #define UNKNOWN_SCOPE (&_unknown_scope)
 
+static inline bool
+is_pyeval_frame(cached_string_t* scope) {
+    return scope != UNKNOWN_SCOPE && isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"));
+}
+
 static inline cached_string_t*
 cached_string_new(key_dt key, char* value) {
     cached_string_t* cached_string = (cached_string_t*)malloc(sizeof(cached_string_t));

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -362,8 +362,19 @@ py_thread__read_remote(py_thread_t* self, raddr_t addr) {
 }
 
 // ----------------------------------------------------------------------------
+static inline void
+_py_thread__load_stack(py_thread_t* self) {
+    if (!isvalid(self->stack) && isvalid(self->stack_raddr)) {
+        self->stack = stack_chunk_new(self->proc->ref, self->stack_raddr);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Read the thread state and immediately perform the top-frame cache check.
+// Sets self->is_repeat; if not a repeat, loads the stack chunk right away to
+// minimise the window between the thread-state read and the frame data read.
 int
-py_thread__read_with_stack_remote(py_thread_t* self, raddr_t addr) {
+py_thread__read_with_stack_remote(py_thread_t* self, raddr_t addr, thread_tracker_t* tracker) {
     if (!isvalid(self)) { // GCOV_EXCL_START
         set_error(NULL, "Invalid thread pointer");
         FAIL;
@@ -372,20 +383,32 @@ py_thread__read_with_stack_remote(py_thread_t* self, raddr_t addr) {
     if (fail(_py_thread__read_remote(self, addr)))
         FAIL;
 
-    if (isvalid(self->stack_raddr)) {
-        self->stack = stack_chunk_new(self->proc->ref, self->stack_raddr);
+    self->is_repeat = false;
+
+    if (!isvalid(tracker))
+        SUCCESS;
+
+    thread_tracker_entry_t* entry = thread_tracker__get_or_create(tracker, self->tid);
+    if (!isvalid(entry))
+        SUCCESS;
+
+    entry->last_gen = tracker->sample_gen;
+
+    if (!pargs_native && isvalid(self->top_frame) && entry->top_frame == self->top_frame) {
+        self->is_repeat = true;
+        SUCCESS;
     }
+
+    _py_thread__load_stack(self);
+    entry->top_frame = self->top_frame;
 
     SUCCESS;
 }
 
 // ----------------------------------------------------------------------------
 int
-py_thread__next(py_thread_t* self) {
+py_thread__next(py_thread_t* self, thread_tracker_t* tracker) {
     V_DESC(self->proc->py_v);
-
-    // Determine if we want to read the stack chunk as well.
-    bool has_stack = isvalid(self->stack);
 
     if (V_MIN(3, 11)) {
         stack_chunk__destroy(self->stack);
@@ -397,7 +420,8 @@ py_thread__next(py_thread_t* self) {
 
     log_t("Found next thread");
 
-    return has_stack ? py_thread__read_with_stack_remote(self, self->next) : py_thread__read_remote(self, self->next);
+    return isvalid(tracker) ? py_thread__read_with_stack_remote(self, self->next, tracker)
+                            : py_thread__read_remote(self, self->next);
 }
 
 // ----------------------------------------------------------------------------
@@ -412,18 +436,15 @@ py_thread__unwind(py_thread_t* self) {
 
     V_DESC(self->proc->py_v);
 
-    // Fetch the datastack chunk if it wasn't read upfront (e.g. thread was
-    // read with py_thread__read_remote during the interrupt loop).
-    // However, in this case it might be better to re-read the whole thread
-    // state.
-    if (!isvalid(self->stack) && isvalid(self->stack_raddr)) {
-        self->stack = stack_chunk_new(self->proc->ref, self->stack_raddr);
-    }
-
     // Clear the Python stack state before any Python stack unwinding.
     stack_reset();
 
-    if (isvalid(self->top_frame)) {
+    if (self->is_repeat) {
+        stack_push_py_repeat();
+    } else if (isvalid(self->top_frame)) {
+        // Ensure the stack chunk is loaded before unwinding
+        _py_thread__load_stack(self);
+
         if (V_MIN(3, 13)) {
             if (fail(_py_thread__unwind_iframe_stack(self, self->top_frame))) {
                 error = true;
@@ -443,8 +464,6 @@ py_thread__unwind(py_thread_t* self) {
         }
     }
 
-    // Update sampling stats
-    stats_count_sample();
     if (error)
         stats_count_error();
 }

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -278,6 +278,27 @@ _py_thread__unwind_cframe_stack(py_thread_t* self) {
 // ---- PUBLIC ----------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
+// Read the code object pointer from the top frame without copying the full
+// frame struct. For < 3.11 reads PyFrameObject.f_code; for >= 3.11 reads
+// _PyInterpreterFrame.f_code. Returns NULL on failure (treated as unknown).
+static inline void*
+_py_thread__read_top_code(py_thread_t* self) {
+    V_DESC(self->proc->py_v);
+
+    raddr_t code = NULL;
+    int     offset;
+
+    if (V_MIN(3, 11)) {
+        offset = py_v->py_iframe.o_code;
+    } else {
+        offset = py_v->py_frame.o_code;
+    }
+
+    copy_memory(self->proc->ref, (char*)self->top_frame + offset, sizeof(raddr_t), &code);
+    return code;
+}
+
+// ----------------------------------------------------------------------------
 // Core thread-state read: copies the remote thread state and extracts all
 // fields except the datastack chunk.  Declared static inline so that both
 // py_thread__read_remote and py_thread__read_with_stack_remote can call it
@@ -394,13 +415,25 @@ py_thread__read_with_stack_remote(py_thread_t* self, raddr_t addr, thread_tracke
 
     entry->last_gen = tracker->sample_gen;
 
-    if (!pargs_native && isvalid(self->top_frame) && entry->top_frame == self->top_frame) {
-        self->is_repeat = true;
-        SUCCESS;
+    V_DESC(self->proc->py_v);
+    // For Python < 3.11 heap-allocated frame objects can be freed and
+    // reallocated at the same address; verify the code object too.
+    // For >= 3.11 frames live in a stack chunk with variable sizing, so
+    // address collisions are rare enough that the frame check alone suffices.
+    void* top_code = (isvalid(self->top_frame) && V_MAX(3, 10)) ? _py_thread__read_top_code(self) : NULL;
+
+    if (entry->top_frame == self->top_frame) {
+        if (V_MIN(3, 11) || top_code == entry->top_code) {
+            self->is_repeat = true;
+            SUCCESS;
+        }
     }
 
     _py_thread__load_stack(self);
+
+    // Track the last seen top frame information.
     entry->top_frame = self->top_frame;
+    entry->top_code  = top_code;
 
     SUCCESS;
 }

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -128,6 +128,9 @@ _py_thread__resolve_py_stack(py_thread_t* self) {
 static inline bool
 _py_thread__read_top_frame_identity(py_thread_t* self, uintptr_t* out_lasti, void** out_code) {
     V_DESC(self->proc->py_v);
+
+    V_ALLOCA(iframe, fi);
+
     py_proc_t* proc = self->proc;
 
     *out_lasti = LASTI_UNSET;
@@ -149,7 +152,6 @@ _py_thread__read_top_frame_identity(py_thread_t* self, uintptr_t* out_lasti, voi
                 return false;
         }
 
-        PyInterpreterFrame fi;
         if (fail(copy_py(proc->ref, iframe_addr, py_iframe, fi)))
             return false;
 
@@ -311,6 +313,8 @@ static inline int
 _py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
     V_DESC(self->proc->py_v);
 
+    V_ALLOCA(iframe, fi);
+
     raddr_t curr = iframe_raddr;
 
     while (isvalid(curr)) {
@@ -336,10 +340,8 @@ _py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
             void*     local = stack_chunk__resolve(self->stack, curr);
             if (isvalid(local)) {
                 lasti = *(uintptr_t*)((char*)local + py_v->py_iframe.o_prev_instr);
-            } else {
-                PyInterpreterFrame fi;
-                if (success(copy_py(self->proc->ref, curr, py_iframe, fi)))
-                    lasti = V_FIELD(uintptr_t, fi, py_iframe, o_prev_instr);
+            } else if (success(copy_py(self->proc->ref, curr, py_iframe, fi))) {
+                lasti = V_FIELD(uintptr_t, fi, py_iframe, o_prev_instr);
             }
             if (lasti == self->prev_top.lasti) {
                 stack_py_push_repeat();

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -493,14 +493,16 @@ py_thread__unwind(py_thread_t* self) {
     if (pargs_native) {
         _py_thread__unwind_native(self, &error);
 
-        // If the Python stack was marked as a repeat but
-        // _PyEval_EvalFrameDefault was not found on the native stack, the
-        // thread is momentarily outside the eval loop (GIL handoff, C-extension
-        // call chain that doesn't pass through the eval frame at this instant).
-        // Treat this as a non-repeat: emit the collected native frames only,
-        // and force a full Python unwind next time so we don't emit cascading
-        // empty stacks via MOJO_STACK_REPEAT.
-        if (self->is_repeat && stack_native_top() != (frame_t*)EVAL_FRAME_MAGIC) {
+        if (stack_native_top() == (frame_t*)EVAL_FRAME_MAGIC) {
+            // Sentinel present: consume it so the emit loop only sees real frames.
+            (void)stack_native_pop();
+        } else if (self->is_repeat) {
+            // Python stack marked as repeat but _PyEval_EvalFrameDefault was not
+            // found on the native stack.  The thread is momentarily outside the
+            // eval loop (GIL handoff, C-extension call chain that doesn't pass
+            // through the eval frame at this instant).  Emit collected native
+            // frames only, and force a full Python unwind next sample to avoid
+            // cascading empty stacks via MOJO_STACK_REPEAT.
             self->is_repeat               = false;
             thread_tracker_entry_t* entry = thread_tracker__get_or_create(self->proc->thread_tracker, self->tid);
             if (isvalid(entry))

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -85,10 +85,18 @@ _py_thread__resolve_py_stack(py_thread_t* self) {
     for (int i = 0; i < stack_pointer(); i++) {
         py_frame_t py_frame = stack_py_get(i);
 
+        // TODO: we can avoid this branching by checking the top of the stack
+        // beforehand.
+        if (py_frame.origin == PYSTACK_REPEAT_MAGIC) {
+            stack_set(i, PYSTACK_REPEAT_MAGIC);
+            break;
+        }
+
         if (py_frame.origin == CFRAME_MAGIC) {
             stack_set(i, CFRAME_MAGIC);
             continue;
         }
+
         int      lasti     = py_frame.lasti;
         key_dt   frame_key = py_frame_key(py_frame.code, lasti);
         frame_t* frame     = lru_cache__maybe_hit(cache, frame_key);
@@ -232,6 +240,13 @@ _py_thread__unwind_frame_stack(py_thread_t* self) {
             log_d("Circular frame reference detected");
             FAIL;
         }
+
+        // Up-stack optimisation: repeat the previous stack if a frame matches
+        // the previous sample's top frame. Only for non-native samples.
+        if (!pargs_native && isvalid(prev) && prev == self->prev_top_frame) {
+            stack_py_push_repeat();
+            SUCCESS;
+        }
     }
 
     SUCCESS;
@@ -257,6 +272,13 @@ _py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
             log_d("Circular frame reference detected");
             FAIL;
         }
+
+        // Up-stack optimisation: repeat the previous stack if a frame matches
+        // the previous sample's top frame. Only for non-native samples.
+        if (!pargs_native && isvalid(curr) && curr == self->prev_top_frame) {
+            stack_py_push_repeat();
+            SUCCESS;
+        }
     }
 
     SUCCESS;
@@ -278,24 +300,23 @@ _py_thread__unwind_cframe_stack(py_thread_t* self) {
 // ---- PUBLIC ----------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
-// Read the code object pointer from the top frame without copying the full
-// frame struct. For < 3.11 reads PyFrameObject.f_code; for >= 3.11 reads
+// Read the code object pointer from a frame without copying the full struct.
+// For < 3.11 reads PyFrameObject.f_code; for >= 3.11 reads
 // _PyInterpreterFrame.f_code. Returns NULL on failure (treated as unknown).
 static inline void*
-_py_thread__read_top_code(py_thread_t* self) {
+_py_thread__read_frame_code(py_thread_t* self, raddr_t frame) {
     V_DESC(self->proc->py_v);
 
-    raddr_t code = NULL;
-    int     offset;
+    raddr_t code   = NULL;
+    int     offset = V_MIN(3, 11) ? py_v->py_iframe.o_code : py_v->py_frame.o_code;
 
-    if (V_MIN(3, 11)) {
-        offset = py_v->py_iframe.o_code;
-    } else {
-        offset = py_v->py_frame.o_code;
-    }
-
-    copy_memory(self->proc->ref, (char*)self->top_frame + offset, sizeof(raddr_t), &code);
+    copy_memory(self->proc->ref, (char*)frame + offset, sizeof(raddr_t), &code);
     return code;
+}
+
+static inline void*
+_py_thread__read_top_code(py_thread_t* self) {
+    return _py_thread__read_frame_code(self, self->top_frame);
 }
 
 // ----------------------------------------------------------------------------
@@ -416,22 +437,26 @@ py_thread__read_with_stack_remote(py_thread_t* self, raddr_t addr, thread_tracke
     entry->last_gen = tracker->sample_gen;
 
     V_DESC(self->proc->py_v);
+
     // For Python < 3.11 heap-allocated frame objects can be freed and
     // reallocated at the same address; verify the code object too.
     // For >= 3.11 frames live in a stack chunk with variable sizing, so
     // address collisions are rare enough that the frame check alone suffices.
     void* top_code = (isvalid(self->top_frame) && V_MAX(3, 10)) ? _py_thread__read_top_code(self) : NULL;
 
-    if (entry->top_frame == self->top_frame) {
+    if (isvalid(self->top_frame) && entry->top_frame == self->top_frame) {
         if (V_MIN(3, 11) || top_code == entry->top_code) {
             self->is_repeat = true;
             SUCCESS;
         }
     }
 
+    // Expose the previous top for partial-repeat detection during unwinding.
+    self->prev_top_frame = entry->top_frame;
+    self->prev_top_code  = entry->top_code;
+
     _py_thread__load_stack(self);
 
-    // Track the last seen top frame information.
     entry->top_frame = self->top_frame;
     entry->top_code  = top_code;
 
@@ -465,7 +490,23 @@ py_thread__unwind(py_thread_t* self) {
     // Platform-specific native stack unwinding dispatch.
     // Each platform header defines _py_thread__unwind_native which handles
     // the is_interrupted check, kernel stack, and native frame unwinding.
-    _py_thread__unwind_native(self, &error);
+    if (pargs_native) {
+        _py_thread__unwind_native(self, &error);
+
+        // If the Python stack was marked as a repeat but
+        // _PyEval_EvalFrameDefault was not found on the native stack, the
+        // thread is momentarily outside the eval loop (GIL handoff, C-extension
+        // call chain that doesn't pass through the eval frame at this instant).
+        // Treat this as a non-repeat: emit the collected native frames only,
+        // and force a full Python unwind next time so we don't emit cascading
+        // empty stacks via MOJO_STACK_REPEAT.
+        if (self->is_repeat && stack_native_top() != (frame_t*)EVAL_FRAME_MAGIC) {
+            self->is_repeat               = false;
+            thread_tracker_entry_t* entry = thread_tracker__get_or_create(self->proc->thread_tracker, self->tid);
+            if (isvalid(entry))
+                entry->top_frame = NULL;
+        }
+    }
 
     V_DESC(self->proc->py_v);
 
@@ -473,7 +514,9 @@ py_thread__unwind(py_thread_t* self) {
     stack_reset();
 
     if (self->is_repeat) {
-        stack_push_py_repeat();
+        // The top frame is the same as the previous sample, so we can skip
+        // unwinding and just push a repeat marker.
+        stack_py_push_repeat();
     } else if (isvalid(self->top_frame)) {
         // Ensure the stack chunk is loaded before unwinding
         _py_thread__load_stack(self);
@@ -491,10 +534,10 @@ py_thread__unwind(py_thread_t* self) {
                 error = true;
             }
         }
+    }
 
-        if (fail(_py_thread__resolve_py_stack(self))) {
-            error = true;
-        }
+    if (fail(_py_thread__resolve_py_stack(self))) {
+        error = true;
     }
 
     if (error)

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -120,6 +120,54 @@ _py_thread__resolve_py_stack(py_thread_t* self) {
 }
 
 // ----------------------------------------------------------------------------
+// Read the top frame into a local buffer and extract lasti + code for the
+// repeat-detection identity check.  Handles the CFrame indirection on 3.11-3.12
+// (where self->top_frame is a CFrame, not an iframe) without using the stack
+// chunk (which may not be loaded yet at this call site).
+// Returns true on success, false if the read failed or top_frame is invalid.
+static inline bool
+_py_thread__read_top_frame_identity(py_thread_t* self, uintptr_t* out_lasti, void** out_code) {
+    V_DESC(self->proc->py_v);
+    py_proc_t* proc = self->proc;
+
+    *out_lasti = LASTI_UNSET;
+    *out_code  = NULL;
+
+    if (!isvalid(self->top_frame))
+        return false;
+
+    if (V_MIN(3, 11)) {
+        raddr_t iframe_addr = self->top_frame;
+
+        if (!V_MIN(3, 13)) {
+            // 3.11-3.12: top_frame is a CFrame pointer; dereference current_frame.
+            PyCFrame cframe;
+            if (fail(copy_py(proc->ref, self->top_frame, py_cframe, cframe)))
+                return false;
+            iframe_addr = V_FIELD(raddr_t, cframe, py_cframe, o_current_frame);
+            if (!isvalid(iframe_addr))
+                return false;
+        }
+
+        PyInterpreterFrame fi;
+        if (fail(copy_py(proc->ref, iframe_addr, py_iframe, fi)))
+            return false;
+
+        *out_lasti = V_FIELD(uintptr_t, fi, py_iframe, o_prev_instr);
+        // out_code not used for >= 3.11 (code-object guard only applies to < 3.11)
+    } else {
+        PyFrameObject fr;
+        if (fail(copy_py(proc->ref, self->top_frame, py_frame, fr)))
+            return false;
+
+        *out_lasti = (uintptr_t)(unsigned int)V_FIELD(int, fr, py_frame, o_lasti);
+        *out_code  = V_FIELD(raddr_t, fr, py_frame, o_code);
+    }
+
+    return true;
+}
+
+// ----------------------------------------------------------------------------
 static inline int
 _py_thread__push_remote_frame(py_thread_t* self, raddr_t* prev) {
     PyFrameObject frame;
@@ -225,6 +273,8 @@ _py_thread__push_iframe(py_thread_t* self, raddr_t* prev) {
 // ----------------------------------------------------------------------------
 static inline int
 _py_thread__unwind_frame_stack(py_thread_t* self) {
+    V_DESC(self->proc->py_v);
+
     raddr_t prev = self->top_frame;
 
     while (isvalid(prev)) {
@@ -241,11 +291,15 @@ _py_thread__unwind_frame_stack(py_thread_t* self) {
             FAIL;
         }
 
-        // Up-stack optimisation: repeat the previous stack if a frame matches
-        // the previous sample's top frame. Only for non-native samples.
-        if (!pargs_native && isvalid(prev) && prev == self->prev_top_frame) {
-            stack_py_push_repeat();
-            SUCCESS;
+        // Up-stack optimisation: repeat the previous stack if the next frame
+        // matches the previous sample's top frame. Only for non-native samples.
+        if (!pargs_native && isvalid(prev) && prev == self->prev_top.frame) {
+            PyFrameObject fr;
+            if (success(copy_py(self->proc->ref, prev, py_frame, fr))
+                && (uintptr_t)(unsigned int)V_FIELD(int, fr, py_frame, o_lasti) == self->prev_top.lasti) {
+                stack_py_push_repeat();
+                SUCCESS;
+            }
         }
     }
 
@@ -255,6 +309,8 @@ _py_thread__unwind_frame_stack(py_thread_t* self) {
 // ----------------------------------------------------------------------------
 static inline int
 _py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
+    V_DESC(self->proc->py_v);
+
     raddr_t curr = iframe_raddr;
 
     while (isvalid(curr)) {
@@ -275,9 +331,20 @@ _py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
 
         // Up-stack optimisation: repeat the previous stack if a frame matches
         // the previous sample's top frame. Only for non-native samples.
-        if (!pargs_native && isvalid(curr) && curr == self->prev_top_frame) {
-            stack_py_push_repeat();
-            SUCCESS;
+        if (!pargs_native && isvalid(curr) && curr == self->prev_top.frame) {
+            uintptr_t lasti = LASTI_UNSET;
+            void*     local = stack_chunk__resolve(self->stack, curr);
+            if (isvalid(local)) {
+                lasti = *(uintptr_t*)((char*)local + py_v->py_iframe.o_prev_instr);
+            } else {
+                PyInterpreterFrame fi;
+                if (success(copy_py(self->proc->ref, curr, py_iframe, fi)))
+                    lasti = V_FIELD(uintptr_t, fi, py_iframe, o_prev_instr);
+            }
+            if (lasti == self->prev_top.lasti) {
+                stack_py_push_repeat();
+                SUCCESS;
+            }
         }
     }
 
@@ -300,25 +367,6 @@ _py_thread__unwind_cframe_stack(py_thread_t* self) {
 // ---- PUBLIC ----------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
-// Read the code object pointer from a frame without copying the full struct.
-// For < 3.11 reads PyFrameObject.f_code; for >= 3.11 reads
-// _PyInterpreterFrame.f_code. Returns NULL on failure (treated as unknown).
-static inline void*
-_py_thread__read_frame_code(py_thread_t* self, raddr_t frame) {
-    V_DESC(self->proc->py_v);
-
-    raddr_t code   = NULL;
-    int     offset = V_MIN(3, 11) ? py_v->py_iframe.o_code : py_v->py_frame.o_code;
-
-    copy_memory(self->proc->ref, (char*)frame + offset, sizeof(raddr_t), &code);
-    return code;
-}
-
-static inline void*
-_py_thread__read_top_code(py_thread_t* self) {
-    return _py_thread__read_frame_code(self, self->top_frame);
-}
-
 // ----------------------------------------------------------------------------
 // Core thread-state read: copies the remote thread state and extracts all
 // fields except the datastack chunk.  Declared static inline so that both
@@ -438,27 +486,28 @@ py_thread__read_with_stack_remote(py_thread_t* self, raddr_t addr, thread_tracke
 
     V_DESC(self->proc->py_v);
 
+    // Read the top frame once; extract lasti + code for the repeat check.
     // For Python < 3.11 heap-allocated frame objects can be freed and
     // reallocated at the same address; verify the code object too.
     // For >= 3.11 frames live in a stack chunk with variable sizing, so
     // address collisions are rare enough that the frame check alone suffices.
-    void* top_code = (isvalid(self->top_frame) && V_MAX(3, 10)) ? _py_thread__read_top_code(self) : NULL;
+    void*     top_code  = NULL;
+    uintptr_t top_lasti = LASTI_UNSET;
 
-    if (isvalid(self->top_frame) && entry->top_frame == self->top_frame) {
-        if (V_MIN(3, 11) || top_code == entry->top_code) {
+    if (_py_thread__read_top_frame_identity(self, &top_lasti, &top_code)) {
+        if (entry->top.frame == self->top_frame && top_lasti == entry->top.lasti
+            && (V_MIN(3, 11) || top_code == entry->top.code)) {
             self->is_repeat = true;
             SUCCESS;
         }
     }
 
     // Expose the previous top for partial-repeat detection during unwinding.
-    self->prev_top_frame = entry->top_frame;
-    self->prev_top_code  = entry->top_code;
+    self->prev_top = entry->top;
 
     _py_thread__load_stack(self);
 
-    entry->top_frame = self->top_frame;
-    entry->top_code  = top_code;
+    entry->top = (py_frame_id_t){self->top_frame, top_code, top_lasti};
 
     SUCCESS;
 }
@@ -506,7 +555,7 @@ py_thread__unwind(py_thread_t* self) {
             self->is_repeat               = false;
             thread_tracker_entry_t* entry = thread_tracker__get_or_create(self->proc->thread_tracker, self->tid);
             if (isvalid(entry))
-                entry->top_frame = NULL;
+                entry->top.frame = NULL;
         }
     }
 

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -52,22 +52,12 @@ typedef struct thread {
 
     tstate_status_t status;
 
-    bool is_repeat; // set by py_thread__next: true when top_frame matches cache
+    bool    is_repeat;      // true when top_frame+code matches the previous sample
+    raddr_t prev_top_frame; // previous sample's top frame (for partial repeat detection)
+    void*   prev_top_code;  // code at prev_top_frame (< 3.11 only)
 } py_thread_t;
 
 #define py_thread__init(_proc) {.proc = _proc}
-
-static inline bool
-_py_thread__is_pyeval_frame(py_thread_t* self, cached_string_t* scope) {
-    if (scope == self->proc->pyeval_scope)
-        return true;
-    if (!self->proc->pyeval_scope && scope != UNKNOWN_SCOPE
-        && isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"))) {
-        self->proc->pyeval_scope = scope;
-        return true;
-    }
-    return false;
-}
 
 /**
  * Fill the thread structure from the given remote address.

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -31,6 +31,7 @@
 #include "py_proc.h"
 #include "stack.h"
 #include "stats.h"
+#include "thread_tracker.h"
 
 #define MAXLEN         1024
 #define MAX_STACK_SIZE 2048
@@ -50,9 +51,23 @@ typedef struct thread {
     stack_chunk_t* stack;
 
     tstate_status_t status;
+
+    bool is_repeat; // set by py_thread__next: true when top_frame matches cache
 } py_thread_t;
 
 #define py_thread__init(_proc) {.proc = _proc}
+
+static inline bool
+_py_thread__is_pyeval_frame(py_thread_t* self, cached_string_t* scope) {
+    if (scope == self->proc->pyeval_scope)
+        return true;
+    if (!self->proc->pyeval_scope && scope != UNKNOWN_SCOPE
+        && isvalid(strstr(scope->value, "PyEval_EvalFrameDefault"))) {
+        self->proc->pyeval_scope = scope;
+        return true;
+    }
+    return false;
+}
 
 /**
  * Fill the thread structure from the given remote address.
@@ -65,24 +80,27 @@ int
 py_thread__read_remote(py_thread_t*, raddr_t);
 
 /**
- * Read the thread state and its datastack chunk from remote memory.
- *
- * Use this when the stack chunk is needed immediately (e.g. the sampling loop).
- * For the interrupt loop where only tid/next are needed, use
- * py_thread__read_remote instead.
+ * Read the thread state and immediately perform the top-frame cache check. Sets
+ * self->is_repeat; if not a repeat, loads the stack chunk right away to
+ * minimise the window between the thread-state read and the frame data read.
+ * The tracker may be NULL, in which case this behaves like
+ * py_thread__read_remote.
  */
 int
-py_thread__read_with_stack_remote(py_thread_t*, raddr_t);
+py_thread__read_with_stack_remote(py_thread_t*, raddr_t, thread_tracker_t*);
 
 /**
- * Get the next thread, if any.
+ * Get the next thread, if any.  If the tracker is non-NULL, checks the
+ * top-frame cache immediately after reading the thread state and loads the
+ * stack chunk if the stack has changed, setting self->is_repeat accordingly.
  *
- * @param  py_thread_t  self.
+ * @param  py_thread_t    self.
+ * @param  thread_tracker_t optional cache (NULL for non-sampling callers).
  *
- * @return a pointer to the next py_thread_t instance.
+ * @return SUCCESS or FAIL/STOP.
  */
 int
-py_thread__next(py_thread_t*);
+py_thread__next(py_thread_t*, thread_tracker_t*);
 
 /**
  * Unwind the thread.

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -52,9 +52,8 @@ typedef struct thread {
 
     tstate_status_t status;
 
-    bool    is_repeat;      // true when top_frame+code matches the previous sample
-    raddr_t prev_top_frame; // previous sample's top frame (for partial repeat detection)
-    void*   prev_top_code;  // code at prev_top_frame (< 3.11 only)
+    bool          is_repeat; // true when top_frame+code+lasti matches the previous sample
+    py_frame_id_t prev_top;  // previous sample's top frame identity (for partial repeat detection)
 } py_thread_t;
 
 #define py_thread__init(_proc) {.proc = _proc}

--- a/src/stack.h
+++ b/src/stack.h
@@ -97,6 +97,8 @@ stack_py_push(raddr_t origin, raddr_t code, int lasti) {
 #define stack_full()     (_stack->pointer >= _stack->size)
 
 #define stack_py_push_cframe() (stack_py_push(CFRAME_MAGIC, NULL, 0))
+#define stack_push_py_repeat()                                  \
+    { _stack->base[_stack->pointer++] = PYSTACK_REPEAT_MAGIC; }
 
 #define stack_native_push(frame)                               \
     { _stack->native_base[_stack->native_pointer++] = frame; }

--- a/src/stack.h
+++ b/src/stack.h
@@ -97,12 +97,12 @@ stack_py_push(raddr_t origin, raddr_t code, int lasti) {
 #define stack_full()     (_stack->pointer >= _stack->size)
 
 #define stack_py_push_cframe() (stack_py_push(CFRAME_MAGIC, NULL, 0))
-#define stack_push_py_repeat()                                  \
-    { _stack->base[_stack->pointer++] = PYSTACK_REPEAT_MAGIC; }
+#define stack_py_push_repeat() (stack_py_push(PYSTACK_REPEAT_MAGIC, NULL, 0))
 
 #define stack_native_push(frame)                               \
     { _stack->native_base[_stack->native_pointer++] = frame; }
 #define stack_native_pop()      (_stack->native_base[--_stack->native_pointer])
+#define stack_native_top()      (_stack->native_pointer ? _stack->native_base[_stack->native_pointer - 1] : NULL)
 #define stack_native_is_empty() (_stack->native_pointer == 0)
 #define stack_native_full()     (_stack->native_pointer >= _stack->size)
 #define stack_native_reset()        \

--- a/src/thread_tracker.c
+++ b/src/thread_tracker.c
@@ -1,0 +1,69 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018-2025 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "thread_tracker.h"
+
+// ----------------------------------------------------------------------------
+thread_tracker_t*
+thread_tracker_new(void) {
+    thread_tracker_t* self = calloc(1, sizeof(thread_tracker_t));
+    return self;
+}
+
+// ----------------------------------------------------------------------------
+thread_tracker_entry_t*
+thread_tracker__get_or_create(thread_tracker_t* self, uintptr_t tid) {
+    for (size_t i = 0; i < self->count; i++) {
+        if (self->entries[i].tid == tid)
+            return &self->entries[i];
+    }
+
+    if (self->count >= MAX_THREAD_TRACKER)
+        return NULL;
+
+    thread_tracker_entry_t* entry = &self->entries[self->count++];
+    memset(entry, 0, sizeof(*entry));
+    entry->tid = tid;
+    return entry;
+}
+
+// ----------------------------------------------------------------------------
+void
+thread_tracker__evict_stale(thread_tracker_t* self) {
+    size_t i = 0;
+    while (i < self->count) {
+        if (self->entries[i].last_gen < self->sample_gen) {
+            self->entries[i] = self->entries[--self->count];
+        } else {
+            i++;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+void
+thread_tracker__destroy(thread_tracker_t* self) {
+    free(self);
+}

--- a/src/thread_tracker.h
+++ b/src/thread_tracker.h
@@ -44,6 +44,7 @@
 typedef struct {
     uintptr_t    tid;
     void*        top_frame; // Python-only pre-unwind identity (NULL = no prior emit)
+    void*        top_code;  // code object at top_frame, guards against frame reuse
     unsigned int last_gen;
 } thread_tracker_entry_t;
 

--- a/src/thread_tracker.h
+++ b/src/thread_tracker.h
@@ -1,0 +1,82 @@
+// This file is part of "austin" which is released under GPL.
+//
+// See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+// details.
+//
+// Austin is a Python frame stack sampler for CPython.
+//
+// Copyright (c) 2018-2025 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Per-thread stack identity tracker used to detect repeated stacks between
+// consecutive samples and emit MOJO_STACK_REPEAT instead of re-emitting the
+// full frame sequence.
+//
+// Python-only mode: identity is the top_frame remote address checked before
+// unwinding, so the unwind can be skipped entirely on a repeat.
+//
+// Native mode: identity is a hash of the resolved stack buffers computed after
+// unwinding; only the emit is skipped on a repeat.
+//
+// Dead threads are evicted by comparing last_gen against sample_gen, which is
+// incremented at the start of each full thread sweep.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define MAX_THREAD_TRACKER 256
+
+typedef struct {
+    uintptr_t    tid;
+    void*        top_frame; // Python-only pre-unwind identity (NULL = no prior emit)
+    unsigned int last_gen;
+} thread_tracker_entry_t;
+
+typedef struct {
+    thread_tracker_entry_t entries[MAX_THREAD_TRACKER];
+    size_t                 count;
+    unsigned int           sample_gen;
+} thread_tracker_t;
+
+/**
+ * Create a new thread tracker.
+ *
+ * @return a pointer to the newly created thread_tracker_t, or NULL on failure.
+ */
+thread_tracker_t*
+thread_tracker_new();
+
+/**
+ * Return the existing entry for tid, or allocate and return a new one.
+ * Returns NULL only if the tracker is full (> MAX_THREAD_TRACKER threads).
+ */
+thread_tracker_entry_t*
+thread_tracker__get_or_create(thread_tracker_t*, uintptr_t tid);
+
+/**
+ * Remove entries that were not visited in the current sample generation.
+ * Uses swap-with-last to keep the array compact.
+ */
+void
+thread_tracker__evict_stale(thread_tracker_t*);
+
+/**
+ * Destroy the thread tracker and free all associated memory.
+ */
+void
+thread_tracker__destroy(thread_tracker_t*);

--- a/src/thread_tracker.h
+++ b/src/thread_tracker.h
@@ -41,11 +41,18 @@
 
 #define MAX_THREAD_TRACKER 256
 
+#define LASTI_UNSET ((uintptr_t)-1)
+
 typedef struct {
-    uintptr_t    tid;
-    void*        top_frame; // Python-only pre-unwind identity (NULL = no prior emit)
-    void*        top_code;  // code object at top_frame, guards against frame reuse
-    unsigned int last_gen;
+    void*     frame; // remote address of the top frame (NULL = no prior emit)
+    void*     code;  // code object at frame, guards against frame reuse (< 3.11)
+    uintptr_t lasti; // lasti/prev_instr at frame, guards against same frame/different line
+} py_frame_id_t;
+
+typedef struct {
+    uintptr_t     tid;
+    py_frame_id_t top; // Python-only pre-unwind identity
+    unsigned int  last_gen;
 } thread_tracker_entry_t;
 
 typedef struct {

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -451,6 +451,10 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
         if (fail(_push_native_frame(self, pc)))
             FAIL;
 
+        frame_t* top = _stack->native_base[_stack->native_pointer - 1];
+        if (self->is_repeat && _py_thread__is_pyeval_frame(self, top->scope))
+            break;
+
         // Save pre-step state so we can fall back to StackWalk64 if the
         // pdata unwinder produces a PC outside any known module.
         uintptr_t saved_pc = pc;

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -452,8 +452,12 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
             FAIL;
 
         frame_t* top = _stack->native_base[_stack->native_pointer - 1];
-        if (self->is_repeat && _py_thread__is_pyeval_frame(self, top->scope))
-            break;
+        if (unlikely(is_pyeval_frame(top->scope))) {
+            (void)stack_native_pop();
+            stack_native_push((frame_t*)EVAL_FRAME_MAGIC);
+            if (self->is_repeat)
+                break;
+        }
 
         // Save pre-step state so we can fall back to StackWalk64 if the
         // pdata unwinder produces a PC outside any known module.
@@ -502,7 +506,7 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
 
 static inline void
 _py_thread__unwind_native(py_thread_t* self, bool* error) {
-    if (pargs_native && _py_thread__is_interrupted(self)) {
+    if (_py_thread__is_interrupted(self)) {
         if (fail(_py_thread__unwind_native_frame_stack(self))) {
             *error = true;
         }

--- a/test/cunit/test_thread_tracker.py
+++ b/test/cunit/test_thread_tracker.py
@@ -1,0 +1,48 @@
+from test.cunit.thread_tracker import ThreadTracker
+
+
+MAX_THREAD_TRACKER = 256
+
+
+def test_new():
+    t = ThreadTracker()
+    assert t.__cself__
+
+
+def test_get_or_create_new_entry():
+    t = ThreadTracker()
+    entry = t.get_or_create(1001)
+    assert entry
+
+
+def test_get_or_create_returns_same_entry():
+    t = ThreadTracker()
+    e1 = t.get_or_create(1001)
+    e2 = t.get_or_create(1001)
+    assert e1 == e2
+
+
+def test_get_or_create_different_tids():
+    t = ThreadTracker()
+    e1 = t.get_or_create(1001)
+    e2 = t.get_or_create(1002)
+    assert e1 != e2
+
+
+def test_get_or_create_capacity_limit():
+    t = ThreadTracker()
+    for tid in range(MAX_THREAD_TRACKER):
+        assert t.get_or_create(tid)
+    # One over the limit returns NULL
+    assert not t.get_or_create(MAX_THREAD_TRACKER)
+
+
+def test_evict_stale_no_eviction_when_gen_unchanged():
+    # sample_gen starts at 0; all entries also have last_gen=0, so nothing evicted
+    t = ThreadTracker()
+    t.get_or_create(1001)
+    t.get_or_create(1002)
+    t.evict_stale()
+    # Both entries should still be present (returned as existing entries, not new ones)
+    assert t.get_or_create(1001) == t.get_or_create(1001)
+    assert t.get_or_create(1002) == t.get_or_create(1002)

--- a/test/cunit/test_thread_tracker.py
+++ b/test/cunit/test_thread_tracker.py
@@ -1,6 +1,5 @@
 from test.cunit.thread_tracker import ThreadTracker
 
-
 MAX_THREAD_TRACKER = 256
 
 

--- a/test/cunit/thread_tracker.py
+++ b/test/cunit/thread_tracker.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+from test.cunit import SRC
+from test.cunit import CModule
+
+CFLAGS = ["-g", "-fprofile-arcs", "-ftest-coverage", "-fPIC"]
+
+sys.modules[__name__] = CModule.compile(
+    SRC / Path(__file__).stem, cflags=CFLAGS, extra_sources=[]
+)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-austin-python~=2.1
+austin-python~=2.2
 flaky~=3.8
 pytest~=9.0
 pytest-xdist~=3.8


### PR DESCRIPTION
We add thread tracking to allow detecting when a stack from a new sample is a repeat of a previous stack. In that case we emit a special event instead of frame information and avoid a new stack unwinding. As a result, the sample rate can increase significantly with small intervals, and the MOJO payloads also benefit from a reduced amount of duplication.

## Note

Experiments show that ignoring the `lasti` check (so dropping fine-grained location information) would lead to effective max sample rates of ~0.8 MHz.