### PR TITLE
Fix stale iframe stack state

### DIFF
--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -246,6 +246,8 @@ _py_thread__unwind_frame_stack(py_thread_t* self) {
 // ----------------------------------------------------------------------------
 static inline int
 _py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
+    stack_reset();
+
     raddr_t curr = iframe_raddr;
 
     while (isvalid(curr)) {


### PR DESCRIPTION
## Summary

Reset Austin's internal Python stack before unwinding 3.13+ interpreter frames.

The older frame and cframe unwind paths already reset the stack before pushing a new sample. The 3.13+ direct iframe path did not, so entries from previous samples could remain and later trigger false stack errors during long profiling runs.

Part of P403n1x87/austin#421.

## Validation

- Built Austin locally with `-Wall -Werror`.
- Built Austin and AustinP on Linux x86_64 with `-Wall -Werror`.
- Ran Austin attach-mode sampling on Linux x86_64:
  - Python 3.13.13, 120 seconds: `Error rate 0/11933`, `busy_loop=1`.
  - Python 3.12.3, 120 seconds: `Error rate 0/11935`, `busy_loop=1`.

Note: Austin returned `254` in this attach-mode smoke after printing complete sampling statistics; stderr showed the run completed normally with `0.00%` error rate.
