### PR TITLE
feat: add free-threaded support

### DIFF
--- a/.github/workflows/build_release_arch.yml
+++ b/.github/workflows/build_release_arch.yml
@@ -85,7 +85,7 @@ jobs:
           file_glob: true
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -109,14 +109,17 @@ jobs:
               ;;
           esac
 
+          # FT Python has no official builds for armv7/ppc64le.
           python scripts/build-wheel.py \
             --version=$VERSION \
             --platform=$PLATFORM \
+            --no-free-threaded \
             --files austin:./artifacts/austin austinp:./artifacts/austinp
 
           python scripts/build-wheel.py \
             --version=$VERSION \
             --platform=$MUSL_PLATFORM \
+            --no-free-threaded \
             --files austin:./artifacts/austin.musl
 
           deactivate

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "3.13"
 
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "3.13"
 
@@ -161,7 +161,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "3.13"
 
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
     name: Code coverage (Python ${{ matrix.python-version }})
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -222,13 +222,21 @@ jobs:
 
       - run: chmod +x src/austin src/austinp
 
-      - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Install Python (standard)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
 
+      - name: Install Python (free-threaded)
+        if: ${{ endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -302,12 +310,12 @@ jobs:
       - run: chmod +x src/austin
 
       - name: Install Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12-dev"
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         name: Checkout Austin
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -120,7 +120,7 @@ jobs:
         name: Checkout Austin
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -223,7 +223,7 @@ jobs:
         name: Checkout Austin
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -249,6 +249,7 @@ jobs:
           python scripts/build-wheel.py \
             --version=${{ steps.tag.outputs.version }} \
             --platform=${{ steps.tag.outputs.platform }} \
+            --no-free-threaded \
             --files austin:src/austin
           deactivate
 
@@ -342,7 +343,7 @@ jobs:
           file_glob: true
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -381,7 +382,7 @@ jobs:
         name: Checkout Austin
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,19 @@ jobs:
             runs-on: ubuntu-24.04
           - arch: aarch64
             runs-on: ubuntu-24.04-arm
+          # Free-threaded builds on both arches
+          - arch: x86_64
+            python-version: "3.13t"
+            runs-on: ubuntu-24.04
+          - arch: x86_64
+            python-version: "3.14t"
+            runs-on: ubuntu-24.04
+          - arch: aarch64
+            python-version: "3.13t"
+            runs-on: ubuntu-24.04-arm
+          - arch: aarch64
+            python-version: "3.14t"
+            runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs-on }}
     if: needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.result == 'skipped'
 
@@ -152,13 +165,21 @@ jobs:
             valgrind \
             gdb
 
-      - name: Install Python
-        uses: actions/setup-python@v4
+      - name: Install Python (standard)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
 
+      - name: Install Python (free-threaded)
+        if: ${{ endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -283,7 +304,7 @@ jobs:
       - run: chmod +x src/austin && chmod +x src/austinp
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -349,7 +370,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -365,13 +386,21 @@ jobs:
 
       - run: chmod +x src/austin
 
-      - name: Install Python
-        uses: actions/setup-python@v4
+      - name: Install Python (standard)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
 
+      - name: Install Python (free-threaded)
+        if: ${{ endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -450,7 +479,7 @@ jobs:
       - run: chmod +x src/austin
 
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -499,7 +528,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -513,12 +542,20 @@ jobs:
           name: austin-binary-${{ runner.os }}
           path: src
 
-      - name: Install Python
-        uses: actions/setup-python@v4
+      - name: Install Python (standard)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
 
-      - uses: actions/setup-python@v4
+      - name: Install Python (free-threaded)
+        if: ${{ endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - uses: actions/setup-python@v5
         name: Install Python 3.12
         with:
           python-version: "3.12"
@@ -596,7 +633,7 @@ jobs:
           name: austin-binary-${{ runner.os }}
           path: src
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python 3.13
         with:
           python-version: '3.13'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -32,13 +32,21 @@ jobs:
 
     name: Data validation on Linux (x86_64) with Python ${{ matrix.python-version }}
     steps:
-      - name: Install Python
-        uses: actions/setup-python@v4
+      - name: Install Python (standard)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
 
+      - name: Install Python (free-threaded)
+        if: ${{ endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -133,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -142,13 +150,21 @@ jobs:
 
     name: Data validation on Windows (x86_64) with Python ${{ matrix.python-version }}
     steps:
-      - name: Install Python
-        uses: actions/setup-python@v4
+      - name: Install Python (standard)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
 
+      - name: Install Python (free-threaded)
+        if: ${{ endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
@@ -230,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
 
     env:
       AUSTIN_TESTS_PYTHON_VERSIONS: ${{ matrix.python-version }}
@@ -239,13 +255,21 @@ jobs:
 
     name: Data validation on macOS (arm64) with Python ${{ matrix.python-version }}
     steps:
-      - name: Install Python
-        uses: actions/setup-python@v4
+      - name: Install Python (standard)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
 
+      - name: Install Python (free-threaded)
+        if: ${{ endsWith(matrix.python-version, 't') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
       - name: Install Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,9 @@
 2026-**-** v4.1.0
 
-  Improved support for Linux containers.
+  Added support for free-threaded CPython builds.
   
+  Improved support for Linux containers.
+
 
 2025-10-31 v4.0.0
 

--- a/README.md
+++ b/README.md
@@ -538,8 +538,8 @@ folder in either the SVG, PDF or PNG format
 
 # Compatibility
 
-Austin supports Python 3.10 through 3.14, and has been tested on the following
-platforms and architectures
+Austin supports Python 3.10 through 3.14, including **free-threaded builds**,
+and has been tested on the following platforms and architectures
 
 |             | <img src="art/tux.svg" /> | <img src="art/win.svg"/> | <img src="art/apple.svg"/> |
 | ----------- | ------------------------- | ------------------------ | -------------------------- |
@@ -549,15 +549,19 @@ platforms and architectures
 | **arm64**   | ✓                         |                          | ✓                          |
 | **ppc64le** | ✓                         |                          |                            |
 
+> [!NOTE]
+> Memory profiling (`-m`/`--memory`) is not supported in free-threaded Python
+> builds as it relies on GIL state to identify the active thread.
+
 If you are looking for support for older versions of CPython, the following table
 summarises the compatibility of Austin with CPython versions
 
-| CPython Versions  | Austin Version |
-| ----------------- | -------------- |
-| 2.3-2.7, 3.3-3.11 | 3.5            |
-| 3.8-3.13          | 3.7            |
-| 3.9-3.14          | 4.0            |
-| 3.10-3.14         | 4.1            |
+| CPython Versions                     | Austin Version |
+| ------------------------------------ | -------------- |
+| 2.3-2.7, 3.3-3.11                    | 3.5            |
+| 3.8-3.13                             | 3.7            |
+| 3.9-3.14                             | 4.0            |
+| 3.10-3.14, (incl. free-threaded)     | 4.1            |
 
 > [!NOTE]
 > Austin *might* work with other platforms and architectures not listed above.

--- a/scripts/build-wheel.py
+++ b/scripts/build-wheel.py
@@ -8,6 +8,12 @@ from urllib.request import urlopen
 from wheel.wheelfile import WheelFile
 from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED
 
+# Free-threaded CPython ABI tags to include alongside the generic py3 tag.
+# Each entry produces an additional Tag: line in the wheel metadata and a
+# dotted component in the wheel filename, making pip prefer this wheel for
+# free-threaded Python environments without requiring a separate upload.
+FT_PYTHON_TAGS = ["cp313t", "cp314t"]
+
 METADATA = {
     "Summary": "Austin - Frame Stack Sampler for CPython",
     "Author": "Gabriele N. Tornetta",
@@ -88,11 +94,18 @@ def make_message(headers, payload=None):
     return message.getvalue().encode("utf-8")
 
 
-def write_austin_wheel(out_dir, *, version, platform, austin_bin_data):
+def write_austin_wheel(
+    out_dir, *, version, platform, austin_bin_data, free_threaded=True
+):
     package_name = "austin-dist"
-    python = "py3"
+    # All Python version tags covered by this wheel: the generic py3 tag plus,
+    # on platforms that ship free-threaded CPython builds, explicit FT tags.
+    # The filename uses them dotted; the WHEEL metadata lists a Tag: line for
+    # every (python, abi, platform) combination.
+    python_tags = ["py3"] + (FT_PYTHON_TAGS if free_threaded else [])
+    python_filename = ".".join(python_tags)
     dist_name = package_name.replace("-", "_")
-    wheel_name = f"{dist_name}-{version}-{python}-none-{platform}.whl"
+    wheel_name = f"{dist_name}-{version}-{python_filename}-none-{platform}.whl"
     dist_info = f"{dist_name}-{version}.dist-info"
     wheel_path = out_dir / wheel_name
 
@@ -124,7 +137,11 @@ def write_austin_wheel(out_dir, *, version, platform, austin_bin_data):
             "Wheel-Version": "1.0",
             "Generator": "austin-dist build-wheel.py",
             "Root-Is-Purelib": "false",
-            "Tag": [f"{python}-none-{p}" for p in platform.split(".")],
+            # One Tag: entry per (python_tag, platform) combination so that pip
+            # resolves this wheel for both GIL and free-threaded environments.
+            "Tag": [
+                f"{py}-none-{p}" for py in python_tags for p in platform.split(".")
+            ],
         }
     )
 
@@ -194,12 +211,21 @@ if __name__ == "__main__":
         default=None,
     )
 
+    argp.add_argument(
+        "--no-free-threaded",
+        help="Omit free-threaded Python tags (use for platforms without FT builds, e.g. musllinux)",
+        action="store_true",
+        default=False,
+    )
+
     args = argp.parse_args()
 
     version = args.version or get_latest_release()
 
     dist_dir = Path.cwd() / "dist"
     dist_dir.mkdir(exist_ok=True)
+
+    free_threaded = not args.no_free_threaded
 
     if args.files is not None:
         if args.platform is None:
@@ -213,6 +239,7 @@ if __name__ == "__main__":
                 (file_name, Path(bin_path).read_bytes())
                 for file_name, bin_path in (file.split(":") for file in args.files)
             ],
+            free_threaded=free_threaded,
         )
     else:
         if args.platform is None:
@@ -227,4 +254,5 @@ if __name__ == "__main__":
                 download_release(version, suffix, variant_name=variant)
                 for variant in variants
             ],
+            free_threaded=free_threaded,
         )

--- a/src/code.h
+++ b/src/code.h
@@ -36,13 +36,14 @@ typedef struct {
     line_table_t     line_table;
     size_t           line_table_size;
     unsigned int     first_line_number;
+    raddr_t          co_tlbc_raddr; // cached _PyCodeArray* for TLBC (3.14+ FT); NULL otherwise
 } code_t;
 
 // ----------------------------------------------------------------------------
 static inline code_t*
 code_new(
     key_dt key, cached_string_t* filename, cached_string_t* scope, line_table_t line_table, size_t line_table_size,
-    unsigned int first_line_number
+    unsigned int first_line_number, raddr_t co_tlbc_raddr
 ) {
     code_t* code = (code_t*)malloc(sizeof(code_t));
     if (!isvalid(code)) {
@@ -55,6 +56,7 @@ code_new(
     code->line_table        = line_table;
     code->line_table_size   = line_table_size;
     code->first_line_number = first_line_number;
+    code->co_tlbc_raddr     = co_tlbc_raddr;
 
     return code;
 }
@@ -139,7 +141,11 @@ _code_remote(py_proc_t* py_proc, raddr_t code_raddr) {
         FAIL_PTR;
     }
 
+    // co_tlbc is already in the local code buffer (no extra read needed).
+    raddr_t co_tlbc_raddr = py_v->py_code.o_tlbc ? V_FIELD(raddr_t, code, py_code, o_tlbc) : NULL;
+
     return code_new(
-        (key_dt)code_raddr, filename, scope, lnotab, len, V_FIELD(unsigned int, code, py_code, o_firstlineno)
+        (key_dt)code_raddr, filename, scope, lnotab, len, V_FIELD(unsigned int, code, py_code, o_firstlineno),
+        co_tlbc_raddr
     );
 }

--- a/src/code.h
+++ b/src/code.h
@@ -141,7 +141,6 @@ _code_remote(py_proc_t* py_proc, raddr_t code_raddr) {
         FAIL_PTR;
     }
 
-    // co_tlbc is already in the local code buffer (no extra read needed).
     raddr_t co_tlbc_raddr = py_v->py_code.o_tlbc ? V_FIELD(raddr_t, code, py_code, o_tlbc) : NULL;
 
     return code_new(

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -266,6 +266,10 @@ _py_proc__infer_python_version(py_proc_t* self) {
 
             init_version_descriptor(self->py_v, &py_d);
 
+            self->free_threaded = py_d.v3_13.free_threaded != 0;
+            if (self->free_threaded)
+                log_d("Free-threaded Python detected");
+
             SUCCESS;
         }
         log_d("PyRuntimeState structure does not match expected cookie");
@@ -1418,15 +1422,16 @@ py_proc__sample(py_proc_t* self) {
 // ----------------------------------------------------------------------------
 void
 py_proc__log_version(py_proc_t* self, bool is_parent) {
-    int major = self->py_v->major;
-    int minor = self->py_v->minor;
-    int patch = self->py_v->patch;
+    int         major = self->py_v->major;
+    int         minor = self->py_v->minor;
+    int         patch = self->py_v->patch;
+    const char* ft    = self->free_threaded ? "t" : "";
 
     if (is_parent) {
-        if (patch == 0xFF) {                                                 // GCOV_EXCL_LINE
-            event_handler__emit_metadata("python", "%d.%d.?", major, minor); // GCOV_EXCL_LINE
+        if (patch == 0xFF) {                                                       // GCOV_EXCL_LINE
+            event_handler__emit_metadata("python", "%d.%d.?%s", major, minor, ft); // GCOV_EXCL_LINE
         } else
-            event_handler__emit_metadata("python", "%d.%d.%d", major, minor, patch);
+            event_handler__emit_metadata("python", "%d.%d.%d%s", major, minor, patch, ft);
     }
 
     if (pargs.pipe)
@@ -1437,19 +1442,19 @@ py_proc__log_version(py_proc_t* self, bool is_parent) {
     if (pargs.children) {
         if (patch == 0xFF) // GCOV_EXCL_START
             log_m(
-                "🐍 %s process [" CYN "%zd" CRESET "] " BOLD "Python" CRESET " version: " BYEL "%d.%d" CRESET,
-                is_parent ? "Parent" : "Child", self->pid, major, minor
+                "🐍 %s process [" CYN "%zd" CRESET "] " BOLD "Python" CRESET " version: " BYEL "%d.%d%s" CRESET,
+                is_parent ? "Parent" : "Child", self->pid, major, minor, ft
             );
         else // GCOV_EXCL_STOP
             log_m(
-                "🐍 %s process [" CYN "%zd" CRESET "] " BOLD "Python" CRESET " version: " BYEL "%d.%d.%d" CRESET,
-                is_parent ? "Parent" : "Child", self->pid, major, minor, patch
+                "🐍 %s process [" CYN "%zd" CRESET "] " BOLD "Python" CRESET " version: " BYEL "%d.%d.%d%s" CRESET,
+                is_parent ? "Parent" : "Child", self->pid, major, minor, patch, ft
             );
     } else {
         if (patch == 0xFF) // GCOV_EXCL_START
-            log_m("🐍 " BOLD "Python" CRESET " version: " BYEL "%d.%d" CRESET, major, minor);
+            log_m("🐍 " BOLD "Python" CRESET " version: " BYEL "%d.%d%s" CRESET, major, minor, ft);
         else // GCOV_EXCL_STOP
-            log_m("🐍 " BOLD "Python" CRESET " version: " BYEL "%d.%d.%d" CRESET, major, minor, patch);
+            log_m("🐍 " BOLD "Python" CRESET " version: " BYEL "%d.%d.%d%s" CRESET, major, minor, patch, ft);
     }
 }
 

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -92,6 +92,8 @@ typedef struct {
     // Offset of the tstate_current field within the _PyRuntimeState structure
     unsigned int tstate_current_offset;
 
+    bool free_threaded;
+
 #ifdef PL_LINUX
 #ifdef AUSTINP
     struct _puw {

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -228,8 +228,6 @@ _bytes_remote(proc_ref_t pref, raddr_t raddr, ssize_t* size, python_v* py_v) {
     unsigned char* array = NULL;
 
     // ob_size is at offset py_object_size (right after the PyObject header).
-    // In GIL builds: py_object_size=16, ob_size at 16.
-    // In free-threaded builds: py_object_size=32, ob_size at 32.
     if (fail(copy_memory(pref, raddr + py_v->py_object_size, sizeof(ssize_t), &len))) // GCOV_EXCL_LINE
         FAIL_PTR;                                                                     // GCOV_EXCL_LINE
     len++;                                                                            // Include null-terminator

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -99,9 +99,10 @@ _string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
     // unicode offsets to locate the state bitfield, length, and ASCII data. The
     // PyObject header is larger in free-threaded builds.
     if (V_MIN(3, 13) && py_v->py_unicode.ascii_size > 0) {
-        // length[8] + hash[8] + state[4] — state always sits exactly
-        // sizeof(Py_ssize_t) + sizeof(Py_hash_t) after length.
-        char hdr[sizeof(ssize_t) + sizeof(Py_hash_t) + sizeof(uint32_t)];
+        // Read length[8] + hash[8] + state[8]. The state struct is 8 bytes on
+        // all platforms (4-byte-aligned, padded to 8), but the bitfield layout
+        // within it differs by compiler.
+        char hdr[sizeof(ssize_t) + sizeof(Py_hash_t) + 2 * sizeof(uint32_t)];
         if (fail(copy_memory(pref, raddr + py_v->py_unicode.o_length, sizeof(hdr), hdr))) // GCOV_EXCL_LINE
             FAIL_PTR;                                                                     // GCOV_EXCL_LINE
 
@@ -110,9 +111,21 @@ _string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
 
         unsigned int kind, compact;
         if (py_v->py_unicode.ft_interned_byte) {
-            // 3.14+ free-threaded: interned is a full unsigned char (byte 0),
-            // kind:3/compact:1/ascii:1 are packed into the next byte (byte 1).
-            uint8_t bits = (state_word >> 8) & 0xff;
+            // 3.14+ free-threaded: interned is a full unsigned char at byte +0
+            // of the state struct. The compiler determines where
+            // kind:3/compact:1 follows: GCC/Clang packs them at byte +1; MSVC
+            // aligns unsigned int bitfields to a 4-byte boundary so they land
+            // at byte +4. Probe on first use: try +1 (GCC), fall back to +4
+            // (MSVC).
+            if (unlikely(py_v->py_unicode.ft_state_kind_byte < 0)) {
+                // Probe: a valid kind is 1–4; if byte +1 gives that, it's GCC
+                // layout.
+                int kb1                             = *(uint8_t*)(hdr + sizeof(ssize_t) + sizeof(Py_hash_t) + 1) & 7;
+                int kb4                             = *(uint8_t*)(hdr + sizeof(ssize_t) + sizeof(Py_hash_t) + 4) & 7;
+                py_v->py_unicode.ft_state_kind_byte = (kb1 >= 1 && kb1 <= 4) ? 1 : (kb4 >= 1 && kb4 <= 4) ? 4 : 1;
+                log_d("Probed FT unicode state kind byte at +%d", py_v->py_unicode.ft_state_kind_byte);
+            }
+            uint8_t bits = *(uint8_t*)(hdr + sizeof(ssize_t) + sizeof(Py_hash_t) + py_v->py_unicode.ft_state_kind_byte);
             kind         = bits & 7;
             compact      = (bits >> 3) & 1;
         } else {

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -92,10 +92,81 @@ string__hash(char* string) {
 // ----------------------------------------------------------------------------
 static inline char*
 _string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
-    PyUnicodeObject unicode;
-    char*           buffer = NULL;
-    ssize_t         len    = 0;
+    char*   buffer = NULL;
+    ssize_t len    = 0;
 
+    // For Python 3.13+ (GIL and free-threaded) use the version-descriptor
+    // unicode offsets to locate the state bitfield, length, and ASCII data. The
+    // PyObject header is larger in free-threaded builds.
+    if (V_MIN(3, 13) && py_v->py_unicode.ascii_size > 0) {
+        // length[8] + hash[8] + state[4] — state always sits exactly
+        // sizeof(Py_ssize_t) + sizeof(Py_hash_t) after length.
+        char hdr[sizeof(ssize_t) + sizeof(Py_hash_t) + sizeof(uint32_t)];
+        if (fail(copy_memory(pref, raddr + py_v->py_unicode.o_length, sizeof(hdr), hdr))) // GCOV_EXCL_LINE
+            FAIL_PTR;                                                                     // GCOV_EXCL_LINE
+
+        len                 = *(ssize_t*)(hdr);
+        uint32_t state_word = *(uint32_t*)(hdr + sizeof(ssize_t) + sizeof(Py_hash_t));
+
+        unsigned int kind, compact;
+        if (py_v->py_unicode.ft_interned_byte) {
+            // 3.14+ free-threaded: interned is a full unsigned char (byte 0),
+            // kind:3/compact:1/ascii:1 are packed into the next byte (byte 1).
+            uint8_t bits = (state_word >> 8) & 0xff;
+            kind         = bits & 7;
+            compact      = (bits >> 3) & 1;
+        } else {
+            // GIL builds and 3.13 free-threaded: classic 2-bit interned bitfield.
+            kind    = (state_word >> 2) & 7;
+            compact = (state_word >> 5) & 1;
+        }
+
+        if (kind != 1) { // GCOV_EXCL_START
+            set_error(PYOBJECT, "Invalid PyASCIIObject kind");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        // Buffer for non-compact path: utf8_length[8] + utf8 pointer[8].
+        char    utf8_hdr[sizeof(ssize_t) + sizeof(raddr_t)];
+        raddr_t data;
+        if (compact) { // GCOV_EXCL_BR_LINE
+            data = p_ascii_data(raddr, py_v->py_unicode.ascii_size);
+        } else { // GCOV_EXCL_START
+            if (fail(
+                    copy_memory(pref, raddr + py_v->py_unicode.ascii_size + sizeof(ssize_t), sizeof(utf8_hdr), utf8_hdr)
+                ))
+                FAIL_PTR;
+            len  = *(ssize_t*)utf8_hdr;
+            data = *(raddr_t*)(utf8_hdr + sizeof(ssize_t));
+        } // GCOV_EXCL_STOP
+
+        if (!isvalid(data)) { // GCOV_EXCL_START
+            set_error(PYOBJECT, "Invalid PyASCIIObject data pointer");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        if (len < 0 || len > 4096) { // GCOV_EXCL_START
+            set_error(PYOBJECT, "Invalid string length");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        buffer = (char*)malloc(len + 1);
+        if (!isvalid(buffer)) { // GCOV_EXCL_START
+            set_error(MALLOC, "Cannot allocate memory for string buffer");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        if (fail(copy_memory(pref, data, len, buffer))) { // GCOV_EXCL_START
+            free(buffer);
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        buffer[len] = '\0';
+        return buffer;
+    }
+
+    // Legacy path for Python < 3.13: use hardcoded GIL struct layout.
+    PyUnicodeObject unicode;
     if (fail(copy_datatype(pref, raddr, unicode)))
         FAIL_PTR;
 
@@ -106,8 +177,6 @@ _string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
         FAIL_PTR;
     } // GCOV_EXCL_STOP
 
-    // Because changes to PyASCIIObject are rare, we handle the version manually
-    // instead of using a version offset descriptor.
     ssize_t ascii_size = V_MIN(3, 12) ? sizeof(unicode.v3_12._base._base) : sizeof(unicode.v3._base._base);
     raddr_t data       = ascii.state.compact ? p_ascii_data(raddr, ascii_size)
                                              : (V_MIN(3, 12) ? unicode.v3_12._base.utf8 : unicode.v3._base.utf8);
@@ -135,30 +204,32 @@ _string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
         FAIL_PTR;
     } // GCOV_EXCL_STOP
 
-    buffer[len] = '\0'; // Ensure null-termination
-
+    buffer[len] = '\0';
     return buffer;
 }
 
 // ----------------------------------------------------------------------------
 static inline unsigned char*
 _bytes_remote(proc_ref_t pref, raddr_t raddr, ssize_t* size, python_v* py_v) {
-    PyBytesObject  bytes = {0};
     ssize_t        len   = 0;
     unsigned char* array = NULL;
 
-    if (fail(copy_datatype(pref, raddr, bytes))) // GCOV_EXCL_LINE
-        FAIL_PTR;                                // GCOV_EXCL_LINE
+    // ob_size is at offset py_object_size (right after the PyObject header).
+    // In GIL builds: py_object_size=16, ob_size at 16.
+    // In free-threaded builds: py_object_size=32, ob_size at 32.
+    if (fail(copy_memory(pref, raddr + py_v->py_object_size, sizeof(ssize_t), &len))) // GCOV_EXCL_LINE
+        FAIL_PTR;                                                                     // GCOV_EXCL_LINE
+    len++;                                                                            // Include null-terminator
 
-    if ((len = bytes.ob_base.ob_size + 1) < 1) { // Include null-terminator // GCOV_EXCL_START
+    if (len < 1) { // GCOV_EXCL_START
         set_error(PYOBJECT, "PyBytesObject is too short");
         FAIL_PTR;
     } // GCOV_EXCL_STOP
 
-    if (len > (100 << 20)) { // 100MB
+    if (len > (100 << 20)) { // GCOV_EXCL_START
         set_error(PYOBJECT, "PyBytesObject size too big to be valid");
         FAIL_PTR;
-    }
+    } // GCOV_EXCL_STOP
 
     array = (unsigned char*)malloc((len + 1) * sizeof(unsigned char*));
     if (!isvalid(array)) { // GCOV_EXCL_START
@@ -166,10 +237,11 @@ _bytes_remote(proc_ref_t pref, raddr_t raddr, ssize_t* size, python_v* py_v) {
         FAIL_PTR;
     } // GCOV_EXCL_STOP
 
-    if (fail(copy_memory(pref, raddr + offsetof(PyBytesObject, ob_sval), len, array))) {
+    // ob_sval is at py_object_size + ob_size[8] + ob_shash[8] = py_object_size + 16
+    if (fail(copy_memory(pref, raddr + py_v->py_object_size + 16, len, array))) { // GCOV_EXCL_START
         free(array);
         FAIL_PTR;
-    }
+    } // GCOV_EXCL_STOP
 
     array[len] = 0;
     *size      = len - 1;

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -207,6 +207,10 @@ _py_thread__push_local_iframe(py_thread_t* self, void* iframe, raddr_t* prev) {
 
     raddr_t origin     = *prev;
     raddr_t code_raddr = V_FIELD_PTR(raddr_t, iframe, py_iframe, o_code);
+    // In free-threaded mode f_executable is a _PyStackRef tagged pointer;
+    // the actual PyObject* is stored in the low bits with Py_TAG_BITS (0x3) masked in.
+    if (self->proc->free_threaded)
+        code_raddr = (raddr_t)((uintptr_t)code_raddr & ~(uintptr_t)3);
 
     *prev = V_FIELD_PTR(raddr_t, iframe, py_iframe, o_previous);
     if (unlikely(origin == *prev)) {
@@ -223,11 +227,45 @@ _py_thread__push_local_iframe(py_thread_t* self, void* iframe, raddr_t* prev) {
         SUCCESS;
     }
 
-    stack_py_push(
-        origin, code_raddr,
-        (((int)(V_FIELD_PTR(raddr_t, iframe, py_iframe, o_prev_instr) - code_raddr)) - py_v->py_code.o_code)
-            / sizeof(_Py_CODEUNIT)
-    );
+    raddr_t instr_ptr = V_FIELD_PTR(raddr_t, iframe, py_iframe, o_prev_instr);
+    int     lasti     = 0;
+
+    // In free-threaded Python 3.14+, instr_ptr points into a thread-local bytecode
+    // copy (TLBC).  Compute lasti relative to the correct TLBC entry base, not
+    // co_code_adaptive, so that line-number resolution is accurate for all threads.
+    if (py_v->py_iframe.o_tlbc_index && py_v->py_code.o_tlbc) {
+        int32_t tlbc_idx = V_FIELD_PTR(int32_t, iframe, py_iframe, o_tlbc_index);
+        if (tlbc_idx > 0) {
+            // Try the code cache first — _code_remote already extracts co_tlbc from
+            // the code object buffer it reads, so hot functions cost 0 reads here.
+            code_t* cached_code   = lru_cache__maybe_hit(self->proc->code_cache, (key_dt)code_raddr);
+            raddr_t co_tlbc_raddr = cached_code ? cached_code->co_tlbc_raddr : NULL;
+
+            if (!isvalid(co_tlbc_raddr)) { // GCOV_EXCL_BR_LINE
+                // Cache miss (first encounter): read co_tlbc from the code object.
+                copy_memory(self->proc->ref, code_raddr + py_v->py_code.o_tlbc, sizeof(co_tlbc_raddr), &co_tlbc_raddr);
+            }
+
+            if (isvalid(co_tlbc_raddr)) { // GCOV_EXCL_BR_LINE
+                // _PyCodeArray: { Py_ssize_t size; char *entries[1]; }
+                // entries start at offset sizeof(Py_ssize_t) = 8.
+                raddr_t tlbc_base = NULL;
+                if (success(copy_memory(
+                        self->proc->ref, co_tlbc_raddr + sizeof(ssize_t) + (ssize_t)tlbc_idx * (ssize_t)sizeof(raddr_t),
+                        sizeof(tlbc_base), &tlbc_base
+                    ))
+                    && isvalid(tlbc_base)) { // GCOV_EXCL_BR_LINE
+                    lasti = (int)(instr_ptr - tlbc_base) / (int)sizeof(_Py_CODEUNIT);
+                    goto push_frame;
+                }
+            }
+        }
+    }
+
+    lasti = (((int)(instr_ptr - code_raddr)) - (int)py_v->py_code.o_code) / (int)sizeof(_Py_CODEUNIT);
+
+push_frame:
+    stack_py_push(origin, code_raddr, lasti);
 
     if (pargs_native && V_EQ(3, 11) && V_FIELD_PTR(int, iframe, py_iframe, o_is_entry)) {
         // This marks the end of a CFrame

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -247,8 +247,7 @@ _py_thread__push_local_iframe(py_thread_t* self, void* iframe, raddr_t* prev) {
             }
 
             if (isvalid(co_tlbc_raddr)) { // GCOV_EXCL_BR_LINE
-                // _PyCodeArray: { Py_ssize_t size; char *entries[1]; }
-                // entries start at offset sizeof(Py_ssize_t) = 8.
+                // _PyCodeArray entries start at offset sizeof(Py_ssize_t).
                 raddr_t tlbc_base = NULL;
                 if (success(copy_memory(
                         self->proc->ref, co_tlbc_raddr + sizeof(ssize_t) + (ssize_t)tlbc_idx * (ssize_t)sizeof(raddr_t),

--- a/src/version.h
+++ b/src/version.h
@@ -97,6 +97,7 @@ typedef struct {
     offset_t o_firstlineno;
     offset_t o_code;
     offset_t o_qualname;
+    offset_t o_tlbc; // offset of co_tlbc in PyCodeObject; 0 when not present (GIL/3.13)
 } py_code_v;
 
 typedef struct {
@@ -123,6 +124,7 @@ typedef struct {
     offset_t o_prev_instr;
     offset_t o_is_entry;
     offset_t o_owner;
+    offset_t o_tlbc_index; // offset of tlbc_index in frame; 0 when not present (GIL/3.13)
 } py_iframe_v;
 
 typedef struct {
@@ -163,6 +165,16 @@ typedef struct {
 } py_gc_v;
 
 typedef struct {
+    ssize_t  size;
+    ssize_t  ascii_size; // sizeof(PyASCIIObject) in target build
+    offset_t o_state;
+    offset_t o_length;
+    // True when PyUnicodeObject_state.interned is a full unsigned char (not 2-bit field).
+    // Introduced in CPython 3.14 free-threaded builds; changes kind/compact bit positions.
+    bool     ft_interned_byte;
+} py_unicode_v;
+
+typedef struct {
     py_code_v    py_code;
     py_frame_v   py_frame;
     py_thread_v  py_thread;
@@ -171,10 +183,16 @@ typedef struct {
     py_gc_v      py_gc;
     py_cframe_v  py_cframe;
     py_iframe_v  py_iframe;
+    py_unicode_v py_unicode;
 
     int major;
     int minor;
     int patch;
+
+    // Size of PyObject header in the target build.  16 in GIL builds,
+    // 32 in free-threaded builds (biased refcounting adds ob_tid + extra fields).
+    // Used to compute ob_size / string-data offsets without hardcoding the GIL layout.
+    ssize_t py_object_size;
 } python_v;
 
 #ifdef PY_PROC_C
@@ -350,6 +368,12 @@ get_version_descriptor(int major, int minor, int patch) {
         py_v->major = major;
         py_v->minor = minor;
         py_v->patch = patch;
+
+        // Default to the standard GIL PyObject header size. For Python 3.13+
+        // init_version_descriptor() reads the actual size from the debug
+        // offsets and overwrites this, handling free-threaded builds
+        // transparently.
+        py_v->py_object_size = sizeof(PyObject);
     }
 
     if (!isvalid(py_v)) { // GCOV_EXCL_START
@@ -378,6 +402,12 @@ get_version_descriptor(int major, int minor, int patch) {
         V_ASSIGN(v, code.o_qualname, code_object.qualname);       \
     }
 
+#define PY_CODE_314(v)                                 \
+    {                                                  \
+        PY_CODE_313(v);                                \
+        V_ASSIGN(v, code.o_tlbc, code_object.co_tlbc); \
+    }
+
 #define PY_IFRAME_313(v)                                               \
     {                                                                  \
         V_ASSIGN(v, iframe.size, interpreter_frame.size);              \
@@ -385,6 +415,12 @@ get_version_descriptor(int major, int minor, int patch) {
         V_ASSIGN(v, iframe.o_code, interpreter_frame.executable);      \
         V_ASSIGN(v, iframe.o_prev_instr, interpreter_frame.instr_ptr); \
         V_ASSIGN(v, iframe.o_owner, interpreter_frame.owner);          \
+    }
+
+#define PY_IFRAME_314(v)                                                \
+    {                                                                   \
+        PY_IFRAME_313(v);                                               \
+        V_ASSIGN(v, iframe.o_tlbc_index, interpreter_frame.tlbc_index); \
     }
 
 #define PY_THREAD_313(v)                                                       \
@@ -428,6 +464,22 @@ get_version_descriptor(int major, int minor, int patch) {
         V_ASSIGN(v, gc.o_collecting, gc.collecting); \
     }
 
+#define PY_UNICODE_313(ver)                                                 \
+    {                                                                       \
+        V_ASSIGN(ver, unicode.size, unicode_object.size);                   \
+        V_ASSIGN(ver, unicode.ascii_size, unicode_object.asciiobject_size); \
+        V_ASSIGN(ver, unicode.o_state, unicode_object.state);               \
+        V_ASSIGN(ver, unicode.o_length, unicode_object.length);             \
+    }
+
+// In free-threaded 3.14+, PyUnicodeObject_state.interned became a full
+// unsigned char rather than a 2-bit field, shifting kind/compact bit positions.
+#define PY_UNICODE_314(ver)                                                  \
+    {                                                                        \
+        PY_UNICODE_313(ver);                                                 \
+        py_v->py_unicode.ft_interned_byte = py_d->v##ver.pyobject.size > 16; \
+    }
+
 // ----------------------------------------------------------------------------
 static void
 init_version_descriptor(python_v* py_v, _Py_DebugOffsets* py_d) {
@@ -439,15 +491,19 @@ init_version_descriptor(python_v* py_v, _Py_DebugOffsets* py_d) {
         PY_RUNTIME_313(3_13);
         PY_IS_313(3_13);
         PY_GC_313(3_13);
+        PY_UNICODE_313(3_13);
+        py_v->py_object_size = py_d->v3_13.pyobject.size;
         break;
 
     case 14:
-        PY_CODE_313(3_14);
-        PY_IFRAME_313(3_14);
+        PY_CODE_314(3_14);
+        PY_IFRAME_314(3_14);
         PY_THREAD_313(3_14);
         PY_RUNTIME_313(3_14);
         PY_IS_314(3_14);
         PY_GC_313(3_14);
+        PY_UNICODE_314(3_14);
+        py_v->py_object_size = py_d->v3_14.pyobject.size;
         break;
 
     default:                                                                           // GCOV_EXCL_LINE

--- a/src/version.h
+++ b/src/version.h
@@ -169,13 +169,14 @@ typedef struct {
     ssize_t  ascii_size; // sizeof(PyASCIIObject) in target build
     offset_t o_state;
     offset_t o_length;
-    // True when PyUnicodeObject_state.interned is a full unsigned char (not 2-bit field).
-    // Introduced in CPython 3.14 free-threaded builds; changes kind/compact bit positions.
+    // True when PyUnicodeObject_state.interned is a full unsigned char (not
+    // 2-bit field). Introduced in CPython 3.14 free-threaded builds; changes
+    // kind/compact bit positions.
     bool     ft_interned_byte;
-    // Byte offset within _PyUnicodeObject_state to the word holding kind:3/compact:1.
-    // Probed lazily on first FT string read: GCC/Clang packs the bits at +1 (immediately
-    // after unsigned char interned); MSVC aligns unsigned int bitfields to +4.
-    // -1 means not yet probed.
+    // Byte offset within _PyUnicodeObject_state to the word holding
+    // kind:3/compact:1. Probed lazily on first FT string read: GCC/Clang packs
+    // the bits immediately after unsigned char interned; MSVC aligns unsigned
+    // int bitfields to +4. -1 means not yet probed.
     int      ft_state_kind_byte;
 } py_unicode_v;
 
@@ -194,9 +195,9 @@ typedef struct {
     int minor;
     int patch;
 
-    // Size of PyObject header in the target build.  16 in GIL builds,
-    // 32 in free-threaded builds (biased refcounting adds ob_tid + extra fields).
-    // Used to compute ob_size / string-data offsets without hardcoding the GIL layout.
+    // Size of PyObject header in the target build (biased refcounting adds
+    // ob_tid + extra fields). Used to compute ob_size / string-data offsets
+    // without hardcoding the GIL layout.
     ssize_t py_object_size;
 } python_v;
 

--- a/src/version.h
+++ b/src/version.h
@@ -172,6 +172,11 @@ typedef struct {
     // True when PyUnicodeObject_state.interned is a full unsigned char (not 2-bit field).
     // Introduced in CPython 3.14 free-threaded builds; changes kind/compact bit positions.
     bool     ft_interned_byte;
+    // Byte offset within _PyUnicodeObject_state to the word holding kind:3/compact:1.
+    // Probed lazily on first FT string read: GCC/Clang packs the bits at +1 (immediately
+    // after unsigned char interned); MSVC aligns unsigned int bitfields to +4.
+    // -1 means not yet probed.
+    int      ft_state_kind_byte;
 } py_unicode_v;
 
 typedef struct {
@@ -474,10 +479,11 @@ get_version_descriptor(int major, int minor, int patch) {
 
 // In free-threaded 3.14+, PyUnicodeObject_state.interned became a full
 // unsigned char rather than a 2-bit field, shifting kind/compact bit positions.
-#define PY_UNICODE_314(ver)                                                  \
-    {                                                                        \
-        PY_UNICODE_313(ver);                                                 \
-        py_v->py_unicode.ft_interned_byte = py_d->v##ver.pyobject.size > 16; \
+#define PY_UNICODE_314(ver)                                                         \
+    {                                                                               \
+        PY_UNICODE_313(ver);                                                        \
+        py_v->py_unicode.ft_interned_byte   = py_d->v##ver.pyobject.size > 16;      \
+        py_v->py_unicode.ft_state_kind_byte = -1; /* probed on first string read */ \
     }
 
 // ----------------------------------------------------------------------------

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,11 +4,15 @@ import platform
 PY3_EARLIEST = 9
 PY3_LATEST = 14
 
+
+def _ver_tuple(v: str) -> tuple[int, ...]:
+    """Parse '3.13' or '3.13t' into a numeric tuple for comparison."""
+    return tuple(int(x.rstrip("t")) for x in v.split("."))
+
+
 try:
-    REQUESTED_PYTHON_VERSIONS = [
-        tuple(int(_) for _ in v.split("."))
-        for v in os.getenv("AUSTIN_TESTS_PYTHON_VERSIONS", "").split(",")
-    ]
+    raw = os.getenv("AUSTIN_TESTS_PYTHON_VERSIONS", "").split(",")
+    REQUESTED_PYTHON_VERSIONS = [v.strip() for v in raw if v.strip()] or None
 except Exception:
     REQUESTED_PYTHON_VERSIONS = None
 
@@ -16,9 +20,9 @@ except Exception:
 match platform.system():
     case "Darwin":
         PYTHON_VERSIONS = REQUESTED_PYTHON_VERSIONS or [
-            (3, _) for _ in range(PY3_EARLIEST, PY3_LATEST + 1)
+            f"3.{_}" for _ in range(PY3_EARLIEST, PY3_LATEST + 1)
         ]
     case _:
         PYTHON_VERSIONS = REQUESTED_PYTHON_VERSIONS or [
-            (3, _) for _ in range(PY3_EARLIEST, PY3_LATEST + 1)
+            f"3.{_}" for _ in range(PY3_EARLIEST, PY3_LATEST + 1)
         ]

--- a/test/functional/test_fork.py
+++ b/test/functional/test_fork.py
@@ -30,6 +30,7 @@ from test.utils import austin
 from test.utils import parse_mojo
 from test.utils import has_frame
 from test.utils import maps
+from test.utils import version_in
 from test.utils import processes
 from test.utils import python
 from test.utils import sum_full_metrics
@@ -46,7 +47,9 @@ import pytest
 @variants
 def test_fork_wall_time(austin, py):
     result = austin("-i", "2ms", *python(py), target("target34.py"))
-    assert py in (result.stderr or result.stdout), result.stderr or result.stdout
+    assert version_in(py, result.stderr or result.stdout), (
+        result.stderr or result.stdout
+    )
 
     assert len(processes(result.samples)) == 1
     ts = threads(result.samples)
@@ -112,6 +115,10 @@ def test_fork_cpu_time_idle(py, austin):
 @pytest.mark.parametrize("args", ("-m", "-cm"))
 @allpythons()
 def test_fork_memory(py, args):
+    if py.endswith("t"):
+        pytest.skip(
+            "Memory mode requires the GIL; not supported for free-threaded Python"
+        )
     result = austin(args, "-i", "1ms", *python(py), target("target34.py"))
     assert result.returncode == 0, result.stderr or result.stdout
 
@@ -176,7 +183,9 @@ def test_fork_multiprocess(py):
 @allpythons()
 def test_fork_full_metrics(py):
     result = austin("-i", "10ms", "-f", *python(py), target("target34.py"))
-    assert py in (result.stderr or result.stdout), result.stderr or result.stdout
+    assert version_in(py, result.stderr or result.stdout), (
+        result.stderr or result.stdout
+    )
 
     assert len(processes(result.samples)) == 1
     ts = threads(result.samples)
@@ -194,7 +203,9 @@ def test_fork_full_metrics(py):
 
     assert 0 < 0.9 * d < wall < 2.1 * d
     assert 0 < cpu <= wall
-    assert alloc * dealloc
+    if not py.endswith("t"):
+        # Memory tracking requires the GIL; free-threaded Python always yields 0 deltas.
+        assert alloc * dealloc
 
 
 @pytest.mark.parametrize("exposure", (1, 2))
@@ -227,7 +238,9 @@ def test_fork_exposure(py, exposure, children):
 @allpythons(min=(3, 11))
 def test_qualnames(py, austin):
     result = austin("-i", "1ms", *python(py), target("qualnames.py"))
-    assert py in (result.stderr or result.stdout), result.stderr or result.stdout
+    assert version_in(py, result.stderr or result.stdout), (
+        result.stderr or result.stdout
+    )
 
     assert len(processes(result.samples)) == 1
     ts = threads(result.samples)
@@ -291,7 +304,9 @@ def test_fork_int_signal(py):
 @variants
 def test_fork_exec(austin, py, children):
     result = austin("-i", "2ms", *children, *python(py), target("target_exec.py"))
-    assert py in (result.stderr or result.stdout), result.stderr or result.stdout
+    assert version_in(py, result.stderr or result.stdout), (
+        result.stderr or result.stdout
+    )
 
     assert len(processes(result.samples)) == 1
     ts = threads(result.samples)

--- a/test/functional/test_gc.py
+++ b/test/functional/test_gc.py
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+
 from test.utils import allpythons
 from test.utils import austin
 from test.utils import python
@@ -48,6 +50,11 @@ def test_gc_on(py):
 
 @allpythons()
 def test_gc_disabled(py, monkeypatch):
+    if py.endswith("t"):
+        pytest.xfail(
+            "Free-threaded Python uses an incremental GC that ignores gc.disable()"
+        )
+
     monkeypatch.setenv("GC_DISABLED", "1")
 
     result = austin("-gi", "10ms", *python(py), target("target_gc.py"))

--- a/test/functional/test_native.py
+++ b/test/functional/test_native.py
@@ -256,8 +256,9 @@ def test_native_does_not_affect_cpu_time_linux(py):
     cpu_total, _ = sum_metrics(cpu.samples)
 
     # CPU time must be strictly less than wall time for a target that does
-    # real sleep: the idle periods should be filtered out.
-    assert cpu_total < wall_total, (
-        f"CPU total ({cpu_total}) should be less than wall total ({wall_total}): "
-        "idle threads may not be filtered correctly"
-    )
+    # real sleep with the GIL: the idle periods should be filtered out.
+    if not py.endswith("t"):
+        assert cpu_total < wall_total, (
+            f"CPU total ({cpu_total}) should be less than wall total ({wall_total}): "
+            "idle threads may not be filtered correctly"
+        )

--- a/test/functional/test_pipe.py
+++ b/test/functional/test_pipe.py
@@ -30,6 +30,7 @@ from test.utils import python
 from test.utils import sum_metrics
 from test.utils import target
 from test.utils import threads
+from test.utils import version_in
 
 
 @allpythons()
@@ -40,7 +41,7 @@ def test_pipe_wall_time(py):
 
     meta = result.metadata
 
-    assert meta["python"].startswith(py), meta
+    assert version_in(py, meta["python"]), meta
     assert meta["mode"] == "wall", meta
     assert int(meta["duration"]) > 100000, meta
     assert meta["interval"] == str(interval * 1000), meta
@@ -65,7 +66,7 @@ def test_pipe_cpu_time(py):
 
     meta = result.metadata
 
-    assert meta["python"].startswith(py), meta
+    assert version_in(py, meta["python"]), meta
     assert meta["mode"] == "cpu", meta
     assert int(meta["duration"]) > 100000, meta
     assert meta["interval"] == "1000", meta
@@ -82,7 +83,7 @@ def test_pipe_wall_time_multiprocess(py):
     assert int(meta["duration"]) > 100000, meta
     assert meta["interval"] == "1000", meta
     assert meta["multiprocess"] == "on", meta
-    assert meta["python"].startswith(py), meta
+    assert version_in(py, meta["python"]), meta
 
 
 @allpythons()
@@ -97,7 +98,7 @@ def test_pipe_wall_time_multiprocess_output(py, tmp_path):
     assert int(meta["duration"]) > 100000, meta
     assert meta["interval"] == "1000", meta
     assert meta["multiprocess"] == "on", meta
-    assert meta["python"].startswith(py), meta
+    assert version_in(py, meta["python"]), meta
 
 
 @allpythons(min=(3, 11))
@@ -118,7 +119,9 @@ def test_python_version(py):
         )
     )
 
-    assert reported_version == actual_version, meta
+    suffix = "t" if py.endswith("t") else ""
+
+    assert reported_version == actual_version + suffix, meta
 
 
 # TODO: Test TTY behaviour

--- a/test/utils.py
+++ b/test/utils.py
@@ -40,6 +40,7 @@ from subprocess import TimeoutExpired
 from subprocess import check_output
 from tempfile import gettempdir
 from test import PYTHON_VERSIONS
+from test import _ver_tuple
 from time import sleep
 from types import FrameType
 from types import ModuleType
@@ -70,16 +71,29 @@ def target(name: str = "target34.py") -> str:
     return str(HERE / "targets" / name)
 
 
+def version_in(py: str, text: str) -> bool:
+    """Check whether Austin's version output for `py` appears in `text`.
+
+    Austin emits the full patch version, e.g. '3.13.13t' for py='3.13t' or
+    '3.13.1' for py='3.13'. For free-threaded builds the 't' suffix is
+    appended after the patch number, so a simple substring search won't work.
+    """
+    import re
+
+    base = py.rstrip("t")
+    ft = py.endswith("t")
+    pattern = re.escape(base) + r"\.\d+" + ("t" if ft else "")
+    return bool(re.search(pattern, text))
+
+
 def allpythons(min=None, max=None):
     def _(f):
         versions = PYTHON_VERSIONS
         if min is not None:
-            versions = [_ for _ in versions if _ >= min]
+            versions = [v for v in versions if _ver_tuple(v) >= min]
         if max is not None:
-            versions = [_ for _ in versions if _ <= max]
-        return pytest.mark.parametrize(
-            "py", [".".join([str(_) for _ in v]) for v in versions]
-        )(f)
+            versions = [v for v in versions if _ver_tuple(v) <= max]
+        return pytest.mark.parametrize("py", versions)(f)
 
     return _
 


### PR DESCRIPTION
We add support for the recent experimental free-threaded builds described in [PEP-703](https://peps.python.org/pep-0703/). This includes both 3.13t and 3.14t at the moment.