### PR TITLE
chore: drop Python 3.9 support

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -256,7 +256,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/Scripts/activate
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
           cd austin
           pip install -r scripts/requirements-bm.txt
           cd -

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -113,7 +113,7 @@ jobs:
 
       - uses: "actions/setup-python@v4"
         with:
-          python-version: "3.9"
+          python-version: "3.13"
 
       - name: Install codespell
         run: pip install codespell~=2.4
@@ -145,7 +145,7 @@ jobs:
 
       - uses: "actions/setup-python@v4"
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install black
         run: pip install black~=26.3.1
@@ -163,7 +163,7 @@ jobs:
 
       - uses: "actions/setup-python@v4"
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install flake8
         run: pip install flake8~=7.3
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name: Code coverage (Python ${{ matrix.python-version }})
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build artifacts but skip all uploads)'
+        required: false
+        default: true
+        type: boolean
+
 jobs:
   release-linux:
     strategy:
@@ -23,10 +31,10 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout Austin
 
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Setup libunwind
         uses: ./.github/actions/setup-libunwind
@@ -38,7 +46,7 @@ jobs:
 
       - name: Generate artifacts
         run: |
-          python3.10 -m venv .venv
+          python3.13 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r scripts/requirements-bw.txt
@@ -76,6 +84,7 @@ jobs:
           deactivate
 
       - name: Upload artifacts to release
+        if: ${{ !inputs.dry_run }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,6 +94,7 @@ jobs:
           file_glob: true
 
       - name: Upload Python wheels to PyPI
+        if: ${{ !inputs.dry_run }}
         run: |
           source .venv/bin/activate
           twine upload dist/*.whl --username __token__ --password ${{ secrets.PYPI_TOKEN }}
@@ -130,6 +140,7 @@ jobs:
           popd
 
       - name: Upload to choco
+        if: ${{ !inputs.dry_run }}
         shell: bash
         run: |
           export VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
@@ -146,6 +157,7 @@ jobs:
           popd
 
       - name: Upload artifacts to release
+        if: ${{ !inputs.dry_run }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -154,28 +166,29 @@ jobs:
           overwrite: true
           file_glob: true
 
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Build Python wheels
         shell: bash
         run: |
-          py -3.10 -m pip install --upgrade pip
-          py -3.10 -m pip install -r scripts/requirements-bw.txt
+          py -3.13 -m pip install --upgrade pip
+          py -3.13 -m pip install -r scripts/requirements-bw.txt
           
           export VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
 
-          py -3.10 scripts/build-wheel.py \
+          py -3.13 scripts/build-wheel.py \
             --version=$VERSION \
             --platform=win_amd64 \
             --files austin.exe:src/austin.exe
       
       - name: Upload Python wheels to PyPI
+        if: ${{ !inputs.dry_run }}
         shell: bash
         run: |
-          py -3.10 -m twine upload dist/*.whl --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+          py -3.13 -m twine upload dist/*.whl --username __token__ --password ${{ secrets.PYPI_TOKEN }}
 
   release-osx:
     runs-on: macos-latest
@@ -186,14 +199,14 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout Austin
 
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Generate artifacts
         run: |
-          python3.10 -m venv .venv
+          python3.13 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r scripts/requirements-bw.txt
@@ -228,6 +241,7 @@ jobs:
           deactivate
 
       - name: Upload artifacts to release
+        if: ${{ !inputs.dry_run }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -235,8 +249,9 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
-      
+
       - name: Upload Python wheels to PyPI
+        if: ${{ !inputs.dry_run }}
         shell: bash
         run: |
           source .venv/bin/activate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - arch: x86_64
             runs-on: ubuntu-24.04
@@ -157,14 +157,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}-dev
 
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install test dependencies
         run: |
-          python3.10 -m venv .venv
+          python3.13 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r test/requirements.txt
@@ -173,7 +173,7 @@ jobs:
         run: |
           echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
           ulimit -c unlimited
-          python3.10 -c "import ctypes;ctypes.string_at(0)" || true
+          python3.13 -c "import ctypes;ctypes.string_at(0)" || true
           ls core.* && rm core.* || true
 
       - name: Run unit tests
@@ -282,14 +282,14 @@ jobs:
 
       - run: chmod +x src/austin && chmod +x src/austinp
 
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Build wheels
         run: |
-          python3.10 -m venv .venv
+          python3.13 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r scripts/requirements-bw.txt
@@ -349,7 +349,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -370,10 +370,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}-dev
 
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Remove signature from the Python binary
         run: |
@@ -382,8 +382,8 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          python3.10 -m pip install --upgrade pip
-          python3.10 -m pip install -r test/requirements.txt
+          python3.13 -m pip install --upgrade pip
+          python3.13 -m pip install -r test/requirements.txt
           python${{ matrix.python-version }} -m venv .venv \
             || (python${{ matrix.python-version }} -m pip install virtualenv && python${{ matrix.python-version }} -m virtualenv .venv)
 
@@ -449,14 +449,14 @@ jobs:
 
       - run: chmod +x src/austin
 
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Build wheels
         run: |
-          python3.10 -m venv .venv
+          python3.13 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r scripts/requirements-bw.txt
@@ -499,7 +499,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -597,19 +597,19 @@ jobs:
           path: src
 
       - uses: actions/setup-python@v4
-        name: Install Python 3.10
+        name: Install Python 3.13
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
       - name: Build wheels
         shell: bash
         run: |
-          py -3.10 -m pip install --upgrade pip
-          py -3.10 -m pip install -r scripts/requirements-bw.txt
+          py -3.13 -m pip install --upgrade pip
+          py -3.13 -m pip install -r scripts/requirements-bw.txt
           
           export VERSION=$(cat src/austin.h | sed -r -n "s/^#define VERSION[ ]+\"(.+)\"/\1/p")
 
-          py -3.10 scripts/build-wheel.py \
+          py -3.13 scripts/build-wheel.py \
             --version=$VERSION \
             --platform=win_amd64 \
             --files austin.exe:src/austin.exe

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -37,10 +37,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}-dev
 
-      - name: Install Python 3.12
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Check out the base branch
         uses: actions/checkout@v3
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install runtime dependencies
         run: |
-          python3.12 -m venv .venv
+          python3.13 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r austin/scripts/requirements-val.txt
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -147,10 +147,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}-dev
 
-      - name: Install Python 3.12
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Check out the base branch
         uses: actions/checkout@v3
@@ -230,7 +230,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -244,10 +244,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}-dev
 
-      - name: Install Python 3.12
+      - name: Install Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Check out the base branch
         uses: actions/checkout@v3
@@ -282,7 +282,7 @@ jobs:
 
       - name: Install runtime dependencies
         run: |
-          python3.12 -m venv .venv
+          python3.13 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r austin/scripts/requirements-val.txt

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ folder in either the SVG, PDF or PNG format
 
 # Compatibility
 
-Austin supports Python 3.9 through 3.14, and has been tested on the following
+Austin supports Python 3.10 through 3.14, and has been tested on the following
 platforms and architectures
 
 |             | <img src="art/tux.svg" /> | <img src="art/win.svg"/> | <img src="art/apple.svg"/> |
@@ -534,6 +534,7 @@ summarises the compatibility of Austin with CPython versions
 | 2.3-2.7, 3.3-3.11 | 3.5            |
 | 3.8-3.13          | 3.7            |
 | 3.9-3.14          | 4.0            |
+| 3.10-3.14         | 4.1            |
 
 > [!NOTE]
 > Austin *might* work with other platforms and architectures not listed above.

--- a/doc/cheatsheet.svg
+++ b/doc/cheatsheet.svg
@@ -6344,7 +6344,7 @@
          y="293.48233"
          x="49.886612"
          id="tspan9522"
-         sodipodi:role="line">3.9 | 3.10 | 3.11 | 3.12 | 3.13 | 3.14</tspan></text>
+         sodipodi:role="line">3.10 | 3.11 | 3.12 | 3.13 | 3.14</tspan></text>
     <text
        id="text9528"
        y="37.82159"

--- a/scripts/build-wheel.py
+++ b/scripts/build-wheel.py
@@ -16,7 +16,6 @@ METADATA = {
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/src/version.h
+++ b/src/version.h
@@ -279,13 +279,6 @@ typedef struct {
         offsetof(s, collecting), \
     }
 
-// ---- Python 3.9 ------------------------------------------------------------
-
-python_v python_v3_9 = {
-    PY_CODE(PyCodeObject3_8),     PY_FRAME(PyFrameObject3_7),     PY_THREAD(PyThreadState3_8),
-    PY_IS(PyInterpreterState3_9), PY_RUNTIME(_PyRuntimeState3_8), PY_GC(struct _gc_runtime_state3_8),
-};
-
 // ---- Python 3.10 -----------------------------------------------------------
 
 python_v python_v3_10 = {
@@ -327,11 +320,6 @@ get_version_descriptor(int major, int minor, int patch) {
     // ---- Python 3 ------------------------------------------------------------
     case 3:
         switch (minor) {
-        //, 3.9
-        case 9:
-            py_v = &python_v3_9;
-            break;
-
         // 3.10
         case 10:
             py_v = &python_v3_10;


### PR DESCRIPTION
Python 3.9 has reached EOL in October 2025 so we drop support in the next Austin release. We also bump our test harnesses to 3.13 for gain some leeway.