### PR TITLE
Fix AustinP unresolved native scopes

### DIFF
--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -479,7 +479,16 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                     }
                 }
                 if (!isvalid(scope)) {
-                    scope  = UNKNOWN_SCOPE;
+                    key_dt scope_key = ~((key_dt)pc);
+                    scope            = lru_cache__maybe_hit(string_cache, scope_key);
+                    if (!isvalid(scope)) {
+                        scope = cached_string_new(scope_key, strdup("<unknown>"));
+                        if (!isvalid(scope)) {
+                            FAIL; // GCOV_EXCL_LINE
+                        }
+                        lru_cache__store(string_cache, scope_key, (value_t)scope);
+                        event_handler__emit_new_string(scope);
+                    }
                     offset = 0;
                 }
 


### PR DESCRIPTION
## Summary

Make AustinP normal-mode Mojo output robust when native frame scope resolution fails.

The native unwinder can produce `UNKNOWN_SCOPE` as a sentinel. `where` output can handle that sentinel, but Mojo frame serialization dereferences `frame->scope`. This patch emits a real cached `"<unknown>"` string for unresolved native scopes before creating the frame event.

Part of P403n1x87/austin#421.

## Validation

- Built Austin locally with `-Wall -Werror`.
- Built Austin and AustinP on Linux x86_64 with `-Wall -Werror`.
- Ran AustinP attach-mode sampling on Linux x86_64:
  - Python 3.12.3, 60 seconds: `Error rate 0/5715`, `busy_loop=1`.
  - Python 3.13.13, 60 seconds: `Error rate 0/5656`, `busy_loop=1`.
  - Python 3.13.13 native workload, 60 seconds: `Error rate 0/5656`, `native_hits=291`.

The split PR-B branch did not reproduce an unresolved-scope sample in these 60 second runs, but the integrated 120 second validation for the full series did exercise `"<unknown>"` entries without crashing:

```text
py312_austinp:  <unknown>=1
py313_austinp:  <unknown>=2
py314t_austinp: <unknown>=3
```

Note: AustinP returned `254` in attach-mode smoke tests after printing complete sampling statistics; stderr showed the runs completed normally with `0.00%` error rate.
