### PR TITLE
Add CPython 3.14t profiling support

### DIFF
--- a/src/py_proc.c
+++ b/src/py_proc.c
@@ -1226,7 +1226,9 @@ _py_proc__sample_interpreter(py_proc_t* self, raddr_t interp, microseconds_t tim
 
     if (pargs.memory) {
         // Use the current thread to determine which thread is manipulating memory
-        if (V_MIN(3, 12)) {
+        if (py_v->free_threaded) {
+            current_thread = tstate_head;
+        } else if (V_MIN(3, 12)) {
             raddr_t gil_state_raddr = NULL;
             if (fail(_py_proc__get_interpreter_state_field(self, interp, gil_state, gil_state_raddr))) // GCOV_EXCL_LINE
                 FAIL;                                                                                  // GCOV_EXCL_LINE

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -84,6 +84,31 @@ string__hash(char* string) {
 }
 
 // ----------------------------------------------------------------------------
+static inline int
+_unicode_write_utf8(char* buffer, Py_UCS4 ch) {
+    if (ch < 0x80) {
+        buffer[0] = (char)ch;
+        return 1;
+    }
+    if (ch < 0x800) {
+        buffer[0] = (char)(0xC0 | (ch >> 6));
+        buffer[1] = (char)(0x80 | (ch & 0x3F));
+        return 2;
+    }
+    if (ch < 0x10000) {
+        buffer[0] = (char)(0xE0 | (ch >> 12));
+        buffer[1] = (char)(0x80 | ((ch >> 6) & 0x3F));
+        buffer[2] = (char)(0x80 | (ch & 0x3F));
+        return 3;
+    }
+    buffer[0] = (char)(0xF0 | (ch >> 18));
+    buffer[1] = (char)(0x80 | ((ch >> 12) & 0x3F));
+    buffer[2] = (char)(0x80 | ((ch >> 6) & 0x3F));
+    buffer[3] = (char)(0x80 | (ch & 0x3F));
+    return 4;
+}
+
+// ----------------------------------------------------------------------------
 static inline char*
 _string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
     PyUnicodeObject unicode;
@@ -92,6 +117,95 @@ _string_remote(proc_ref_t pref, raddr_t raddr, python_v* py_v) {
 
     if (fail(copy_datatype(pref, raddr, unicode)))
         FAIL_PTR;
+
+    if (V_MIN(3, 13)) {
+        ssize_t len        = V_FIELD_PTR(ssize_t, &unicode, py_unicode, o_length);
+        unsigned char state = V_FIELD_PTR(unsigned char, &unicode, py_unicode, o_state);
+        if (py_v->free_threaded) {
+            // In free-threaded builds, PyASCIIObject.state.interned is a full
+            // unsigned char (for atomic access) instead of a 2-bit bitfield.
+            // This pushes kind/compact/ascii bitfields to the next byte.
+            // The +1 offset is little-endian specific (x86_64, aarch64).
+            state = *((unsigned char*)(((raddr_t)&unicode) + py_v->py_unicode.o_state + 1));
+        }
+
+        unsigned char kind    = py_v->free_threaded ? state & 0x07 : (state >> 2) & 0x07;
+        unsigned char compact = py_v->free_threaded ? state & 0x08 : state & 0x20;
+        unsigned char ascii   = py_v->free_threaded ? state & 0x10 : state & 0x40;
+
+        if (kind != 1 && kind != 2 && kind != 4) { // GCOV_EXCL_START
+            set_error(PYOBJECT, "Invalid PyASCIIObject kind");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        if (!compact) { // GCOV_EXCL_START
+            set_error(PYOBJECT, "Unsupported non-compact PyUnicodeObject");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        if (len < 0 || len > 4096) { // GCOV_EXCL_START
+            set_error(PYOBJECT, "Invalid string length");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        if (len == 0) {
+            buffer = (char*)malloc(1);
+            if (!isvalid(buffer)) {
+                set_error(MALLOC, "Cannot allocate memory for string buffer");
+                FAIL_PTR;
+            }
+            buffer[0] = '\0';
+            return buffer;
+        }
+
+        // Non-ASCII compact strings store data after PyCompactUnicodeObject.
+        // On LP64, that is 16 bytes after PyASCIIObject.
+        raddr_t data = raddr + py_v->py_unicode.o_asciiobject_size + (ascii ? 0 : 16);
+        if (!isvalid(data)) { // GCOV_EXCL_START
+            set_error(PYOBJECT, "Invalid PyASCIIObject data pointer");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        buffer = (char*)malloc((len * 4) + 1); // GCOV_EXCL_START
+        if (!isvalid(buffer)) {
+            set_error(MALLOC, "Cannot allocate memory for string buffer");
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        size_t raw_len = len * kind;
+        char*  raw     = (char*)malloc(raw_len);
+        if (!isvalid(raw)) {
+            free(buffer);
+            set_error(MALLOC, "Cannot allocate memory for string buffer");
+            FAIL_PTR;
+        }
+
+        if (fail(copy_memory(pref, data, raw_len, raw))) { // GCOV_EXCL_START
+            free(raw);
+            free(buffer);
+            FAIL_PTR;
+        } // GCOV_EXCL_STOP
+
+        size_t pos = 0;
+        for (ssize_t i = 0; i < len; i++) {
+            Py_UCS4 ch = 0;
+            switch (kind) {
+            case 1:
+                ch = ((Py_UCS1*)raw)[i];
+                break;
+            case 2:
+                ch = ((Py_UCS2*)raw)[i];
+                break;
+            case 4:
+                ch = ((Py_UCS4*)raw)[i];
+                break;
+            }
+            pos += _unicode_write_utf8(buffer + pos, ch);
+        }
+        free(raw);
+        buffer[pos] = '\0';
+        return buffer;
+    }
 
     PyASCIIObject ascii = unicode.v3._base._base;
 
@@ -144,7 +258,8 @@ _bytes_remote(proc_ref_t pref, raddr_t raddr, ssize_t* size, python_v* py_v) {
     if (fail(copy_datatype(pref, raddr, bytes))) // GCOV_EXCL_LINE
         FAIL_PTR;                                // GCOV_EXCL_LINE
 
-    if ((len = bytes.ob_base.ob_size + 1) < 1) { // Include null-terminator // GCOV_EXCL_START
+    len = V_MIN(3, 13) ? V_FIELD_PTR(ssize_t, &bytes, py_bytes, o_size) + 1 : bytes.ob_base.ob_size + 1;
+    if (len < 1) { // Include null-terminator // GCOV_EXCL_START
         set_error(PYOBJECT, "PyBytesObject is too short");
         FAIL_PTR;
     } // GCOV_EXCL_STOP
@@ -160,7 +275,8 @@ _bytes_remote(proc_ref_t pref, raddr_t raddr, ssize_t* size, python_v* py_v) {
         FAIL_PTR;
     } // GCOV_EXCL_STOP
 
-    if (fail(copy_memory(pref, raddr + offsetof(PyBytesObject, ob_sval), len, array))) {
+    raddr_t data = raddr + (V_MIN(3, 13) ? py_v->py_bytes.o_sval : offsetof(PyBytesObject, ob_sval));
+    if (fail(copy_memory(pref, data, len, array))) {
         free(array);
         FAIL_PTR;
     }

--- a/src/py_thread.c
+++ b/src/py_thread.c
@@ -150,6 +150,10 @@ _py_thread__push_local_iframe(py_thread_t* self, void* iframe, raddr_t* prev) {
 
     raddr_t origin     = *prev;
     raddr_t code_raddr = V_FIELD_PTR(raddr_t, iframe, py_iframe, o_code);
+    if (V_MIN(3, 14)) {
+        // CPython 3.14 stores the executable as a tagged _PyStackRef.
+        code_raddr = (raddr_t)(((uintptr_t)code_raddr) & ~(uintptr_t)3);
+    }
 
     *prev = V_FIELD_PTR(raddr_t, iframe, py_iframe, o_previous);
     if (unlikely(origin == *prev)) {
@@ -157,7 +161,8 @@ _py_thread__push_local_iframe(py_thread_t* self, void* iframe, raddr_t* prev) {
         FAIL;
     }
 
-    if (V_MIN(3, 12) && V_FIELD_PTR(char, iframe, py_iframe, o_owner) == FRAME_OWNED_BY_CSTACK) {
+    char owner = V_FIELD_PTR(char, iframe, py_iframe, o_owner);
+    if (V_MIN(3, 12) && (owner == FRAME_OWNED_BY_CSTACK || (V_MIN(3, 14) && owner == FRAME_OWNED_BY_INTERPRETER))) {
 // This is a shim frame that we can ignore
 #ifdef NATIVE
         // In native mode we take this as the marker for the beginning of the stack
@@ -246,6 +251,8 @@ _py_thread__unwind_frame_stack(py_thread_t* self) {
 // ----------------------------------------------------------------------------
 static inline int
 _py_thread__unwind_iframe_stack(py_thread_t* self, raddr_t iframe_raddr) {
+    stack_reset();
+
     raddr_t curr = iframe_raddr;
 
     while (isvalid(curr)) {
@@ -479,7 +486,16 @@ _py_thread__unwind_native_frame_stack(py_thread_t* self) {
                     }
                 }
                 if (!isvalid(scope)) {
-                    scope  = UNKNOWN_SCOPE;
+                    key_dt scope_key = ~((key_dt)pc);
+                    scope            = lru_cache__maybe_hit(string_cache, scope_key);
+                    if (!isvalid(scope)) {
+                        scope = cached_string_new(scope_key, strdup("<unknown>"));
+                        if (!isvalid(scope)) {
+                            FAIL; // GCOV_EXCL_LINE
+                        }
+                        lru_cache__store(string_cache, scope_key, (value_t)scope);
+                        event_handler__emit_new_string(scope);
+                    }
                     offset = 0;
                 }
 

--- a/src/python/iframe.h
+++ b/src/python/iframe.h
@@ -55,7 +55,8 @@ typedef struct _PyInterpreterFrame3_11 {
     PyObject*                       localsplus[1];
 } _PyInterpreterFrame3_11;
 
-#define FRAME_OWNED_BY_CSTACK 3
+#define FRAME_OWNED_BY_CSTACK       3
+#define FRAME_OWNED_BY_INTERPRETER  4  // 3.14+
 
 typedef struct _PyInterpreterFrame3_12 {
     PyCodeObject*                   f_code; /* Strong reference */

--- a/src/version.h
+++ b/src/version.h
@@ -163,6 +163,21 @@ typedef struct {
 } py_gc_v;
 
 typedef struct {
+    ssize_t size;
+
+    offset_t o_length;
+    offset_t o_state;
+    offset_t o_asciiobject_size;
+} py_unicode_v;
+
+typedef struct {
+    ssize_t size;
+
+    offset_t o_size;
+    offset_t o_sval;
+} py_bytes_v;
+
+typedef struct {
     py_code_v    py_code;
     py_frame_v   py_frame;
     py_thread_v  py_thread;
@@ -171,10 +186,13 @@ typedef struct {
     py_gc_v      py_gc;
     py_cframe_v  py_cframe;
     py_iframe_v  py_iframe;
+    py_unicode_v py_unicode;
+    py_bytes_v   py_bytes;
 
     int major;
     int minor;
     int patch;
+    int free_threaded;
 } python_v;
 
 #ifdef PY_PROC_C
@@ -440,26 +458,49 @@ get_version_descriptor(int major, int minor, int patch) {
         V_ASSIGN(v, gc.o_collecting, gc.collecting); \
     }
 
+#define PY_UNICODE(v)                                                   \
+    {                                                                   \
+        V_ASSIGN(v, unicode.size, unicode_object.size);                 \
+        V_ASSIGN(v, unicode.o_length, unicode_object.length);           \
+        V_ASSIGN(v, unicode.o_state, unicode_object.state);             \
+        V_ASSIGN(v, unicode.o_asciiobject_size, unicode_object.asciiobject_size); \
+    }
+
+#define PY_BYTES(v)                                          \
+    {                                                        \
+        V_ASSIGN(v, bytes.size, bytes_object.size);          \
+        V_ASSIGN(v, bytes.o_size, bytes_object.ob_size);     \
+        V_ASSIGN(v, bytes.o_sval, bytes_object.ob_sval);     \
+    }
+
 // ----------------------------------------------------------------------------
 static void
 init_version_descriptor(python_v* py_v, _Py_DebugOffsets* py_d) {
+    py_v->free_threaded = 0;
+
     switch (py_v->minor) {
     case 13:
+        py_v->free_threaded = py_d->v3_13.free_threaded != 0;
         PY_CODE_313(3_13);
         PY_IFRAME_313(3_13);
         PY_THREAD_313(3_13);
         PY_RUNTIME_313(3_13);
         PY_IS_313(3_13);
         PY_GC_313(3_13);
+        PY_UNICODE(3_13);
+        PY_BYTES(3_13);
         break;
 
     case 14:
+        py_v->free_threaded = py_d->v3_14.free_threaded != 0;
         PY_CODE_313(3_14);
         PY_IFRAME_313(3_14);
         PY_THREAD_313(3_14);
         PY_RUNTIME_313(3_14);
         PY_IS_314(3_14);
         PY_GC_313(3_14);
+        PY_UNICODE(3_14);
+        PY_BYTES(3_14);
         break;
 
     default:                                                                           // GCOV_EXCL_LINE


### PR DESCRIPTION
## Summary

Draft PR for CPython 3.14 free-threaded profiling support.

This updates Austin's runtime descriptor, interpreter-frame handling, Unicode/Bytes reads, and memory-mode fallback so CPython 3.14t builds can be sampled.

Part of P403n1x87/austin#421.

## Dependency note

This draft currently includes the changes from:

- P403n1x87/austin#422
- P403n1x87/austin#423

I opened it as a draft so the broader 3.14t direction can be reviewed while the smaller prerequisite PRs are considered. If those land first, I can rebase this PR and remove the duplicated hunks.

## Main changes

- Clear CPython 3.14 `_PyStackRef` tag bits before treating iframe executable as a code object.
- Add `FRAME_OWNED_BY_INTERPRETER` handling for CPython 3.14+ sentinel frames.
- Extend Austin's `_Py_DebugOffsets` runtime descriptor use for 3.13+ Unicode and Bytes.
- Decode compact Unicode strings for 3.13+ from runtime offsets.
- Keep memory mode usable for free-threaded Python by attributing process RSS delta to the interpreter head thread when there is no GIL holder.

## Validation

- Built Austin locally with `-Wall -Werror`.
- Built Austin and AustinP on Linux x86_64 with `-Wall -Werror`.
- Ran a 60 second Linux x86_64 matrix:

```text
py312_base:       Error rate 0/5968,  busy_loop hit
py313_base:       Error rate 0/5967,  busy_loop hit
py314t_base:      Error rate 0/5961,  busy_loop hit
py314t_memory:    Error rate 0/1,     memory_busy_loop hit
py314t_full:      Error rate 0/5969,  memory_busy_loop hit
py314t_unicode:   Error rate 0/5968,  Unicode path/function hit
py314t_subinterp: Error rate 0/17901, sub_busy_loop hit
py312_austinp:    Error rate 0/5702,  busy_loop/<unknown> hit
py313_austinp:    Error rate 0/5669,  busy_loop/<unknown> hit
py314t_austinp:   Error rate 0/5637,  busy_loop/<unknown> hit
```

The combined local patch was also run through a 120 second integrated validation matrix:

```text
py312_base:        0/11847
py313_base:        0/11854
py314t_base:       0/11847
py314t_memory:     0/1
py314t_full:       0/11855
py314t_unicode:    0/11852
py314t_subinterp:  0/35556
py312_austinp:     0/11229
py313_austinp:     0/11248
py314t_austinp:    0/11275
```

## Known limitations

- Tested on Linux x86_64 only.
- No macOS/Windows validation yet.
- No normal GIL CPython 3.14 validation yet.
- The free-threaded Unicode `state + 1` and non-ASCII compact string data `+16` handling reflects current CPython LP64/little-endian layout. If maintainers prefer avoiding that assumption, CPython may need to expose additional `_Py_DebugOffsets` fields.
- Free-threaded memory mode attribution is still process RSS delta, not object-level allocation tracing.
