### PR TITLE
perf: per-tlbc generation code array caching

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -37,6 +37,9 @@ typedef struct {
     size_t           line_table_size;
     unsigned int     first_line_number;
     raddr_t          co_tlbc_raddr; // cached _PyCodeArray* for TLBC (3.14+ FT); NULL otherwise
+    raddr_t*         tlbc_entries;  // snapshot of _PyCodeArray.entries; NULL until first read
+    ssize_t          tlbc_count;    // number of entries in the snapshot
+    uint64_t         tlbc_gen;      // tlbc_generation at which the snapshot was taken
 } code_t;
 
 // ----------------------------------------------------------------------------
@@ -57,6 +60,9 @@ code_new(
     code->line_table_size   = line_table_size;
     code->first_line_number = first_line_number;
     code->co_tlbc_raddr     = co_tlbc_raddr;
+    code->tlbc_entries      = NULL;
+    code->tlbc_count        = 0;
+    code->tlbc_gen          = 0;
 
     return code;
 }
@@ -69,6 +75,7 @@ code__destroy(code_t* self) {
     }
 
     sfree(self->line_table);
+    sfree(self->tlbc_entries);
 
     free(self);
 }

--- a/src/py_interp.h
+++ b/src/py_interp.h
@@ -36,6 +36,7 @@
 typedef struct _interpreter_state {
     int64_t  id;
     uint64_t code_object_gen;
+    uint64_t tlbc_gen;
 } interpreter_state_t;
 
 // ----------------------------------------------------------------------------
@@ -49,6 +50,7 @@ interpreter_state_new(int64_t id, uint64_t code_object_gen) {
 
     state->id              = id;
     state->code_object_gen = code_object_gen;
+    state->tlbc_gen        = 0;
 
     return state;
 }

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1239,6 +1239,11 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
             ))
             FAIL; // GCOV_EXCL_LINE
 
+        uint64_t tlbc_gen = 0;
+        if (py_v->py_is.o_tlbc_generation) {
+            _py_proc__get_interpreter_state_field(self, interp, tlbc_generation, tlbc_gen);
+        }
+
         key_dt               key                    = interpreter_state_key(interp_id);
         interpreter_state_t* interpreter_state_info = lru_cache__maybe_hit(self->interpreter_state_cache, key);
         if (!isvalid(interpreter_state_info)) {
@@ -1268,6 +1273,12 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
             lru_cache__invalidate(self->code_cache);
 
             interpreter_state_info->code_object_gen = code_object_gen;
+        }
+
+        if (tlbc_gen != interpreter_state_info->tlbc_gen) {
+            log_d("TLBC generation changed from %lu to %lu", interpreter_state_info->tlbc_gen, tlbc_gen);
+            interpreter_state_info->tlbc_gen = tlbc_gen;
+            self->tlbc_generation            = tlbc_gen;
         }
     }
 

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -94,6 +94,8 @@ typedef struct {
 
     bool free_threaded;
 
+    uint64_t tlbc_generation; // current interpreter tlbc_generation (3.14+ FT)
+
 #ifdef PL_LINUX
 #ifdef AUSTINP
     struct _puw {

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -236,24 +236,57 @@ _py_thread__push_local_iframe(py_thread_t* self, void* iframe, raddr_t* prev) {
     if (py_v->py_iframe.o_tlbc_index && py_v->py_code.o_tlbc) {
         int32_t tlbc_idx = V_FIELD_PTR(int32_t, iframe, py_iframe, o_tlbc_index);
         if (tlbc_idx > 0) {
-            // Try the code cache first — _code_remote already extracts co_tlbc from
-            // the code object buffer it reads, so hot functions cost 0 reads here.
             code_t* cached_code   = lru_cache__maybe_hit(self->proc->code_cache, (key_dt)code_raddr);
             raddr_t co_tlbc_raddr = cached_code ? cached_code->co_tlbc_raddr : NULL;
 
             if (!isvalid(co_tlbc_raddr)) { // GCOV_EXCL_BR_LINE
-                // Cache miss (first encounter): read co_tlbc from the code object.
                 copy_memory(self->proc->ref, code_raddr + py_v->py_code.o_tlbc, sizeof(co_tlbc_raddr), &co_tlbc_raddr);
             }
 
             if (isvalid(co_tlbc_raddr)) { // GCOV_EXCL_BR_LINE
-                // _PyCodeArray entries start at offset sizeof(Py_ssize_t).
                 raddr_t tlbc_base = NULL;
-                if (success(copy_memory(
-                        self->proc->ref, co_tlbc_raddr + sizeof(ssize_t) + (ssize_t)tlbc_idx * (ssize_t)sizeof(raddr_t),
-                        sizeof(tlbc_base), &tlbc_base
-                    ))
-                    && isvalid(tlbc_base)) { // GCOV_EXCL_BR_LINE
+
+                // Use the cached _PyCodeArray snapshot when the generation
+                // matches and the index is in range
+                uint64_t cur_tlbc_gen = self->proc->tlbc_generation;
+                if (cached_code && cached_code->tlbc_gen == cur_tlbc_gen && tlbc_idx < cached_code->tlbc_count) {
+                    tlbc_base = cached_code->tlbc_entries[tlbc_idx];
+                } else {
+                    // Read the full array header to get count, then all entries.
+                    ssize_t count = 0;
+                    if (success(copy_memory(self->proc->ref, co_tlbc_raddr, sizeof(count), &count))
+                        && count > 0) { // GCOV_EXCL_BR_LINE
+                        raddr_t* entries = (raddr_t*)malloc((size_t)count * sizeof(raddr_t));
+                        if (isvalid(entries)
+                            && success(copy_memory(
+                                self->proc->ref, co_tlbc_raddr + sizeof(ssize_t), (size_t)count * sizeof(raddr_t),
+                                entries
+                            ))) {
+                            if (tlbc_idx < count)
+                                tlbc_base = entries[tlbc_idx]; // cppcheck-suppress uninitdata
+                            if (cached_code) {
+                                sfree(cached_code->tlbc_entries);
+                                cached_code->tlbc_entries = entries;
+                                cached_code->tlbc_count   = count;
+                                cached_code->tlbc_gen     = cur_tlbc_gen;
+                            } else {
+                                free(entries);
+                            }
+                        } else {
+                            sfree(entries);
+                        }
+                    }
+                    // Fall back to single-entry read if array fetch failed.
+                    if (!isvalid(tlbc_base)) {
+                        copy_memory(
+                            self->proc->ref,
+                            co_tlbc_raddr + sizeof(ssize_t) + (ssize_t)tlbc_idx * (ssize_t)sizeof(raddr_t),
+                            sizeof(tlbc_base), &tlbc_base
+                        );
+                    }
+                }
+
+                if (isvalid(tlbc_base)) { // GCOV_EXCL_BR_LINE
                     lasti = (int)(instr_ptr - tlbc_base) / (int)sizeof(_Py_CODEUNIT);
                     goto push_frame;
                 }

--- a/src/version.h
+++ b/src/version.h
@@ -156,6 +156,7 @@ typedef struct {
     offset_t o_gc;
     offset_t o_gil_state;
     offset_t o_code_object_gen;
+    offset_t o_tlbc_generation;
 } py_is_v;
 
 typedef struct {
@@ -462,6 +463,7 @@ get_version_descriptor(int major, int minor, int patch) {
     {                                                                                \
         PY_IS_313(v);                                                                \
         V_ASSIGN(v, is.o_code_object_gen, interpreter_state.code_object_generation); \
+        V_ASSIGN(v, is.o_tlbc_generation, interpreter_state.tlbc_generation);        \
     }
 
 #define PY_GC_313(v)                                 \


### PR DESCRIPTION
We cache the tlbc code array snapshot to avoid re-reading when it has not mutated across samples. This saves us a few remote reads when we have a frame that we have not seen before that requires the computation of location information.