### PR TITLE
feat(native): unwind non-Python threads

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -53,9 +53,10 @@ mojo_event_handler__handle_stack_begin(base_event_handler_t* self, sample_t* sam
     else
         sprintf(thread_name, FORMAT_TID, sample->tid); // GCOV_EXCL_LINE
 
+    bool is_iid_negative = sample->iid < 0;
     mojo_event(MOJO_STACK);
     mojo_integer(sample->pid, 0);
-    mojo_integer(sample->iid, 0);
+    mojo_integer(is_iid_negative ? -sample->iid : sample->iid, is_iid_negative);
     mojo_string(thread_name);
 }
 

--- a/src/linux/py_thread.h
+++ b/src/linux/py_thread.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -133,6 +134,7 @@ py_thread__is_idle(py_thread_t* self) {
 
         return _tids_idle[index] & (1 << offset);
     }
+
     char file_name[64];
     char buffer[2048] = "";
 
@@ -794,6 +796,86 @@ _py_thread__unwind_native(py_thread_t* self, bool* error) {
         *error = true;
     }
 #endif
+}
+
+// ---- Non-Python thread sampling (native mode) ------------------------------
+
+// Interrupt all OS threads not already interrupted.  Best-effort: failures
+// are silently ignored so that the Python thread sweep is not affected.
+void
+py_thread__interrupt_os_threads(py_proc_t* proc) {
+    char task_dir[32];
+    snprintf(task_dir, sizeof(task_dir), "/proc/%d/task", proc->pid);
+
+    DIR* dir = opendir(task_dir);
+    if (!isvalid(dir))
+        return;
+
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != NULL) {
+        if (ent->d_name[0] == '.')
+            continue;
+
+        pid_t tid = (pid_t)strtol(ent->d_name, NULL, 10);
+        if (tid <= 0 || (size_t)tid >= max_pid)
+            continue;
+
+        if (_tids_int[tid >> 3] & (1 << (tid & 7)))
+            continue; // already interrupted by the Python thread sweep
+
+        py_thread_t thread = py_thread__init(proc);
+        thread.tid         = (uintptr_t)tid;
+        py_thread__interrupt(&thread); // best-effort
+    }
+    closedir(dir);
+}
+
+// Call fn(thread, userdata) for each interrupted thread that was not visited
+// during the Python thread sweep (i.e. has no PyThreadState).  Sets last_gen
+// on each visited tracker entry so the thread is not evicted after this sample.
+void
+py_thread__for_each_non_python(
+    py_proc_t* proc, thread_tracker_t* tracker, void (*fn)(py_thread_t*, void*), void* userdata
+) {
+    for (size_t i = 0; i < _int_n; i++) {
+        pid_t tid = _int_list[i];
+
+        if (!(_tids_int[tid >> 3] & (1 << (tid & 7))))
+            continue; // bit cleared; thread already resumed or invalid
+
+        thread_tracker_entry_t* entry = thread_tracker__get_or_create(tracker, (uintptr_t)tid);
+        if (!isvalid(entry))
+            continue;
+        if (entry->last_gen == tracker->sample_gen)
+            continue; // already sampled as a Python thread
+
+        entry->last_gen = tracker->sample_gen;
+
+        if (!entry->name[0]) {
+            char comm_path[64];
+            snprintf(comm_path, sizeof(comm_path), "/proc/%d/task/%d/comm", proc->pid, tid);
+            int fd = open(comm_path, O_RDONLY);
+            if (fd >= 0) {
+                char    comm[32];
+                ssize_t n = read(fd, comm, sizeof(comm) - 1);
+                close(fd);
+                if (n > 0) {
+                    if (comm[n - 1] == '\n')
+                        n--;
+                    comm[n] = '\0';
+                    snprintf(entry->name, sizeof(entry->name), "%s", comm);
+                    entry->name_state = NAME_RESOLVED;
+                }
+            }
+        }
+
+        // Synthetic py_thread_t: only .proc and .tid are populated.
+        // The unwinding and idle-check machinery needs nothing else for a
+        // thread that has no PyThreadState.
+        py_thread_t thread = py_thread__init(proc);
+        thread.tid         = (uintptr_t)tid;
+        fn(&thread, userdata);
+    }
 }
 
 // ---- Allocation/deallocation -----------------------------------------------

--- a/src/mac/py_thread.h
+++ b/src/mac/py_thread.h
@@ -518,6 +518,99 @@ _py_thread__unwind_native(py_thread_t* self, bool* error) {
     // state cannot change between _py_proc__interrupt_threads and now.
 }
 
+// ---- Non-Python thread sampling (native mode) ------------------------------
+
+// Interrupt all OS threads not already interrupted.  Uses a single task_threads
+// call and pre-caches each Mach port so _py_thread__seize does not need to call
+// task_threads again per thread.  Best-effort: failures are silently ignored.
+void
+py_thread__interrupt_os_threads(py_proc_t* proc) {
+    if (!_silly_offset)
+        return; // offset not yet inferred; cannot map thread_handle to tid key
+
+    thread_act_array_t     threads;
+    mach_msg_type_number_t count;
+    if (task_threads(proc->ref, &threads, &count) != KERN_SUCCESS)
+        return;
+
+    for (mach_msg_type_number_t i = 0; i < count; i++) {
+        thread_act_t port = threads[i];
+
+        thread_identifier_info_data_t info       = {0};
+        mach_msg_type_number_t        info_count = THREAD_IDENTIFIER_INFO_COUNT;
+        if (thread_info(port, THREAD_IDENTIFIER_INFO, (thread_info_t)&info, &info_count) != KERN_SUCCESS) {
+            mach_port_deallocate(mach_task_self(), port);
+            continue;
+        }
+
+        uintptr_t tid = (uintptr_t)info.thread_handle - _silly_offset;
+
+        if (isvalid(hash_table__get(_int, (key_dt)tid))) {
+            mach_port_deallocate(mach_task_self(), port);
+            continue; // already interrupted by the Python thread sweep
+        }
+
+        // Pre-cache the port so _py_thread__seize skips its own task_threads call.
+        if (!isvalid(hash_table__get(_ports, (key_dt)tid)))
+            hash_table__set(_ports, (key_dt)tid, (value_t)(uintptr_t)port);
+        else
+            mach_port_deallocate(mach_task_self(), port);
+
+        py_thread_t thread = py_thread__init(proc);
+        thread.tid         = tid;
+        py_thread__interrupt(&thread); // best-effort
+    }
+    vm_deallocate(mach_task_self(), (vm_address_t)threads, count * sizeof(thread_act_t));
+}
+
+// Call fn(thread, userdata) for each interrupted thread that was not visited
+// during the Python thread sweep.  Sets last_gen on each visited entry.
+void
+py_thread__for_each_non_python(
+    py_proc_t* proc, thread_tracker_t* tracker, void (*fn)(py_thread_t*, void*), void* userdata
+) {
+    key_dt interrupted[256];
+    int    n = 0;
+    hash_table__iteritems_start(_int, key_dt, _itid, void*, _sentinel) {
+        (void)_sentinel;
+        if (n < 256)
+            interrupted[n++] = _itid;
+    }
+    hash_table__iter_stop(_int);
+
+    for (int i = 0; i < n; i++) {
+        uintptr_t tid = (uintptr_t)interrupted[i];
+
+        thread_tracker_entry_t* entry = thread_tracker__get_or_create(tracker, tid);
+        if (!isvalid(entry))
+            continue;
+        if (entry->last_gen == tracker->sample_gen)
+            continue; // already sampled as a Python thread
+
+        entry->last_gen = tracker->sample_gen;
+
+        if (!entry->name[0]) {
+            thread_act_t port = (thread_act_t)(uintptr_t)hash_table__get(_ports, (key_dt)tid);
+            if (port != MACH_PORT_NULL) {
+                thread_extended_info_data_t einfo       = {0};
+                mach_msg_type_number_t      einfo_count = THREAD_EXTENDED_INFO_COUNT;
+                if (thread_info(port, THREAD_EXTENDED_INFO, (thread_info_t)&einfo, &einfo_count) == KERN_SUCCESS
+                    && einfo.pth_name[0]) {
+                    snprintf(entry->name, sizeof(entry->name), "%s", einfo.pth_name);
+                    entry->name_state = NAME_RESOLVED;
+                }
+            }
+        }
+
+        // Synthetic py_thread_t: only .proc and .tid are populated.
+        // The unwinding and idle-check machinery needs nothing else for a
+        // thread that has no PyThreadState.
+        py_thread_t thread = py_thread__init(proc);
+        thread.tid         = tid;
+        fn(&thread, userdata);
+    }
+}
+
 // ---- Allocation/deallocation -----------------------------------------------
 
 #define MAC_THREAD_TABLE_SIZE 256

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1367,7 +1367,14 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
 typedef struct {
     py_proc_t*     proc;
     microseconds_t time_delta;
+    bool           found; // set to true when at least one non-Python thread is sampled
 } _non_python_sample_ctx_t;
+
+// Target re-check window for the OS thread enumeration (microseconds).
+// When no non-Python threads were seen, we skip the scan until this much wall
+// time has elapsed — equivalent to (window / sampling_interval) samples.
+// Sampling intervals >= the window produce a value of 1 (check every sample).
+#define NON_PYTHON_SCAN_WINDOW_US 100000 // 100 ms
 
 // ----------------------------------------------------------------------------
 // Emit a single sample for a non-Python (native-only) thread.
@@ -1414,16 +1421,18 @@ _emit_non_python_thread_sample(py_thread_t* thread, void* userdata) {
 
     event_handler__emit_stack_end();
 
+    ctx->found = true;
     stats_count_sample();
 }
 
 // ----------------------------------------------------------------------------
 // Sample native stacks for every OS thread that was not covered by the Python
-// thread sweep.  No-op unless native mode is active.
+// thread sweep.  Updates self->has_non_python_threads for the next cycle.
 static inline void
 _py_proc__sample_non_python_threads(py_proc_t* self, microseconds_t time_delta) {
     _non_python_sample_ctx_t ctx = {.proc = self, .time_delta = time_delta};
     py_thread__for_each_non_python(self, self->thread_tracker, _emit_non_python_thread_sample, &ctx);
+    self->has_non_python_threads = ctx.found;
 }
 
 // ----------------------------------------------------------------------------
@@ -1434,7 +1443,9 @@ static inline int
 _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t time_delta) {
     V_DESC(self->py_v);
 
-    raddr_t tstate_head = NULL;
+    raddr_t tstate_head     = NULL;
+    bool    scan_non_python = false;
+
     if (fail(_py_proc__get_interpreter_state_field(self, interp, tstate_head, tstate_head))) // GCOV_EXCL_LINE
         FAIL;                                                                                // GCOV_EXCL_LINE
 
@@ -1451,13 +1462,21 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t tim
             FAIL;                                                   // GCOV_EXCL_LINE
         }
         // Extend the snapshot to non-Python OS threads (best-effort).
-        py_thread__interrupt_os_threads(self);
+        // Skip the expensive OS enumeration when the previous sweep found none
+        // and we have not yet reached the periodic re-check window (100 ms).
+        unsigned int scan_interval = (unsigned int)(NON_PYTHON_SCAN_WINDOW_US / pargs.t_sampling_interval);
+        if (scan_interval == 0)
+            scan_interval = 1;
+        scan_non_python = self->has_non_python_threads || self->sample_ticker % scan_interval == 0;
+        if (scan_non_python)
+            py_thread__interrupt_os_threads(self);
     }
 
     int result = _py_proc__sample_threads(self, interp, tstate_head, time_delta);
 
     // In native mode, also emit samples for threads with no PyThreadState.
-    if (pargs_native && success(result))
+    // Only needed when we ran the OS scan above.
+    if (pargs_native && success(result) && scan_non_python)
         _py_proc__sample_non_python_threads(self, time_delta);
 
     if (pargs_native)
@@ -1469,6 +1488,8 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t tim
 // ----------------------------------------------------------------------------
 int
 py_proc__sample(py_proc_t* self) {
+    self->sample_ticker++;
+
     raddr_t current_interp = self->istate_raddr;
 
     V_DESC(self->py_v);

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1367,13 +1367,14 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
 typedef struct {
     py_proc_t*     proc;
     microseconds_t time_delta;
-    bool           found; // set to true when at least one non-Python thread is sampled
+    uintptr_t      tids[MAX_THREAD_TRACKER]; // TIDs found this sweep, for cache update
+    int            n;
 } _non_python_sample_ctx_t;
 
-// Target re-check window for the OS thread enumeration (microseconds).
-// When no non-Python threads were seen, we skip the scan until this much wall
-// time has elapsed — equivalent to (window / sampling_interval) samples.
-// Sampling intervals >= the window produce a value of 1 (check every sample).
+// Full OS thread enumeration is capped at this interval so that the expensive
+// platform scan (e.g. CreateToolhelp32Snapshot) is amortised even when
+// non-Python threads are present.  Between scans, cached TIDs are re-interrupted
+// directly without enumerating all OS threads.
 #define NON_PYTHON_SCAN_WINDOW_US 100000 // 100 ms
 
 // ----------------------------------------------------------------------------
@@ -1387,6 +1388,11 @@ typedef struct {
 static void
 _emit_non_python_thread_sample(py_thread_t* thread, void* userdata) {
     _non_python_sample_ctx_t* ctx = (_non_python_sample_ctx_t*)userdata;
+
+    // Record TID in the cache regardless of idle/time filters so the fast
+    // re-interrupt path sees every non-Python thread next sample.
+    if (ctx->n < MAX_THREAD_TRACKER)
+        ctx->tids[ctx->n++] = thread->tid;
 
     bool is_idle = py_thread__is_idle(thread);
     if (!pargs.full && is_idle && pargs.cpu)
@@ -1421,18 +1427,18 @@ _emit_non_python_thread_sample(py_thread_t* thread, void* userdata) {
 
     event_handler__emit_stack_end();
 
-    ctx->found = true;
     stats_count_sample();
 }
 
 // ----------------------------------------------------------------------------
 // Sample native stacks for every OS thread that was not covered by the Python
-// thread sweep.  Updates self->has_non_python_threads for the next cycle.
+// thread sweep.  Updates the non-Python TID cache on py_proc_t.
 static inline void
 _py_proc__sample_non_python_threads(py_proc_t* self, microseconds_t time_delta) {
     _non_python_sample_ctx_t ctx = {.proc = self, .time_delta = time_delta};
     py_thread__for_each_non_python(self, self->thread_tracker, _emit_non_python_thread_sample, &ctx);
-    self->has_non_python_threads = ctx.found;
+    self->non_python_n = ctx.n;
+    memcpy(self->non_python_tids, ctx.tids, ctx.n * sizeof(uintptr_t));
 }
 
 // ----------------------------------------------------------------------------
@@ -1462,14 +1468,22 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t tim
             FAIL;                                                   // GCOV_EXCL_LINE
         }
         // Extend the snapshot to non-Python OS threads (best-effort).
-        // Skip the expensive OS enumeration when the previous sweep found none
-        // and we have not yet reached the periodic re-check window (100 ms).
-        unsigned int scan_interval = (unsigned int)(NON_PYTHON_SCAN_WINDOW_US / pargs.t_sampling_interval);
-        if (scan_interval == 0)
-            scan_interval = 1;
-        scan_non_python = self->has_non_python_threads || self->sample_ticker % scan_interval == 0;
-        if (scan_non_python)
+        // The full OS enumeration runs only when the deadline fires (every
+        // 100 ms).  Between deadline ticks, known non-Python TIDs are
+        // re-interrupted directly from the cache — no OS-wide scan needed.
+        microseconds_t now = gettime();
+        if (now >= self->non_python_scan_deadline) {
             py_thread__interrupt_os_threads(self);
+            self->non_python_scan_deadline = now + NON_PYTHON_SCAN_WINDOW_US;
+            scan_non_python                = true;
+        } else if (self->non_python_n > 0) {
+            for (int i = 0; i < self->non_python_n; i++) {
+                py_thread_t t = py_thread__init(self);
+                t.tid         = self->non_python_tids[i];
+                py_thread__interrupt(&t); // best-effort
+            }
+            scan_non_python = true;
+        }
     }
 
     int result = _py_proc__sample_threads(self, interp, tstate_head, time_delta);
@@ -1488,8 +1502,6 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t tim
 // ----------------------------------------------------------------------------
 int
 py_proc__sample(py_proc_t* self) {
-    self->sample_ticker++;
-
     raddr_t current_interp = self->istate_raddr;
 
     V_DESC(self->py_v);

--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1364,6 +1364,68 @@ _py_proc__sample_threads(py_proc_t* self, raddr_t interp, raddr_t tstate_head, m
     SUCCESS;
 } /* _py_proc__sample_threads */
 
+typedef struct {
+    py_proc_t*     proc;
+    microseconds_t time_delta;
+} _non_python_sample_ctx_t;
+
+// ----------------------------------------------------------------------------
+// Emit a single sample for a non-Python (native-only) thread.
+// Called by py_thread__for_each_non_python for every interrupted thread that
+// has no PyThreadState.
+//
+// `thread` is a synthetic py_thread_t with only .proc and .tid populated.
+// It carries exactly the information the native unwinding and idle-check
+// machinery needs; no Python-level fields (top_frame, stack, …) are set.
+static void
+_emit_non_python_thread_sample(py_thread_t* thread, void* userdata) {
+    _non_python_sample_ctx_t* ctx = (_non_python_sample_ctx_t*)userdata;
+
+    bool is_idle = py_thread__is_idle(thread);
+    if (!pargs.full && is_idle && pargs.cpu)
+        return;
+
+    if (ctx->time_delta == 0) // GCOV_EXCL_LINE
+        return;               // GCOV_EXCL_LINE
+
+    gc_state_t gc = GC_STATE_UNKNOWN;
+    if (pargs.gc) {
+        gc = py_proc__get_gc_state(ctx->proc);
+        if (gc == GC_STATE_COLLECTING)
+            stats_gc_time(ctx->time_delta);
+    }
+
+    thread_tracker_entry_t* tentry = thread_tracker__get_or_create(thread->proc->thread_tracker, thread->tid);
+    const char* thread_name        = (isvalid(tentry) && tentry->name[0]) ? tentry->name : NULL; // GCOV_EXCL_BR_LINE
+
+    sample_t sample = {
+        .pid         = ctx->proc->pid,
+        .tid         = thread->tid,
+        .iid         = -1, // no interpreter owns native-only threads
+        .time        = ctx->time_delta,
+        .memory      = 0, // non-Python threads never hold the GIL
+        .is_idle     = is_idle,
+        .gc_state    = gc,
+        .thread_name = thread_name,
+    };
+    event_handler__emit_stack_begin(&sample);
+
+    py_thread__unwind(thread);
+
+    event_handler__emit_stack_end();
+
+    stats_count_sample();
+}
+
+// ----------------------------------------------------------------------------
+// Sample native stacks for every OS thread that was not covered by the Python
+// thread sweep.  No-op unless native mode is active.
+static inline void
+_py_proc__sample_non_python_threads(py_proc_t* self, microseconds_t time_delta) {
+    _non_python_sample_ctx_t ctx = {.proc = self, .time_delta = time_delta};
+    py_thread__for_each_non_python(self, self->thread_tracker, _emit_non_python_thread_sample, &ctx);
+}
+
 // ----------------------------------------------------------------------------
 // Orchestrate a single interpreter sample: read the thread state head,
 // interrupt all threads (native mode), sample, then resume.
@@ -1388,9 +1450,15 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t tim
             py_thread__resume_all_interrupted();                    // GCOV_EXCL_LINE
             FAIL;                                                   // GCOV_EXCL_LINE
         }
+        // Extend the snapshot to non-Python OS threads (best-effort).
+        py_thread__interrupt_os_threads(self);
     }
 
     int result = _py_proc__sample_threads(self, interp, tstate_head, time_delta);
+
+    // In native mode, also emit samples for threads with no PyThreadState.
+    if (pargs_native && success(result))
+        _py_proc__sample_non_python_threads(self, time_delta);
 
     if (pargs_native)
         py_thread__resume_all_interrupted();

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -96,6 +96,11 @@ typedef struct {
 
     bool free_threaded;
 
+    // Non-Python thread sampling: track whether any were found last sweep so
+    // we can skip the expensive OS thread enumeration on pure-Python processes.
+    bool         has_non_python_threads;
+    unsigned int sample_ticker;
+
     uint64_t tlbc_generation; // current interpreter tlbc_generation (3.14+ FT)
 
 #ifdef PL_LINUX

--- a/src/py_proc.h
+++ b/src/py_proc.h
@@ -96,10 +96,15 @@ typedef struct {
 
     bool free_threaded;
 
-    // Non-Python thread sampling: track whether any were found last sweep so
-    // we can skip the expensive OS thread enumeration on pure-Python processes.
-    bool         has_non_python_threads;
-    unsigned int sample_ticker;
+    // Non-Python thread sampling.
+    //
+    // The full OS thread enumeration (e.g. CreateToolhelp32Snapshot on Windows)
+    // is expensive and only runs when non_python_scan_deadline is reached.
+    // Between scans, known non-Python TIDs are re-interrupted directly from the
+    // cache, avoiding the enumeration entirely.
+    microseconds_t non_python_scan_deadline;
+    uintptr_t      non_python_tids[MAX_THREAD_TRACKER];
+    int            non_python_n;
 
     uint64_t tlbc_generation; // current interpreter tlbc_generation (3.14+ FT)
 

--- a/src/py_thread.h
+++ b/src/py_thread.h
@@ -123,3 +123,15 @@ py_thread__is_idle(py_thread_t*);
 
 int
 py_thread__interrupt(py_thread_t*);
+
+// Interrupt all OS threads in the process not already interrupted (native mode,
+// best-effort).  Must be called after py_thread__interrupt has been called for
+// each Python thread so that platform state (e.g. _silly_offset) is ready.
+void
+py_thread__interrupt_os_threads(py_proc_t*);
+
+// Call fn(thread, userdata) for every thread interrupted this sample that has
+// no PyThreadState (i.e. was not visited during the Python thread sweep).
+// Sets last_gen on each visited tracker entry.
+void
+py_thread__for_each_non_python(py_proc_t*, thread_tracker_t*, void (*)(py_thread_t*, void*), void*);

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <Ntstatus.h>
+#include <tlhelp32.h>
 #include <winternl.h>
 
 #include "../argparse.h"
@@ -516,6 +517,85 @@ _py_thread__unwind_native(py_thread_t* self, bool* error) {
 // ---- Allocation/deallocation -----------------------------------------------
 
 #define WIN_THREAD_TABLE_SIZE 256
+
+// ---- Non-Python thread sampling (native mode) ------------------------------
+
+// Interrupt all OS threads in the target process not already interrupted.
+// Best-effort: failures are silently ignored.
+void
+py_thread__interrupt_os_threads(py_proc_t* proc) {
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+    if (snap == INVALID_HANDLE_VALUE)
+        return;
+
+    THREADENTRY32 entry = {.dwSize = sizeof(entry)};
+    if (!Thread32First(snap, &entry)) {
+        CloseHandle(snap);
+        return;
+    }
+
+    do {
+        if (entry.th32OwnerProcessID != (DWORD)proc->pid)
+            continue;
+
+        uintptr_t tid = (uintptr_t)entry.th32ThreadID;
+        if (isvalid(hash_table__get(_int, (key_dt)tid)))
+            continue; // already interrupted by the Python thread sweep
+
+        py_thread_t thread = py_thread__init(proc);
+        thread.tid         = tid;
+        py_thread__interrupt(&thread); // best-effort
+    } while (Thread32Next(snap, &entry));
+
+    CloseHandle(snap);
+}
+
+// Call fn(thread, userdata) for each interrupted thread that was not visited
+// during the Python thread sweep.  Sets last_gen on each visited entry.
+void
+py_thread__for_each_non_python(
+    py_proc_t* proc, thread_tracker_t* tracker, void (*fn)(py_thread_t*, void*), void* userdata
+) {
+    key_dt interrupted[256];
+    int    n = 0;
+    hash_table__iteritems_start(_int, key_dt, _itid, void*, _sentinel) {
+        (void)_sentinel;
+        if (n < 256)
+            interrupted[n++] = _itid;
+    }
+    hash_table__iter_stop(_int);
+
+    for (int i = 0; i < n; i++) {
+        uintptr_t tid = (uintptr_t)interrupted[i];
+
+        thread_tracker_entry_t* entry = thread_tracker__get_or_create(tracker, tid);
+        if (!isvalid(entry))
+            continue;
+        if (entry->last_gen == tracker->sample_gen)
+            continue; // already sampled as a Python thread
+
+        entry->last_gen = tracker->sample_gen;
+
+        if (!entry->name[0]) {
+            HANDLE h = (HANDLE)hash_table__get(_handles, (key_dt)tid);
+            if (isvalid(h)) {
+                PWSTR wname = NULL;
+                if (SUCCEEDED(GetThreadDescription(h, &wname)) && wname && wname[0]) {
+                    WideCharToMultiByte(CP_UTF8, 0, wname, -1, entry->name, sizeof(entry->name), NULL, NULL);
+                    entry->name_state = NAME_RESOLVED;
+                    LocalFree(wname);
+                }
+            }
+        }
+
+        // Synthetic py_thread_t: only .proc and .tid are populated.
+        // The unwinding and idle-check machinery needs nothing else for a
+        // thread that has no PyThreadState.
+        py_thread_t thread = py_thread__init(proc);
+        thread.tid         = tid;
+        fn(&thread, userdata);
+    }
+}
 
 static int
 _py_thread_allocate_native(void) {

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <Ntstatus.h>
-#include <tlhelp32.h>
 #include <winternl.h>
 
 #include "../argparse.h"
@@ -520,34 +519,56 @@ _py_thread__unwind_native(py_thread_t* self, bool* error) {
 
 // ---- Non-Python thread sampling (native mode) ------------------------------
 
+// Populate _pi_buffer via NtQuerySystemInformation and return a pointer to
+// the SYSTEM_PROCESS_INFORMATION entry for proc->pid, or NULL on failure.
+// Grows _pi_buffer as needed (same pattern as py_thread__is_idle).
+static SYSTEM_PROCESS_INFORMATION*
+_find_process_info(py_proc_t* proc) {
+    for (;;) {
+        ULONG    n;
+        NTSTATUS status = NtQuerySystemInformation(SystemProcessInformation, _pi_buffer, _pi_buffer_size, &n);
+        if (status == STATUS_INFO_LENGTH_MISMATCH) {
+            _pi_buffer_size = n;
+            PVOID buf       = realloc(_pi_buffer, n);
+            if (!isvalid(buf))
+                return NULL;
+            _pi_buffer = buf;
+            continue;
+        }
+        if (status != STATUS_SUCCESS)
+            return NULL;
+        break;
+    }
+
+    SYSTEM_PROCESS_INFORMATION* pi = (SYSTEM_PROCESS_INFORMATION*)_pi_buffer;
+    while (pi->UniqueProcessId != (HANDLE)proc->pid) {
+        if (pi->NextEntryOffset == 0)
+            return NULL;
+        pi = (SYSTEM_PROCESS_INFORMATION*)(((BYTE*)pi) + pi->NextEntryOffset);
+    }
+    return pi;
+}
+
 // Interrupt all OS threads in the target process not already interrupted.
+// Uses NtQuerySystemInformation (reuses _pi_buffer) rather than a system-wide
+// Toolhelp snapshot, which only enumerates the target process's threads.
 // Best-effort: failures are silently ignored.
 void
 py_thread__interrupt_os_threads(py_proc_t* proc) {
-    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
-    if (snap == INVALID_HANDLE_VALUE)
+    SYSTEM_PROCESS_INFORMATION* pi = _find_process_info(proc);
+    if (!isvalid(pi))
         return;
 
-    THREADENTRY32 entry = {.dwSize = sizeof(entry)};
-    if (!Thread32First(snap, &entry)) {
-        CloseHandle(snap);
-        return;
-    }
-
-    do {
-        if (entry.th32OwnerProcessID != (DWORD)proc->pid)
-            continue;
-
-        uintptr_t tid = (uintptr_t)entry.th32ThreadID;
+    SYSTEM_THREADS* ti = (SYSTEM_THREADS*)((char*)pi + sizeof(SYSTEM_PROCESS_INFORMATION));
+    for (ULONG i = 0; i < pi->NumberOfThreads; i++, ti++) {
+        uintptr_t tid = (uintptr_t)ti->ClientId.UniqueThread;
         if (isvalid(hash_table__get(_int, (key_dt)tid)))
             continue; // already interrupted by the Python thread sweep
 
         py_thread_t thread = py_thread__init(proc);
         thread.tid         = tid;
         py_thread__interrupt(&thread); // best-effort
-    } while (Thread32Next(snap, &entry));
-
-    CloseHandle(snap);
+    }
 }
 
 // Call fn(thread, userdata) for each interrupted thread that was not visited

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,62 @@ _MOJO_DIR = (
     if "AUSTIN_MOJO_DIR" in os.environ
     else Path("test-profiles") / str(_uid)
 )
+
+
+_NATIVE_EXT_SRC = Path(__file__).parent.parent / "native"
+
+_installed_for: set[str] = set()
+
+
+def _python_exe(py: str) -> list[str] | None:
+    """Return the argv prefix for the given Python version, or None if not found.
+
+    Mirrors the platform-specific logic in test.utils.python() so that
+    Windows (py launcher) and POSIX (pythonX.Y) are both handled correctly.
+    """
+    import platform as _platform
+    from subprocess import check_output, STDOUT, CalledProcessError
+
+    if _platform.system() == "Windows":
+        cmd = ["py", f"-{py}"]
+    else:
+        cmd = [f"python{py}"]
+
+    try:
+        check_output([*cmd, "-V"], stderr=STDOUT)
+        return cmd
+    except (FileNotFoundError, CalledProcessError):
+        return None
+
+
+def install_native_ext(py: str) -> None:
+    """Install test/native/ into the given Python version's site-packages.
+
+    Uses pip install to build and install the native_ext C extension.
+    Results are cached per Python version for the duration of the process.
+    """
+    if py in _installed_for:
+        return
+    cmd = _python_exe(py)
+    if cmd is None:
+        return
+    subprocess.run(
+        [*cmd, "-m", "pip", "install", "--quiet", str(_NATIVE_EXT_SRC)],
+        check=True,
+    )
+    _installed_for.add(py)
+
+
+@pytest.fixture
+def native_ext(request):
+    """Build and install native_ext for the Python version under test.
+
+    Reads the ``py`` parametrize value from the current test node and calls
+    ``install_native_ext`` so the C extension is available when the target
+    script runs.  Results are cached per Python version for the process lifetime.
+    """
+    py = request.node.callspec.params["py"]
+    install_native_ext(py)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/test/functional/test_native.py
+++ b/test/functional/test_native.py
@@ -32,6 +32,7 @@ from test.utils import requires_sudo
 from test.utils import run_python
 from test.utils import sum_metrics
 from test.utils import target
+from test.utils import threads
 from time import sleep
 
 import pytest
@@ -262,3 +263,37 @@ def test_native_does_not_affect_cpu_time_linux(py):
             f"CPU total ({cpu_total}) should be less than wall total ({wall_total}): "
             "idle threads may not be filtered correctly"
         )
+
+
+# ---- Non-Python OS thread sampling -----------------------------------------
+
+
+@requires_sudo
+@allpythons()
+def test_native_non_python_thread(py, native_ext):
+    """Native mode must emit samples for OS threads with no PyThreadState.
+
+    The target imports native_ext and starts two threads named "Native-0"
+    and "Native-1" that have no PyThreadState.  Austin should include them in
+    the output with their OS thread name and only native frames.
+    """
+    result = austin("-n", "-i", "1ms", *python(py), target("target_native_thread.py"))
+    assert result.returncode == 0, result.stderr or result.stdout
+
+    # Use threshold=0 so Native is not filtered out by the denoise step
+    # even if it appears in fewer samples than the Python main thread.
+    thread_names = {name for _, name, _ in threads(result.samples, threshold=0)}
+    assert {
+        "Native-0",
+        "Native-1",
+    } <= thread_names, (
+        f"Expected 'Native-0' and 'Native-1' threads in samples; got: {thread_names}"
+    )
+
+    # All frames for each native thread must be native (line == 0).
+    for sample in result.samples:
+        if not sample.thread.startswith("Native-"):
+            continue
+        assert all(
+            frame.line == 0 for frame in sample.frames
+        ), f"Expected only native frames for {sample.thread}, got: {sample.frames}"

--- a/test/functional/test_native.py
+++ b/test/functional/test_native.py
@@ -165,7 +165,12 @@ def test_native_wall_time(py, save_mojo):
     meta = result.metadata
     assert meta["mode"] == "wall"
 
-    a, _ = sum_metrics(result.samples)
+    # Exclude non-Python threads (iid == -1) from the time sum: target34.py has
+    # exactly 2 Python threads, so total attributed time should be < 2.1 * d.
+    # Non-Python OS threads (Python runtime internals, etc.) are now also
+    # sampled in native mode and would push the total above the expected range.
+    python_samples = [s for s in result.samples if s.iid is not None and s.iid >= 0]
+    a, _ = sum_metrics(python_samples)
     d = int(meta["duration"])
     assert 0 < a < 2.1 * d
 

--- a/test/native/native_ext.c
+++ b/test/native/native_ext.c
@@ -18,6 +18,21 @@
 
 typedef HANDLE thread_handle_t;
 
+// SetThreadDescription was added in Windows 10 1607.  Load it dynamically so
+// the extension has no hard import dependency on it and loads on older systems.
+typedef HRESULT(WINAPI* _SetThreadDescriptionFn)(HANDLE, PCWSTR);
+
+static _SetThreadDescriptionFn
+_get_set_thread_description(void) {
+    static _SetThreadDescriptionFn fn = NULL;
+    if (!fn) {
+        HMODULE h = GetModuleHandleW(L"KernelBase.dll");
+        if (h)
+            fn = (_SetThreadDescriptionFn)GetProcAddress(h, "SetThreadDescription");
+    }
+    return fn;
+}
+
 typedef struct {
     volatile LONG* running;
     int            index;
@@ -25,10 +40,13 @@ typedef struct {
 
 static DWORD WINAPI
 _worker(LPVOID raw) {
-    worker_arg_t* a = (worker_arg_t*)raw;
-    wchar_t       name[32];
-    swprintf(name, 32, L"Native-%d", a->index);
-    SetThreadDescription(GetCurrentThread(), name);
+    worker_arg_t*           a  = (worker_arg_t*)raw;
+    _SetThreadDescriptionFn fn = _get_set_thread_description();
+    if (fn) {
+        wchar_t name[32];
+        swprintf(name, 32, L"Native-%d", a->index);
+        fn(GetCurrentThread(), name);
+    }
     while (InterlockedCompareExchange(a->running, 1, 1))
         Sleep(1);
     return 0;

--- a/test/native/native_ext.c
+++ b/test/native/native_ext.c
@@ -1,0 +1,231 @@
+// Python C extension used by Austin's test suite to start OS threads that
+// have no PyThreadState, exercising the non-Python thread sampling path.
+//
+// API
+// ---
+//   token = native_ext.start_threads(n)   -- spawn n native threads
+//   native_ext.join_threads(token)        -- signal stop and join all
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <stdio.h>
+
+// ---- Platform thread primitives --------------------------------------------
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+typedef HANDLE thread_handle_t;
+
+typedef struct {
+    volatile LONG* running;
+    int            index;
+} worker_arg_t;
+
+static DWORD WINAPI
+_worker(LPVOID raw) {
+    worker_arg_t* a = (worker_arg_t*)raw;
+    wchar_t       name[32];
+    swprintf(name, 32, L"Native-%d", a->index);
+    SetThreadDescription(GetCurrentThread(), name);
+    while (InterlockedCompareExchange(a->running, 1, 1))
+        Sleep(1);
+    return 0;
+}
+
+static int
+_thread_create(thread_handle_t* out, worker_arg_t* arg) {
+    *out = CreateThread(NULL, 0, _worker, (LPVOID)arg, 0, NULL);
+    return *out ? 0 : -1;
+}
+
+static void
+_thread_join(thread_handle_t h) {
+    WaitForSingleObject(h, INFINITE);
+    CloseHandle(h);
+}
+
+#else /* POSIX */
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <time.h>
+
+typedef pthread_t thread_handle_t;
+
+typedef struct {
+    atomic_int* running;
+    int         index;
+} worker_arg_t;
+
+// Linux caps thread names at 15 characters (TASK_COMM_LEN - 1).
+// macOS allows up to 63.  Use the stricter limit everywhere so the name
+// is identical on all platforms and never silently truncated by the kernel.
+#define THREAD_NAME_MAX 15
+
+static void*
+_worker(void* raw) {
+    worker_arg_t* a = (worker_arg_t*)raw;
+    char          name[THREAD_NAME_MAX + 1];
+    snprintf(name, sizeof(name), "Native-%d", a->index);
+#ifdef __APPLE__
+    pthread_setname_np(name);
+#else
+    pthread_setname_np(pthread_self(), name);
+#endif
+    struct timespec ts = {0, 500000}; // 0.5 ms
+    while (atomic_load(a->running))
+        nanosleep(&ts, NULL);
+    return NULL;
+}
+
+static int
+_thread_create(thread_handle_t* out, worker_arg_t* arg) {
+    return pthread_create(out, NULL, _worker, arg);
+}
+
+static void
+_thread_join(thread_handle_t h) {
+    pthread_join(h, NULL);
+}
+
+#endif /* _WIN32 */
+
+// ---- Thread group ----------------------------------------------------------
+
+typedef struct {
+    int              n;
+    thread_handle_t* handles;
+    worker_arg_t*    args;
+#ifdef _WIN32
+    volatile LONG running;
+#else
+    atomic_int running;
+#endif
+} thread_group_t;
+
+static void
+_thread_group_stop_and_free(thread_group_t* g) {
+    if (!g)
+        return;
+#ifdef _WIN32
+    InterlockedExchange(&g->running, 0);
+#else
+    atomic_store(&g->running, 0);
+#endif
+    for (int i = 0; i < g->n; i++)
+        _thread_join(g->handles[i]);
+    PyMem_Free(g->args);
+    PyMem_Free(g->handles);
+    PyMem_Free(g);
+}
+
+// Sentinel stored in a capsule after join_threads() has consumed it.
+// PyCapsule_SetPointer rejects NULL, so we use a static address instead.
+static char _joined;
+
+// PyCapsule destructor — called when the token is garbage collected without
+// an explicit join_threads() call.
+static void
+_capsule_destructor(PyObject* cap) {
+    void* ptr = PyCapsule_GetPointer(cap, "native_ext.thread_group");
+    if (!ptr || ptr == &_joined)
+        return;
+    _thread_group_stop_and_free((thread_group_t*)ptr);
+}
+
+// ---- Python API ------------------------------------------------------------
+
+static PyObject*
+start_threads(PyObject* self, PyObject* args) {
+    (void)self;
+    int n = 1;
+    if (!PyArg_ParseTuple(args, "i", &n))
+        return NULL;
+    if (n < 1) {
+        PyErr_SetString(PyExc_ValueError, "n must be >= 1");
+        return NULL;
+    }
+
+    thread_group_t* g = (thread_group_t*)PyMem_Calloc(1, sizeof(thread_group_t));
+    if (!g)
+        return PyErr_NoMemory();
+
+    g->handles = (thread_handle_t*)PyMem_Calloc(n, sizeof(thread_handle_t));
+    g->args    = (worker_arg_t*)PyMem_Calloc(n, sizeof(worker_arg_t));
+    if (!g->handles || !g->args) {
+        PyMem_Free(g->handles);
+        PyMem_Free(g->args);
+        PyMem_Free(g);
+        return PyErr_NoMemory();
+    }
+
+#ifdef _WIN32
+    InterlockedExchange(&g->running, 1);
+#else
+    atomic_store(&g->running, 1);
+#endif
+
+    for (int i = 0; i < n; i++) {
+        g->args[i].running = &g->running;
+        g->args[i].index   = i;
+        if (_thread_create(&g->handles[i], &g->args[i]) != 0) {
+            // Signal already-started threads to stop before returning an error.
+            g->n = i;
+            _thread_group_stop_and_free(g);
+            PyErr_SetString(PyExc_RuntimeError, "failed to create thread");
+            return NULL;
+        }
+    }
+    g->n = n;
+
+    return PyCapsule_New(g, "native_ext.thread_group", _capsule_destructor);
+}
+
+static PyObject*
+join_threads(PyObject* self, PyObject* args) {
+    (void)self;
+    PyObject* cap;
+    if (!PyArg_ParseTuple(args, "O", &cap))
+        return NULL;
+
+    void* ptr = PyCapsule_GetPointer(cap, "native_ext.thread_group");
+    if (!ptr)
+        return NULL; // PyCapsule_GetPointer sets TypeError on mismatch
+    if (ptr == &_joined) {
+        PyErr_SetString(PyExc_RuntimeError, "join_threads: token already consumed");
+        return NULL;
+    }
+
+    _thread_group_stop_and_free((thread_group_t*)ptr);
+
+    // Mark capsule consumed so a second join_threads() call or the GC
+    // destructor does not attempt to free already-freed memory.
+    if (PyCapsule_SetPointer(cap, &_joined) < 0)
+        return NULL;
+
+    Py_RETURN_NONE;
+}
+
+// ---- Module definition -----------------------------------------------------
+
+static PyMethodDef _methods[] = {
+    {"start_threads", start_threads, METH_VARARGS,
+     "start_threads(n) -> token\n\n"
+     "Spawn n OS threads named 'Native-<i>' with no PyThreadState.\n"
+     "Returns an opaque token to pass to join_threads()."                  },
+    {"join_threads",  join_threads,  METH_VARARGS,
+     "join_threads(token)\n\n"
+     "Signal all threads in the group to stop and wait for them to finish."},
+    {NULL,            NULL,          0,            NULL                    },
+};
+
+static struct PyModuleDef _module = {
+    PyModuleDef_HEAD_INIT, "native_ext", NULL, -1, _methods,
+};
+
+PyMODINIT_FUNC
+PyInit_native_ext(void) {
+    return PyModule_Create(&_module);
+}

--- a/test/native/native_ext.pyi
+++ b/test/native/native_ext.pyi
@@ -1,0 +1,21 @@
+from typing import final
+
+@final
+class ThreadGroup:
+    """Opaque token returned by start_threads().  Pass to join_threads()."""
+
+    ...
+
+def start_threads(n: int) -> ThreadGroup:
+    """Spawn *n* OS threads named ``Native-<i>`` with no PyThreadState.
+
+    Returns a token to pass to :func:`join_threads`.
+    """
+    ...
+
+def join_threads(token: ThreadGroup) -> None:
+    """Signal all threads in the group to stop and wait for them to finish.
+
+    Raises :exc:`RuntimeError` if the token has already been consumed.
+    """
+    ...

--- a/test/native/pyproject.toml
+++ b/test/native/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "austin-native-test"
+version = "0.1.0"

--- a/test/native/setup.py
+++ b/test/native/setup.py
@@ -1,0 +1,20 @@
+import platform
+from setuptools import Extension, setup
+
+extra_compile_args = []
+extra_link_args = []
+
+if platform.system() != "Windows":
+    extra_compile_args = ["-pthread"]
+    extra_link_args = ["-pthread"]
+
+setup(
+    ext_modules=[
+        Extension(
+            "native_ext",
+            sources=["native_ext.c"],
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
+        )
+    ]
+)

--- a/test/targets/target_native_thread.py
+++ b/test/targets/target_native_thread.py
@@ -1,0 +1,15 @@
+"""Target for testing native mode sampling of non-Python OS threads.
+
+Imports native_ext (a C extension built from test/native/) and starts two
+native threads named "Native-0" and "Native-1" that have no PyThreadState.  Austin
+should observe both threads alongside the Python main thread.
+"""
+
+import native_ext
+import time
+
+token = native_ext.start_threads(2)
+
+time.sleep(1)
+
+native_ext.join_threads(token)


### PR DESCRIPTION
We collect samples from non-Python threads when in native mode to give a more comprehensive view of what is running within a Python process.