### PR TITLE
fix(win): prevent early native unwind stop

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -168,50 +168,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Set up Python PDB symbol path
-        shell: pwsh
-        run: |
-          # Locate the test Python installation and ensure PDB files are present
-          # so DbgHelp can resolve _PyEval_EvalFrameDefault by name (including
-          # cold blocks that don't carry CHAININFO entries in python310.dll etc.)
-          $pyver = "${{ matrix.python-version }}" -replace 't$', ''
-          $pyinstall = Get-ChildItem "C:\hostedtoolcache\windows\Python" -Filter "$pyver.*" -ErrorAction SilentlyContinue |
-            Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $pyinstall) {
-            Write-Host "Python $pyver not found in tool cache — skipping PDB setup"
-            exit 0
-          }
-          $pydir  = Join-Path $pyinstall.FullName "x64"
-          $fullver = $pyinstall.Name  # e.g. 3.12.10
-
-          $pdbs = Get-ChildItem $pydir -Filter "python*.pdb" -ErrorAction SilentlyContinue
-          if (-not $pdbs) {
-            Write-Host "No PDB files in $pydir — downloading core_pdb.msi for Python $fullver"
-            $msi = "$env:TEMP\core_pdb.msi"
-            $url = "https://www.python.org/ftp/python/$fullver/amd64/core_pdb.msi"
-            try {
-              Invoke-WebRequest -Uri $url -OutFile $msi -ErrorAction Stop
-              $extract = "$env:TEMP\pdb_extract"
-              Start-Process msiexec.exe -ArgumentList "/a `"$msi`" /qn TARGETDIR=`"$extract`"" -Wait -NoNewWindow
-              $extracted = Get-ChildItem $extract -Filter "python*.pdb" -Recurse -ErrorAction SilentlyContinue
-              if ($extracted) {
-                $extracted | ForEach-Object { Copy-Item $_.FullName $pydir }
-                Write-Host "Installed PDB files: $($extracted.Name -join ', ')"
-              } else {
-                Write-Host "No PDB files found after extraction — skipping symbol path setup"
-                exit 0
-              }
-            } catch {
-              Write-Host "Failed to download/extract PDB: $_  — skipping symbol path setup"
-              exit 0
-            }
-          } else {
-            Write-Host "PDB files already present: $($pdbs.Name -join ', ')"
-          }
-
-          Write-Host "Setting _NT_SYMBOL_PATH=$pydir"
-          Add-Content $env:GITHUB_ENV "_NT_SYMBOL_PATH=$pydir"
-
       - name: Check out the base branch
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -168,6 +168,50 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Set up Python PDB symbol path
+        shell: pwsh
+        run: |
+          # Locate the test Python installation and ensure PDB files are present
+          # so DbgHelp can resolve _PyEval_EvalFrameDefault by name (including
+          # cold blocks that don't carry CHAININFO entries in python310.dll etc.)
+          $pyver = "${{ matrix.python-version }}" -replace 't$', ''
+          $pyinstall = Get-ChildItem "C:\hostedtoolcache\windows\Python" -Filter "$pyver.*" -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $pyinstall) {
+            Write-Host "Python $pyver not found in tool cache — skipping PDB setup"
+            exit 0
+          }
+          $pydir  = Join-Path $pyinstall.FullName "x64"
+          $fullver = $pyinstall.Name  # e.g. 3.12.10
+
+          $pdbs = Get-ChildItem $pydir -Filter "python*.pdb" -ErrorAction SilentlyContinue
+          if (-not $pdbs) {
+            Write-Host "No PDB files in $pydir — downloading core_pdb.msi for Python $fullver"
+            $msi = "$env:TEMP\core_pdb.msi"
+            $url = "https://www.python.org/ftp/python/$fullver/amd64/core_pdb.msi"
+            try {
+              Invoke-WebRequest -Uri $url -OutFile $msi -ErrorAction Stop
+              $extract = "$env:TEMP\pdb_extract"
+              Start-Process msiexec.exe -ArgumentList "/a `"$msi`" /qn TARGETDIR=`"$extract`"" -Wait -NoNewWindow
+              $extracted = Get-ChildItem $extract -Filter "python*.pdb" -Recurse -ErrorAction SilentlyContinue
+              if ($extracted) {
+                $extracted | ForEach-Object { Copy-Item $_.FullName $pydir }
+                Write-Host "Installed PDB files: $($extracted.Name -join ', ')"
+              } else {
+                Write-Host "No PDB files found after extraction — skipping symbol path setup"
+                exit 0
+              }
+            } catch {
+              Write-Host "Failed to download/extract PDB: $_  — skipping symbol path setup"
+              exit 0
+            }
+          } else {
+            Write-Host "PDB files already present: $($pdbs.Name -join ', ')"
+          }
+
+          Write-Host "Setting _NT_SYMBOL_PATH=$pydir"
+          Add-Content $env:GITHUB_ENV "_NT_SYMBOL_PATH=$pydir"
+
       - name: Check out the base branch
         uses: actions/checkout@v3
         with:

--- a/src/win/addr2line.h
+++ b/src/win/addr2line.h
@@ -84,8 +84,12 @@ _has_pdb_symbols(HANDLE hProcess, uintptr_t pc) {
     return mod_info.SymType == SymPdb || mod_info.SymType == SymDia;
 }
 
+// Resolve a PC to a function name.
+// If p_export_addr is not NULL it receives the export's base address on
+// success (useful for .pdata cross-checking by callers that have access to
+// the pdata cache).
 static inline const char*
-get_func_name(HANDLE hProcess, uintptr_t pc) {
+get_func_name(HANDLE hProcess, uintptr_t pc, uintptr_t* p_export_addr) {
     sym_init(hProcess);
 
     SYMBOL_INFO* sym  = (SYMBOL_INFO*)_sym_buf;
@@ -101,10 +105,20 @@ get_func_name(HANDLE hProcess, uintptr_t pc) {
     // Without PDBs (export-only), SymFromAddr maps the PC to the nearest
     // preceding export which can be wildly wrong.  Validate that the PC
     // actually falls within the reported symbol's bounds.
-    if (!_has_pdb_symbols(hProcess, pc)) {
+    bool has_pdb = _has_pdb_symbols(hProcess, pc);
+    log_d(
+        "win: sym pc=%" PRIxPTR " -> %s disp=%llu size=%lu has_pdb=%d", pc, sym->Name, (unsigned long long)displacement,
+        (unsigned long)sym->Size, (int)has_pdb
+    );
+    if (!has_pdb) {
         if (sym->Size > 0) {
-            if (displacement >= sym->Size)
+            if (displacement >= sym->Size) {
+                log_d(
+                    "win: sym rejected (size): pc=%" PRIxPTR " disp=%llu size=%lu", pc,
+                    (unsigned long long)displacement, (unsigned long)sym->Size
+                );
                 return NULL;
+            }
         } else {
             // Export-only symbol with unknown size: only accept if the PC is
             // within 512 bytes of the exported entry point.  The previous
@@ -114,10 +128,18 @@ get_func_name(HANDLE hProcess, uintptr_t pc) {
             // producing garbage flame-graph labels and — critically — breaking
             // the is_pyeval_frame check that relies on the symbol name to
             // detect _PyEval_EvalFrameDefault and collect Python frames.
-            if (displacement > 512)
+            if (displacement > 512) {
+                log_d(
+                    "win: sym rejected (disp>512): pc=%" PRIxPTR " sym=%s disp=%llu", pc, sym->Name,
+                    (unsigned long long)displacement
+                );
                 return NULL;
+            }
         }
     }
+
+    if (p_export_addr != NULL)
+        *p_export_addr = (uintptr_t)sym->Address;
 
     return sym->Name;
 }

--- a/src/win/addr2line.h
+++ b/src/win/addr2line.h
@@ -105,8 +105,17 @@ get_func_name(HANDLE hProcess, uintptr_t pc) {
         if (sym->Size > 0) {
             if (displacement >= sym->Size)
                 return NULL;
-        } else if (displacement > 0x10000) {
-            return NULL;
+        } else {
+            // Export-only symbol with unknown size: only accept if the PC is
+            // within 512 bytes of the exported entry point.  The previous
+            // threshold (64 KB) caused internal functions like take_gil and
+            // _PyEval_EvalFrameDefault to be mislabeled as the nearest
+            // preceding export (e.g. PyObject_GC_UnTrack, PyList_Reverse),
+            // producing garbage flame-graph labels and — critically — breaking
+            // the is_pyeval_frame check that relies on the symbol name to
+            // detect _PyEval_EvalFrameDefault and collect Python frames.
+            if (displacement > 512)
+                return NULL;
         }
     }
 

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -449,11 +449,14 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
             break;
         prev_pc = pc;
 
+        log_d("win: unwind frame pc=%" PRIxPTR " sp=%" PRIxPTR, pc, gp[REG_RSP]);
+
         if (fail(_push_native_frame(self, pc)))
             FAIL;
 
         frame_t* top = _stack->native_base[_stack->native_pointer - 1];
         if (unlikely(is_pyeval_frame(top->scope))) {
+            log_d("win: unwind hit eval frame at pc=%" PRIxPTR, pc);
             (void)stack_native_pop();
             stack_native_push((frame_t*)EVAL_FRAME_MAGIC);
             if (self->is_repeat)
@@ -481,7 +484,10 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
         // If the fast .pdata unwinder couldn't step, fall back to StackWalk64
         // for this one frame.
         if (!stepped && isvalid(hThread)) {
+            log_d("win: pdata failed for pc=%" PRIxPTR ", trying StackWalk64", saved_pc);
             stepped = _stackwalk64_step(hProcess, hThread, &pc, gp);
+            if (stepped)
+                log_d("win: StackWalk64 stepped to pc=%" PRIxPTR " sp=%" PRIxPTR, pc, gp[REG_RSP]);
         }
 
         if (!stepped) {
@@ -523,8 +529,13 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
         // SP must advance (grow upward) on each frame; if it doesn't, the
         // unwind produced garbage and we should stop.
         uintptr_t sp = gp[REG_RSP];
-        if (sp != 0 && prev_sp != 0 && sp <= prev_sp)
+        if (sp != 0 && prev_sp != 0 && sp <= prev_sp) {
+            log_d(
+                "win: unwind stopped: sp=%" PRIxPTR " did not advance past prev_sp=%" PRIxPTR " (pc=%" PRIxPTR ")", sp,
+                prev_sp, pc
+            );
             break;
+        }
         prev_sp = sp;
     }
 

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -422,30 +422,7 @@ _stackwalk64_step(HANDLE hProcess, HANDLE hThread, uintptr_t* pc, uintptr_t gp[G
 // direct .pdata parsing for the majority of frames while preserving the data
 // quality of StackWalk64 for edge cases (syscall stubs, JIT code, etc.).
 
-// Return true if pc falls within the eval-frame region of any Python DLL.
-// Used to detect cold blocks: code that is a sub-section of
-// _PyEval_EvalFrameDefault but located at a distant virtual address, where
-// export-table symbol resolution would give a wrong label.
-static inline bool
-_pc_is_eval_frame(uintptr_t pc) {
-    if (pc == 0 || _mod_count == 0)
-        return false;
-    DWORD mlo = 0, mhi = _mod_count;
-    while (mlo < mhi) {
-        DWORD mid = mlo + (mhi - mlo) / 2;
-        if (_mod_table[mid].base <= pc)
-            mlo = mid + 1;
-        else
-            mhi = mid;
-    }
-    if (mlo == 0 || pc < _mod_table[mlo - 1].base || pc >= _mod_table[mlo - 1].end)
-        return false;
-    const char* mod_path = _mod_table[mlo - 1].path;
-    if (!mod_path || (!strstr(mod_path, "python") && !strstr(mod_path, "Python")))
-        return false;
-    pdata_cache_entry_t* ce = _pdata_cache_lookup(_mod_table[mlo - 1].base);
-    return ce && ce->largest_func_begin != 0 && pc >= ce->largest_func_begin && pc < ce->largest_func_end;
-}
+
 
 static inline int
 _py_thread__unwind_native_frame_stack(py_thread_t* self) {
@@ -517,23 +494,6 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                                 ce->largest_func_begin, ce->largest_func_end
                             );
                             is_eval = true;
-                        }
-                        // Cold-block check: PC not in the absorbed range but its
-                        // RUNTIME_FUNCTION chains (via CHAININFO) back to the main
-                        // body of _PyEval_EvalFrameDefault.  pdata_step follows the
-                        // chain directly to EvalFrame's caller, bypassing the main
-                        // body — so the return-address check (_pc_is_eval_frame)
-                        // never fires.  We must recognise the cold block here.
-                        if (!is_eval && ce->main_func_rva != 0 && ce->xdata != NULL) {
-                            DWORD             rva = (DWORD)(pc - mod_base);
-                            RUNTIME_FUNCTION* rf  = _pdata_find(ce, rva);
-                            if (rf) {
-                                RUNTIME_FUNCTION* root = _pdata_logical_root(ce, rf);
-                                if (root && root->BeginAddress == ce->main_func_rva) {
-                                    log_d("win: eval frame by CHAININFO at pc=%" PRIxPTR, pc);
-                                    is_eval = true;
-                                }
-                            }
                         }
                     }
                 }
@@ -622,21 +582,6 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                 saved_pc, saved_gp[REG_RSP]
             );
             break;
-        }
-
-        // If the current frame was not detected as an eval frame but the return
-        // address (new pc) lands inside the eval-frame region, then the current
-        // frame is a cold block of _PyEval_EvalFrameDefault placed at a distant
-        // virtual address by the compiler.  Without PDB symbols it gets a wrong
-        // export-table label (e.g. PyList_Reverse).  Remove the misleading
-        // native frame; the next iteration will detect is_eval for the main-body
-        // return address and push EVAL_FRAME_MAGIC.
-        if (!is_eval && _pc_is_eval_frame(pc)) {
-            log_d(
-                "win: cold block at %" PRIxPTR " returns into eval frame at %" PRIxPTR " — suppressing frame", saved_pc,
-                pc
-            );
-            (void)stack_native_pop();
         }
 
         // SP must advance (grow upward) on each frame; if it doesn't, the

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -444,8 +444,22 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
     uintptr_t prev_pc = 0;
     uintptr_t prev_sp = 0;
     while (!stack_native_full()) {
-        if (pc == 0 || pc < 0x10000 || pc == prev_pc)
+        if (pc == 0 || pc < 0x10000)
             break;
+        if (pc == prev_pc) {
+            // Same PC as last step — either genuine recursion or an
+            // artefact from the pdata/.pdata+StackWalk64 hybrid.
+            uintptr_t cur_sp = gp[REG_RSP];
+            if (cur_sp != 0 && prev_sp != 0 && cur_sp > prev_sp) {
+                // SP advanced: genuine recursive call, allow through.
+            } else {
+                // SP stalled at the same PC — likely an unwind artefact.
+                // Try one StackWalk64 step to break out of the stuck state.
+                if (isvalid(hThread) && _stackwalk64_step(hProcess, hThread, &pc, gp))
+                    continue;
+                break;
+            }
+        }
         prev_pc = pc;
 
         if (fail(_push_native_frame(self, pc)))
@@ -484,9 +498,37 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
         }
 
         if (!stepped) {
+            // Last resort: naive frame-pointer walk.  Only attempt when RBP
+            // looks like a genuine saved frame pointer: it must be above RSP,
+            // 8-byte aligned, within a plausible frame size, the return
+            // address it yields must land in a known module, and next_rbp must
+            // be strictly above rbp (unwind moves up the stack).
+            // Without these guards the walk produces garbage on x64 code that
+            // uses RBP as a general-purpose register (e.g. Python 3.10 DLL).
+            uintptr_t rbp = gp[REG_RBP];
+            uintptr_t sp  = gp[REG_RSP];
+            if (rbp != 0 && rbp > sp && (rbp & 7) == 0 && (rbp - sp) < 0x10000) {
+                uintptr_t ret_addr = 0;
+                uintptr_t next_rbp = 0;
+                SIZE_T    n_read   = 0;
+                bool got_ret = ReadProcessMemory(hProcess, (LPCVOID)(rbp + 8), &ret_addr, sizeof(ret_addr), &n_read)
+                            && n_read == sizeof(ret_addr) && _pc_in_module(ret_addr, _mod_table, _mod_count);
+                bool got_rbp = ReadProcessMemory(hProcess, (LPCVOID)rbp, &next_rbp, sizeof(next_rbp), &n_read)
+                            && n_read == sizeof(next_rbp) && next_rbp > rbp;
+                if (got_ret && got_rbp) {
+                    log_d(
+                        "win: fp fallback: rbp=%" PRIxPTR " -> ret=%" PRIxPTR " next_rbp=%" PRIxPTR, rbp, ret_addr,
+                        next_rbp
+                    );
+                    pc          = ret_addr;
+                    gp[REG_RSP] = rbp + 16;
+                    gp[REG_RBP] = next_rbp;
+                    continue;
+                }
+            }
             log_d(
-                "win: unwind stopped at pc=%" PRIxPTR " sp=%" PRIxPTR " (pdata and stackwalk64 both failed)", saved_pc,
-                saved_gp[REG_RSP]
+                "win: unwind stopped at pc=%" PRIxPTR " sp=%" PRIxPTR " (pdata, stackwalk64, and fp walk all failed)",
+                saved_pc, saved_gp[REG_RSP]
             );
             break;
         }

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -314,7 +314,7 @@ _push_native_frame(py_thread_t* self, uintptr_t pc) {
         key_dt           scope_key = frame_key + 1;
         cached_string_t* scope     = lru_cache__maybe_hit(string_cache, scope_key);
         if (!isvalid(scope)) {
-            const char* fname = get_func_name(self->proc->ref, pc);
+            const char* fname = get_func_name(self->proc->ref, pc, NULL);
             if (isvalid(fname)) {
                 scope = cached_string_new(scope_key, strdup(fname));
                 if (!isvalid(scope))
@@ -421,6 +421,32 @@ _stackwalk64_step(HANDLE hProcess, HANDLE hThread, uintptr_t* pc, uintptr_t gp[G
 // problematic frame, then resume the .pdata walk.  This gives us the speed of
 // direct .pdata parsing for the majority of frames while preserving the data
 // quality of StackWalk64 for edge cases (syscall stubs, JIT code, etc.).
+
+// Return true if pc falls within the eval-frame region of any Python DLL.
+// Used to detect cold blocks: code that is a sub-section of
+// _PyEval_EvalFrameDefault but located at a distant virtual address, where
+// export-table symbol resolution would give a wrong label.
+static inline bool
+_pc_is_eval_frame(uintptr_t pc) {
+    if (pc == 0 || _mod_count == 0)
+        return false;
+    DWORD mlo = 0, mhi = _mod_count;
+    while (mlo < mhi) {
+        DWORD mid = mlo + (mhi - mlo) / 2;
+        if (_mod_table[mid].base <= pc)
+            mlo = mid + 1;
+        else
+            mhi = mid;
+    }
+    if (mlo == 0 || pc < _mod_table[mlo - 1].base || pc >= _mod_table[mlo - 1].end)
+        return false;
+    const char* mod_path = _mod_table[mlo - 1].path;
+    if (!mod_path || (!strstr(mod_path, "python") && !strstr(mod_path, "Python")))
+        return false;
+    pdata_cache_entry_t* ce = _pdata_cache_lookup(_mod_table[mlo - 1].base);
+    return ce && ce->largest_func_begin != 0 && pc >= ce->largest_func_begin && pc < ce->largest_func_end;
+}
+
 static inline int
 _py_thread__unwind_native_frame_stack(py_thread_t* self) {
     stack_native_reset();
@@ -477,14 +503,38 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                 // module is a Python DLL (path contains "python").
                 const char* mod_path = _mod_table[mlo - 1].path;
                 if (mod_path && (strstr(mod_path, "python") || strstr(mod_path, "Python"))) {
-                    pdata_cache_entry_t* ce = _pdata_cache_lookup(_mod_table[mlo - 1].base);
-                    if (ce && ce->largest_func_begin != 0 && pc >= ce->largest_func_begin
-                        && pc < ce->largest_func_end) {
+                    uintptr_t            mod_base = _mod_table[mlo - 1].base;
+                    pdata_cache_entry_t* ce       = _pdata_cache_lookup(mod_base);
+                    if (ce && ce->largest_func_begin != 0) {
                         log_d(
-                            "win: eval frame by size at pc=%" PRIxPTR " in [%" PRIxPTR ",%" PRIxPTR ")", pc,
-                            ce->largest_func_begin, ce->largest_func_end
+                            "win: eval frame check: pc=%" PRIxPTR " region=[%" PRIxPTR ",%" PRIxPTR ") in=%d", pc,
+                            ce->largest_func_begin, ce->largest_func_end,
+                            (int)(pc >= ce->largest_func_begin && pc < ce->largest_func_end)
                         );
-                        is_eval = true;
+                        if (pc >= ce->largest_func_begin && pc < ce->largest_func_end) {
+                            log_d(
+                                "win: eval frame by size at pc=%" PRIxPTR " in [%" PRIxPTR ",%" PRIxPTR ")", pc,
+                                ce->largest_func_begin, ce->largest_func_end
+                            );
+                            is_eval = true;
+                        }
+                        // Cold-block check: PC not in the absorbed range but its
+                        // RUNTIME_FUNCTION chains (via CHAININFO) back to the main
+                        // body of _PyEval_EvalFrameDefault.  pdata_step follows the
+                        // chain directly to EvalFrame's caller, bypassing the main
+                        // body — so the return-address check (_pc_is_eval_frame)
+                        // never fires.  We must recognise the cold block here.
+                        if (!is_eval && ce->main_func_rva != 0 && ce->xdata != NULL) {
+                            DWORD             rva = (DWORD)(pc - mod_base);
+                            RUNTIME_FUNCTION* rf  = _pdata_find(ce, rva);
+                            if (rf) {
+                                RUNTIME_FUNCTION* root = _pdata_logical_root(ce, rf);
+                                if (root && root->BeginAddress == ce->main_func_rva) {
+                                    log_d("win: eval frame by CHAININFO at pc=%" PRIxPTR, pc);
+                                    is_eval = true;
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -513,6 +563,20 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
             pc = saved_pc;
             memcpy(gp, saved_gp, sizeof(gp));
             stepped = false;
+        }
+
+        // If pdata stepped but the PC did not change (CHAININFO self-reference:
+        // a sub-entry whose parent's "return address" is an intra-function JMP
+        // target back into the same eval loop body), let StackWalk64 resolve the
+        // true caller.  Unlike our .pdata parser, StackWalk64 uses the actual
+        // saved return address on the stack and will escape the self-loop.
+        if (stepped && pc == saved_pc && isvalid(hThread)) {
+            log_d("win: pdata self-loop at pc=%" PRIxPTR " (CHAININFO intra-function), trying StackWalk64", saved_pc);
+            pc = saved_pc;
+            memcpy(gp, saved_gp, sizeof(gp));
+            stepped = _stackwalk64_step(hProcess, hThread, &pc, gp);
+            if (stepped)
+                log_d("win: StackWalk64 escaped self-loop to pc=%" PRIxPTR " sp=%" PRIxPTR, pc, gp[REG_RSP]);
         }
 
         // If the fast .pdata unwinder couldn't step, fall back to StackWalk64
@@ -558,6 +622,21 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                 saved_pc, saved_gp[REG_RSP]
             );
             break;
+        }
+
+        // If the current frame was not detected as an eval frame but the return
+        // address (new pc) lands inside the eval-frame region, then the current
+        // frame is a cold block of _PyEval_EvalFrameDefault placed at a distant
+        // virtual address by the compiler.  Without PDB symbols it gets a wrong
+        // export-table label (e.g. PyList_Reverse).  Remove the misleading
+        // native frame; the next iteration will detect is_eval for the main-body
+        // return address and push EVAL_FRAME_MAGIC.
+        if (!is_eval && _pc_is_eval_frame(pc)) {
+            log_d(
+                "win: cold block at %" PRIxPTR " returns into eval frame at %" PRIxPTR " — suppressing frame", saved_pc,
+                pc
+            );
+            (void)stack_native_pop();
         }
 
         // SP must advance (grow upward) on each frame; if it doesn't, the

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -381,7 +381,8 @@ _stackwalk64_step(HANDLE hProcess, HANDLE hThread, uintptr_t* pc, uintptr_t gp[G
     // than stepping to the caller.  Call up to twice to ensure we advance.
     for (int attempt = 0; attempt < 2; attempt++) {
         if (!StackWalk64(
-                machine, hProcess, hThread, &sf, &ctx, NULL, SymFunctionTableAccess64, SymGetModuleBase64, NULL
+                machine, hProcess, hThread, &sf, &ctx, NULL, _custom_function_table_access64, _custom_get_module_base64,
+                NULL
             ))
             return false;
 
@@ -444,22 +445,8 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
     uintptr_t prev_pc = 0;
     uintptr_t prev_sp = 0;
     while (!stack_native_full()) {
-        if (pc == 0 || pc < 0x10000)
+        if (pc == 0 || pc < 0x10000 || pc == prev_pc)
             break;
-        if (pc == prev_pc) {
-            // Same PC as last step — either genuine recursion or an
-            // artefact from the pdata/.pdata+StackWalk64 hybrid.
-            uintptr_t cur_sp = gp[REG_RSP];
-            if (cur_sp != 0 && prev_sp != 0 && cur_sp > prev_sp) {
-                // SP advanced: genuine recursive call, allow through.
-            } else {
-                // SP stalled at the same PC — likely an unwind artefact.
-                // Try one StackWalk64 step to break out of the stuck state.
-                if (isvalid(hThread) && _stackwalk64_step(hProcess, hThread, &pc, gp))
-                    continue;
-                break;
-            }
-        }
         prev_pc = pc;
 
         if (fail(_push_native_frame(self, pc)))

--- a/src/win/py_thread.h
+++ b/src/win/py_thread.h
@@ -454,8 +454,42 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
         if (fail(_push_native_frame(self, pc)))
             FAIL;
 
-        frame_t* top = _stack->native_base[_stack->native_pointer - 1];
-        if (unlikely(is_pyeval_frame(top->scope))) {
+        frame_t* top     = _stack->native_base[_stack->native_pointer - 1];
+        // Detect _PyEval_EvalFrameDefault by symbol name OR by being the
+        // largest function in the Python DLL.  The name check fails when only
+        // export-table symbols are available (no PDB): the function then gets
+        // mislabeled as the nearest export.  The size-based check is reliable
+        // because _PyEval_EvalFrameDefault is always the biggest function in
+        // any CPython build by a large margin.
+        bool     is_eval = is_pyeval_frame(top->scope);
+        if (!is_eval && _mod_count > 0) {
+            // Binary-search the module table for this PC.
+            DWORD mlo = 0, mhi = _mod_count;
+            while (mlo < mhi) {
+                DWORD mid = mlo + (mhi - mlo) / 2;
+                if (_mod_table[mid].base <= pc)
+                    mlo = mid + 1;
+                else
+                    mhi = mid;
+            }
+            if (mlo > 0 && pc >= _mod_table[mlo - 1].base && pc < _mod_table[mlo - 1].end) {
+                // Only treat the largest function as the eval frame if the
+                // module is a Python DLL (path contains "python").
+                const char* mod_path = _mod_table[mlo - 1].path;
+                if (mod_path && (strstr(mod_path, "python") || strstr(mod_path, "Python"))) {
+                    pdata_cache_entry_t* ce = _pdata_cache_lookup(_mod_table[mlo - 1].base);
+                    if (ce && ce->largest_func_begin != 0 && pc >= ce->largest_func_begin
+                        && pc < ce->largest_func_end) {
+                        log_d(
+                            "win: eval frame by size at pc=%" PRIxPTR " in [%" PRIxPTR ",%" PRIxPTR ")", pc,
+                            ce->largest_func_begin, ce->largest_func_end
+                        );
+                        is_eval = true;
+                    }
+                }
+            }
+        }
+        if (unlikely(is_eval)) {
             log_d("win: unwind hit eval frame at pc=%" PRIxPTR, pc);
             (void)stack_native_pop();
             stack_native_push((frame_t*)EVAL_FRAME_MAGIC);

--- a/src/win/unwind.h
+++ b/src/win/unwind.h
@@ -316,9 +316,14 @@ static inline bool
 _pe_try_epilog(
     HANDLE hProcess, uintptr_t pc, uintptr_t func_end, uint8_t frame_reg, uintptr_t* rip, uintptr_t gp[GP_REG_COUNT]
 ) {
-    // Read up to 128 bytes of instructions from pc to func_end.
+    // Read up to 32 bytes of instructions from pc to func_end.  A genuine
+    // in-progress epilog is at most a handful of pop/add/ret instructions
+    // (~20-30 bytes).  A larger window produces false positives when the
+    // thread is parked at a mid-function call site that happens to have
+    // epilog-looking bytes between it and the function end (e.g. the return
+    // site of NtWaitForSingleObject inside WaitForSingleObjectEx).
     size_t  remaining = (size_t)(func_end - pc);
-    uint8_t ibuf[128];
+    uint8_t ibuf[32];
     if (remaining == 0 || remaining > sizeof(ibuf))
         return false;
 
@@ -504,8 +509,43 @@ _pe_unwind_step(
                         if (tgt_ce && tgt_ce->count > 0) {
                             DWORD ret_rva      = (DWORD)(*rip - tgt_ce->image_base);
                             DWORD max_code_rva = tgt_ce->funcs[tgt_ce->count - 1].EndAddress;
-                            if (ret_rva > max_code_rva)
+                            if (ret_rva > max_code_rva) {
                                 epilog_valid = false;
+                            } else {
+                                // Require the return address to fall inside a
+                                // known RUNTIME_FUNCTION.  An address that is
+                                // in the module image but outside every .pdata
+                                // entry (e.g. a data section or a gap) is
+                                // almost certainly a false-positive epilog.
+                                // Leaf call sites (no RUNTIME_FUNCTION) are
+                                // still accepted because _pdata_find returning
+                                // NULL for them is expected and harmless.
+                                // We only reject when the ret_rva is strictly
+                                // beyond the last function end yet within the
+                                // image — that case is already caught above.
+                                // The stricter check: if we DO have a cache
+                                // entry and the address falls in a gap between
+                                // functions (pdata_find returns NULL AND it is
+                                // not a leaf, i.e. ret_rva <
+                                // funcs[0].BeginAddress or in a mid-pdata
+                                // gap), reject it.
+                                if (ret_rva < tgt_ce->funcs[0].BeginAddress)
+                                    epilog_valid = false;
+                                else if (_pdata_find(tgt_ce, ret_rva) == NULL) {
+                                    // ret_rva is between function entries —
+                                    // either a leaf call site (acceptable) or
+                                    // a gap (likely garbage).  Distinguish by
+                                    // checking the new RSP makes sense: after
+                                    // the epilog the RSP must be strictly
+                                    // above the saved_gp RSP (at least +8 for
+                                    // the popped return address, typically
+                                    // much more).  If RSP didn't advance by
+                                    // at least 16 bytes beyond the pre-step
+                                    // RSP the epilog likely consumed no frame.
+                                    if (gp[REG_RSP] < saved_gp[REG_RSP] + 16)
+                                        epilog_valid = false;
+                                }
+                            }
                         }
                     }
                 }

--- a/src/win/unwind.h
+++ b/src/win/unwind.h
@@ -115,6 +115,12 @@ typedef struct _pdata_cache_entry {
     uint8_t*                   xdata; // local copy of unwind data section(s)
     size_t                     xdata_size;
     uintptr_t                  xdata_rva; // RVA of the xdata section start
+    // Absolute [begin, end) address range of the largest function in this
+    // module.  Used to identify _PyEval_EvalFrameDefault by size rather than
+    // by symbol name, which is unreliable when only export-table symbols are
+    // available (common in CI without PDB files).
+    uintptr_t                  largest_func_begin;
+    uintptr_t                  largest_func_end;
     struct _pdata_cache_entry* next;
 } pdata_cache_entry_t;
 
@@ -239,6 +245,25 @@ _pdata_cache_load(HANDLE hProcess, uintptr_t image_base) {
     entry->xdata      = xdata;
     entry->xdata_size = xdata_size;
     entry->xdata_rva  = xdata_rva;
+
+    // Find the largest RUNTIME_FUNCTION in this module.  _PyEval_EvalFrameDefault
+    // is always the largest function in any CPython build by a large margin, so
+    // the biggest pdata entry reliably identifies it even without PDB symbols.
+    DWORD largest_size        = 0;
+    entry->largest_func_begin = 0;
+    entry->largest_func_end   = 0;
+    for (DWORD i = 0; i < count; i++) {
+        DWORD sz = funcs[i].EndAddress - funcs[i].BeginAddress;
+        if (sz > largest_size) {
+            largest_size              = sz;
+            entry->largest_func_begin = image_base + funcs[i].BeginAddress;
+            entry->largest_func_end   = image_base + funcs[i].EndAddress;
+        }
+    }
+    log_d(
+        "win: largest func in module at %" PRIxPTR ": [%" PRIxPTR ", %" PRIxPTR ") size=%lu", image_base,
+        entry->largest_func_begin, entry->largest_func_end, (unsigned long)largest_size
+    );
 
     size_t bucket        = (image_base >> 12) % _PDATA_CACHE_BUCKETS;
     entry->next          = _pdata_cache[bucket];

--- a/src/win/unwind.h
+++ b/src/win/unwind.h
@@ -316,16 +316,14 @@ static inline bool
 _pe_try_epilog(
     HANDLE hProcess, uintptr_t pc, uintptr_t func_end, uint8_t frame_reg, uintptr_t* rip, uintptr_t gp[GP_REG_COUNT]
 ) {
-    // Read up to 32 bytes of instructions from pc to func_end.  A genuine
-    // in-progress epilog is at most a handful of pop/add/ret instructions
-    // (~20-30 bytes).  A larger window produces false positives when the
-    // thread is parked at a mid-function call site that happens to have
-    // epilog-looking bytes between it and the function end (e.g. the return
-    // site of NtWaitForSingleObject inside WaitForSingleObjectEx).
+    // Read up to 128 bytes of instructions from pc to func_end.
     size_t  remaining = (size_t)(func_end - pc);
-    uint8_t ibuf[32];
-    if (remaining == 0 || remaining > sizeof(ibuf))
+    uint8_t ibuf[128];
+    log_d("win: epilog? pc=%" PRIxPTR " func_end=%" PRIxPTR " remaining=%zu", pc, func_end, remaining);
+    if (remaining == 0 || remaining > sizeof(ibuf)) {
+        log_d("win: epilog skip: remaining=%zu out of range", remaining);
         return false;
+    }
 
     SIZE_T n = 0;
     if (!ReadProcessMemory(hProcess, (LPCVOID)pc, ibuf, remaining, &n) || n != remaining)
@@ -418,6 +416,10 @@ _pe_try_epilog(
         *rip        = ret_addr;
         gp[REG_RSP] = sp + 8;
         gp[REG_RBP] = bp;
+        log_d(
+            "win: epilog matched (ret) at pc=%" PRIxPTR " remaining=%zu -> ret=%" PRIxPTR " new_sp=%" PRIxPTR, pc,
+            remaining, ret_addr, gp[REG_RSP]
+        );
         return true;
     }
     if (*p == 0xeb || *p == 0xe9) {
@@ -431,6 +433,10 @@ _pe_try_epilog(
         *rip        = ret_addr;
         gp[REG_RSP] = sp + 8;
         gp[REG_RBP] = bp;
+        log_d(
+            "win: epilog matched (jmp) at pc=%" PRIxPTR " remaining=%zu -> ret=%" PRIxPTR " new_sp=%" PRIxPTR, pc,
+            remaining, ret_addr, gp[REG_RSP]
+        );
         return true;
     }
     if (*p == 0xff && p + 1 < end) {
@@ -446,10 +452,16 @@ _pe_try_epilog(
             *rip        = ret_addr;
             gp[REG_RSP] = sp + 8;
             gp[REG_RBP] = bp;
+            log_d(
+                "win: epilog matched (jmp*/call*) at pc=%" PRIxPTR " remaining=%zu -> ret=%" PRIxPTR
+                " new_sp=%" PRIxPTR,
+                pc, remaining, ret_addr, gp[REG_RSP]
+            );
             return true;
         }
     }
 
+    log_d("win: epilog no match at pc=%" PRIxPTR " remaining=%zu (byte=0x%02x)", pc, remaining, (unsigned)*p);
     return false; // Not a valid epilog
 }
 
@@ -770,12 +782,24 @@ pdata_step(HANDLE hProcess, uintptr_t* pc, uintptr_t gp[GP_REG_COUNT], _mod_entr
         if (!ReadProcessMemory(hProcess, (LPCVOID)gp[REG_RSP], &ret_addr, sizeof(ret_addr), &read_size)
             || read_size != sizeof(ret_addr))
             return false;
+        log_d(
+            "win: pdata_step: leaf %" PRIxPTR " -> ret=%" PRIxPTR " new_sp=%" PRIxPTR, *pc, ret_addr,
+            gp[REG_RSP] + sizeof(uintptr_t)
+        );
         *pc          = ret_addr;
         gp[REG_RSP] += sizeof(uintptr_t);
         return true;
     }
 
-    return _pe_unwind_step(ce, rt_func, *pc, hProcess, pc, gp);
+    log_d(
+        "win: pdata_step: pc=%" PRIxPTR " rva=%x rf=[%x,%x) in %s", *pc, rva, rt_func->BeginAddress,
+        rt_func->EndAddress, mod->path
+    );
+    uintptr_t old_pc = *pc;
+    bool      ok     = _pe_unwind_step(ce, rt_func, old_pc, hProcess, pc, gp);
+    if (ok)
+        log_d("win: pdata_step: unwound %" PRIxPTR " -> %" PRIxPTR " new_sp=%" PRIxPTR, old_pc, *pc, gp[REG_RSP]);
+    return ok;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/win/unwind.h
+++ b/src/win/unwind.h
@@ -115,12 +115,14 @@ typedef struct _pdata_cache_entry {
     uint8_t*                   xdata; // local copy of unwind data section(s)
     size_t                     xdata_size;
     uintptr_t                  xdata_rva; // RVA of the xdata section start
-    // Absolute [begin, end) address range of the largest function in this
-    // module.  Used to identify _PyEval_EvalFrameDefault by size rather than
-    // by symbol name, which is unreliable when only export-table symbols are
-    // available (common in CI without PDB files).
+    // Absolute [begin, end) address range covering the largest function (==
+    // _PyEval_EvalFrameDefault) and any absorbed sub-entries/cold-blocks.
     uintptr_t                  largest_func_begin;
     uintptr_t                  largest_func_end;
+    // BeginAddress RVA of the main body of the largest function.  This is
+    // the canonical identifier used to recognise cold-block (CHAININFO)
+    // sub-entries via _pdata_logical_root comparisons.
+    DWORD                      main_func_rva;
     struct _pdata_cache_entry* next;
 } pdata_cache_entry_t;
 
@@ -137,6 +139,43 @@ _pdata_cache_lookup(uintptr_t image_base) {
         e = e->next;
     }
     return NULL;
+}
+
+// Get a pointer into the cached xdata buffer for a given RVA.
+// Returns NULL if the RVA is outside the cached region.
+static inline void*
+_pdata_get_xdata(pdata_cache_entry_t* ce, DWORD rva, size_t min_size) {
+    if (ce->xdata == NULL || rva < ce->xdata_rva || (rva - ce->xdata_rva) + min_size > ce->xdata_size)
+        return NULL;
+    return ce->xdata + (rva - ce->xdata_rva);
+}
+
+// Get a pointer to the UNWIND_INFO for a RUNTIME_FUNCTION from the cached
+// xdata buffer.  Returns NULL if the data is outside the cached region.
+static inline pe_unwind_info_t*
+_pdata_get_unwind_info(pdata_cache_entry_t* ce, RUNTIME_FUNCTION* rf) {
+    return (pe_unwind_info_t*)_pdata_get_xdata(ce, rf->UnwindData, sizeof(pe_unwind_info_t));
+}
+
+// Follow UNW_FLAG_CHAININFO links and return the logical root RUNTIME_FUNCTION.
+// A chained RF delegates its unwind to a parent RF; the root has no chain.
+// Returns rf itself if unchained or if the chain cannot be resolved.
+static inline RUNTIME_FUNCTION*
+_pdata_logical_root(pdata_cache_entry_t* ce, RUNTIME_FUNCTION* rf) {
+    int depth = 8; // guard against corrupt data
+    while (rf && depth-- > 0) {
+        pe_unwind_info_t* ui = _pdata_get_unwind_info(ce, rf);
+        if (!ui || !(ui->Flags & UNW_FLAG_CHAININFO))
+            break;
+        // The chained RUNTIME_FUNCTION follows the unwind codes (even-aligned).
+        DWORD             code_words = ((DWORD)ui->CountOfCodes + 1u) & ~1u;
+        DWORD             chain_off  = rf->UnwindData + sizeof(pe_unwind_info_t) + code_words * 2;
+        RUNTIME_FUNCTION* parent     = (RUNTIME_FUNCTION*)_pdata_get_xdata(ce, chain_off, sizeof(RUNTIME_FUNCTION));
+        if (!parent)
+            break;
+        rf = parent;
+    }
+    return rf;
 }
 
 // Read the PE exception directory (.pdata) and unwind data section from a
@@ -249,19 +288,85 @@ _pdata_cache_load(HANDLE hProcess, uintptr_t image_base) {
     // Find the largest RUNTIME_FUNCTION in this module.  _PyEval_EvalFrameDefault
     // is always the largest function in any CPython build by a large margin, so
     // the biggest pdata entry reliably identifies it even without PDB symbols.
+    //
+    // The compiler can split a large function into non-contiguous sub-sections.
+    // These appear as:
+    //   (a) UNW_FLAG_CHAININFO entries that reference the main body RF, or
+    //   (b) independent sub-entries placed at distant addresses (cold blocks).
+    //
+    // Strategy: find the main body (largest RF), then do two passes:
+    //   1. Scan all RFs for UNW_FLAG_CHAININFO links back to the main body.
+    //   2. Absorb adjacent entries within a 256-byte gap (handles case (b) when
+    //      the compiler does NOT emit a CHAININFO for cold blocks).
     DWORD largest_size        = 0;
+    DWORD largest_idx         = 0;
     entry->largest_func_begin = 0;
     entry->largest_func_end   = 0;
+    entry->main_func_rva      = 0;
     for (DWORD i = 0; i < count; i++) {
         DWORD sz = funcs[i].EndAddress - funcs[i].BeginAddress;
         if (sz > largest_size) {
             largest_size              = sz;
+            largest_idx               = i;
             entry->largest_func_begin = image_base + funcs[i].BeginAddress;
             entry->largest_func_end   = image_base + funcs[i].EndAddress;
         }
     }
+    if (entry->largest_func_begin != 0) {
+        // Save the main body's RVA before Pass 1 may expand largest_func_begin.
+        entry->main_func_rva = funcs[largest_idx].BeginAddress;
+
+        RUNTIME_FUNCTION* main_rf    = &funcs[largest_idx];
+        DWORD             main_begin = main_rf->BeginAddress;
+
+        // Pass 1: follow UNW_FLAG_CHAININFO links — absorb any RF whose
+        // logical root is the main body RF (handles both adjacent sub-entries
+        // and cold blocks at completely different addresses).
+        // NOTE: _pdata_logical_root returns a pointer into the xdata buffer
+        // when a CHAININFO chain is followed, while main_rf points into the
+        // funcs buffer.  Pointer identity is therefore UNRELIABLE; compare
+        // BeginAddress fields instead.
+        for (DWORD i = 0; i < count; i++) {
+            if (i == largest_idx)
+                continue;
+            pe_unwind_info_t* ui = _pdata_get_unwind_info(entry, &funcs[i]);
+            if (!ui || !(ui->Flags & UNW_FLAG_CHAININFO))
+                continue;
+            RUNTIME_FUNCTION* root = _pdata_logical_root(entry, &funcs[i]);
+            if (!root || root->BeginAddress != main_begin)
+                continue;
+            uintptr_t rf_begin = image_base + funcs[i].BeginAddress;
+            uintptr_t rf_end   = image_base + funcs[i].EndAddress;
+            log_d("win: eval frame: absorb chained RF [%" PRIxPTR ", %" PRIxPTR ") -> main body", rf_begin, rf_end);
+            if (rf_begin < entry->largest_func_begin)
+                entry->largest_func_begin = rf_begin;
+            if (rf_end > entry->largest_func_end)
+                entry->largest_func_end = rf_end;
+        }
+
+        // Pass 2: absorb immediately adjacent non-chained entries (gap <= 256
+        // bytes from the ORIGINAL boundary).  Snapshot begin/end first so the
+        // gap check uses fixed reference points — updating them inside the loop
+        // would let the boundary cascade and sweep the entire DLL (every pair
+        // of contiguous functions has gap == 0, which is always <= 256).
+        const DWORD gap         = 256;
+        uintptr_t   fixed_begin = entry->largest_func_begin;
+        uintptr_t   fixed_end   = entry->largest_func_end;
+        for (int j = (int)largest_idx - 1; j >= 0; j--) {
+            uintptr_t rf_end = image_base + funcs[j].EndAddress;
+            if (rf_end > fixed_begin || fixed_begin - rf_end > gap)
+                break;
+            entry->largest_func_begin = image_base + funcs[j].BeginAddress;
+        }
+        for (DWORD j = largest_idx + 1; j < count; j++) {
+            uintptr_t rf_begin = image_base + funcs[j].BeginAddress;
+            if (rf_begin < fixed_end || rf_begin - fixed_end > gap)
+                break;
+            entry->largest_func_end = image_base + funcs[j].EndAddress;
+        }
+    }
     log_d(
-        "win: largest func in module at %" PRIxPTR ": [%" PRIxPTR ", %" PRIxPTR ") size=%lu", image_base,
+        "win: eval frame region in module at %" PRIxPTR ": [%" PRIxPTR ", %" PRIxPTR ") largest_size=%lu", image_base,
         entry->largest_func_begin, entry->largest_func_end, (unsigned long)largest_size
     );
 
@@ -287,22 +392,6 @@ _pdata_find(pdata_cache_entry_t* ce, DWORD rva) {
             return &ce->funcs[mid];
     }
     return NULL;
-}
-
-// Get a pointer into the cached xdata buffer for a given RVA.
-// Returns NULL if the RVA is outside the cached region.
-static inline void*
-_pdata_get_xdata(pdata_cache_entry_t* ce, DWORD rva, size_t min_size) {
-    if (ce->xdata == NULL || rva < ce->xdata_rva || (rva - ce->xdata_rva) + min_size > ce->xdata_size)
-        return NULL;
-    return ce->xdata + (rva - ce->xdata_rva);
-}
-
-// Get a pointer to the UNWIND_INFO for a RUNTIME_FUNCTION from the cached
-// xdata buffer.  Returns NULL if the data is outside the cached region.
-static inline pe_unwind_info_t*
-_pdata_get_unwind_info(pdata_cache_entry_t* ce, RUNTIME_FUNCTION* rf) {
-    return (pe_unwind_info_t*)_pdata_get_xdata(ce, rf->UnwindData, sizeof(pe_unwind_info_t));
 }
 
 static void

--- a/src/win/unwind.h
+++ b/src/win/unwind.h
@@ -737,3 +737,68 @@ pdata_step(HANDLE hProcess, uintptr_t* pc, uintptr_t gp[GP_REG_COUNT], _mod_entr
 
     return _pe_unwind_step(ce, rt_func, *pc, hProcess, pc, gp);
 }
+
+// ---------------------------------------------------------------------------
+// Custom StackWalk64 callbacks backed by our local pdata/module caches
+// ---------------------------------------------------------------------------
+//
+// SymFunctionTableAccess64 depends on DbgHelp having loaded each module's
+// exception directory.  With SYMOPT_DEFERRED_LOADS that may not have happened
+// yet when a module is first encountered, causing StackWalk64 to fall back to
+// frame-pointer unwinding and produce garbage frames in optimised x64 code.
+//
+// These callbacks consult our own pdata cache first (already populated from
+// the target process via ReadProcessMemory), then fall through to DbgHelp for
+// any module we haven't seen yet.  Because we use the same cache as the fast
+// pdata walker, StackWalk64 effectively gets the same function table coverage
+// we do — but uses its own (battle-tested) unwind-opcode interpreter, which
+// may handle edge cases our walker misses.
+
+#if defined(_M_X64)
+
+static PVOID CALLBACK
+_custom_function_table_access64(HANDLE hProcess, DWORD64 addr_base) {
+    uintptr_t pc  = (uintptr_t)addr_base;
+    DWORD     mlo = 0, mhi = _mod_count;
+    while (mlo < mhi) {
+        DWORD mid = mlo + (mhi - mlo) / 2;
+        if (_mod_table[mid].base <= pc)
+            mlo = mid + 1;
+        else
+            mhi = mid;
+    }
+    if (mlo > 0 && pc >= _mod_table[mlo - 1].base && pc < _mod_table[mlo - 1].end) {
+        uintptr_t            image_base = _mod_table[mlo - 1].base;
+        pdata_cache_entry_t* ce         = _pdata_cache_lookup(image_base);
+        if (!ce)
+            ce = _pdata_cache_load(hProcess, image_base);
+        if (ce) {
+            DWORD             rva = (DWORD)(pc - image_base);
+            RUNTIME_FUNCTION* rf  = _pdata_find(ce, rva);
+            // For leaf functions rf is NULL: return NULL so StackWalk64 reads
+            // the return address from [RSP] directly, which is correct.
+            return (PVOID)rf;
+        }
+    }
+    // Module not in our table yet — fall back to DbgHelp.
+    return SymFunctionTableAccess64(hProcess, addr_base);
+}
+
+static DWORD64 CALLBACK
+_custom_get_module_base64(HANDLE hProcess, DWORD64 addr) {
+    uintptr_t pc  = (uintptr_t)addr;
+    DWORD     mlo = 0, mhi = _mod_count;
+    while (mlo < mhi) {
+        DWORD mid = mlo + (mhi - mlo) / 2;
+        if (_mod_table[mid].base <= pc)
+            mlo = mid + 1;
+        else
+            mhi = mid;
+    }
+    if (mlo > 0 && pc >= _mod_table[mlo - 1].base && pc < _mod_table[mlo - 1].end)
+        return (DWORD64)_mod_table[mlo - 1].base;
+    // Not in our table — fall back to DbgHelp.
+    return SymGetModuleBase64(hProcess, addr);
+}
+
+#endif // _M_X64

--- a/test/functional/test_native.py
+++ b/test/functional/test_native.py
@@ -153,14 +153,14 @@ def test_native_wall_time(py, save_mojo):
         result.samples, filename="target34.py", function="keep_cpu_busy", line=32
     ), "Expected Python frame from target34.py"
 
-    assert has_native_frame(
-        result.samples, filename_contains="python"
-    ), "Expected native frame from the Python runtime"
+    assert has_native_frame(result.samples, filename_contains="python"), (
+        "Expected native frame from the Python runtime"
+    )
 
     if _python_has_Py_RunMain_symbol(py):
-        assert has_native_frame(
-            result.samples, function="Py_RunMain"
-        ), "Expected Py_RunMain native frame from the Python runtime"
+        assert has_native_frame(result.samples, function="Py_RunMain"), (
+            "Expected Py_RunMain native frame from the Python runtime"
+        )
 
     meta = result.metadata
     assert meta["mode"] == "wall"
@@ -193,9 +193,9 @@ def test_native_interleaved(py, save_mojo):
             found_interleaved = True
             break
 
-    assert (
-        found_interleaved
-    ), "Expected at least one sample with both Python and native frames interleaved"
+    assert found_interleaved, (
+        "Expected at least one sample with both Python and native frames interleaved"
+    )
 
 
 @requires_sudo
@@ -208,18 +208,18 @@ def test_native_attach(py, save_mojo):
     save_mojo(result.stdout)
     assert result.returncode == 0, result.stderr or result.stdout
 
-    assert has_frame(
-        result.samples, filename="sleepy.py", function="<module>"
-    ), "Expected Python frame from sleepy.py in attach mode"
+    assert has_frame(result.samples, filename="sleepy.py", function="<module>"), (
+        "Expected Python frame from sleepy.py in attach mode"
+    )
 
-    assert has_native_frame(
-        result.samples, filename_contains="python"
-    ), "Expected native frame from the Python runtime in attach mode"
+    assert has_native_frame(result.samples, filename_contains="python"), (
+        "Expected native frame from the Python runtime in attach mode"
+    )
 
     if _python_has_Py_RunMain_symbol(py):
-        assert has_native_frame(
-            result.samples, function="Py_RunMain"
-        ), "Expected Py_RunMain native frame from the Python runtime in attach mode"
+        assert has_native_frame(result.samples, function="Py_RunMain"), (
+            "Expected Py_RunMain native frame from the Python runtime in attach mode"
+        )
 
     meta = result.metadata
     assert meta["mode"] == "wall"
@@ -238,9 +238,9 @@ def test_native_where(py):
     assert "<module>" in result.stdout, result.stdout
 
     if _python_has_Py_RunMain_symbol(py):
-        assert (
-            "Py_RunMain" in result.stdout
-        ), "Expected Py_RunMain native frame in where output"
+        assert "Py_RunMain" in result.stdout, (
+            "Expected Py_RunMain native frame in where output"
+        )
 
 
 @allpythons()
@@ -299,6 +299,62 @@ def test_native_non_python_thread(py, native_ext):
     for sample in result.samples:
         if not sample.thread.startswith("Native-"):
             continue
-        assert all(
-            frame.line == 0 for frame in sample.frames
-        ), f"Expected only native frames for {sample.thread}, got: {sample.frames}"
+        assert all(frame.line == 0 for frame in sample.frames), (
+            f"Expected only native frames for {sample.thread}, got: {sample.frames}"
+        )
+
+
+# ---- Windows unwind quality checks -----------------------------------------
+
+# These function names appear in a known garbage chain caused by a false-positive
+# epilog detection on Windows x64 (Python 3.10).  Any sample where one of these
+# functions appears as a *caller* of WaitForSingleObjectEx is bogus — real callers
+# are GIL-acquisition functions like take_gil / PyEval_RestoreThread, not list
+# operations.
+_WIN_GARBAGE_CALLERS = {"PyList_Reverse", "PyList_Append", "PyObject_GC_UnTrack"}
+
+
+def _has_garbage_win_unwind(samples) -> list[str]:
+    """Return descriptions of samples that show the known garbage unwind chain.
+
+    Austin frames are ordered outermost-first: frames[0] is the thread root and
+    frames[-1] is the leaf.  Callers of WaitForSingleObjectEx therefore appear
+    at *lower* indices (closer to [0]) than WaitForSingleObjectEx itself.
+    """
+    bad = []
+    for sample in samples:
+        frames = sample.frames
+        for i, frame in enumerate(frames):
+            if "WaitForSingleObjectEx" not in frame.function:
+                continue
+            # Check up to 4 frames outward (lower indices = callers)
+            lo = max(0, i - 4)
+            for j in range(lo, i):
+                if any(g in frames[j].function for g in _WIN_GARBAGE_CALLERS):
+                    bad.append(
+                        f"thread={sample.thread}: "
+                        + " -> ".join(f.function for f in frames[j : i + 2])
+                    )
+                    break
+    return bad
+
+
+@allpythons()
+@pytest.mark.skipif(not _IS_WIN, reason="Windows-specific unwind quality check")
+def test_native_no_garbage_unwind_win(py, save_mojo):
+    """On Windows, GIL-waiting threads must not show list/GC functions above WaitForSingleObjectEx.
+
+    A false-positive epilog detection in the pdata unwinder can produce a garbage
+    call chain like PyList_Reverse -> PyEval_RestoreThread -> PyObject_GC_UnTrack
+    -> WaitForSingleObjectEx.  This test catches that regression.
+    """
+    result = austin("-n", "-i", "1ms", *python(py), target("target34.py"))
+    save_mojo(result.stdout)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+    bad = _has_garbage_win_unwind(result.samples)
+    assert not bad, (
+        "Garbage unwind chain detected on Windows:\n"
+        + "\n".join(f"  {b}" for b in bad[:10])
+        + f"\n\naustin stderr:\n{result.stderr}"
+    )

--- a/test/functional/test_native.py
+++ b/test/functional/test_native.py
@@ -229,8 +229,8 @@ def test_native_attach(py, save_mojo):
 @allpythons()
 def test_native_where(py):
     """--where output must include Python source information in native mode."""
-    with run_python(py, target("sleepy.py"), "2") as p:
-        sleep(0.5)
+    with run_python(py, target("sleepy.py"), "5") as p:
+        sleep(1.5)
         result = austin("-n", "-w", str(p.pid))
     assert result.returncode == 0, result.stderr or result.stdout
 
@@ -306,12 +306,17 @@ def test_native_non_python_thread(py, native_ext):
 
 # ---- Windows unwind quality checks -----------------------------------------
 
-# These function names appear in a known garbage chain caused by a false-positive
-# epilog detection on Windows x64 (Python 3.10).  Any sample where one of these
-# functions appears as a *caller* of WaitForSingleObjectEx is bogus — real callers
-# are GIL-acquisition functions like take_gil / PyEval_RestoreThread, not list
-# operations.
-_WIN_GARBAGE_CALLERS = {"PyList_Reverse", "PyList_Append", "PyObject_GC_UnTrack"}
+# These function names appear in a known garbage chain caused by cold-block
+# mislabeling on Windows x64 (Python 3.10).  Any sample where one of these
+# functions appears as a *caller* of WaitForSingleObjectEx is bogus — list
+# operations can never legitimately call WaitForSingleObjectEx.
+#
+# Note: PyObject_GC_UnTrack is excluded.  Without PDB symbols, take_gil
+# (which genuinely calls WaitForSingleObjectEx to acquire the GIL) is
+# mislabeled as PyObject_GC_UnTrack because it shares the same .pdata
+# RUNTIME_FUNCTION as that export.  The call relationship is real even if
+# the label is wrong, so flagging it would be a false positive.
+_WIN_GARBAGE_CALLERS = {"PyList_Reverse", "PyList_Append"}
 
 
 def _has_garbage_win_unwind(samples) -> list[str]:


### PR DESCRIPTION
Try to step past a region containing a stub or with no unwind info to avoid halting the stack walk too early.