### PR TITLE
chore: improve mojo ref keys

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -31,6 +31,13 @@
 typedef uintptr_t key_dt;
 typedef void*     value_t;
 
+// Heap object addresses are at least 8-byte aligned, so their low 3 bits are
+// always zero and carry no entropy. Shift them out before using the address
+// as a cache/reference key so that truncating the key to fewer bits retains
+// as much real entropy as possible.
+#define PTR_ALIGN_SHIFT 3
+#define ptr_key(ptr)    (((key_dt)(uintptr_t)(ptr)) >> PTR_ALIGN_SHIFT)
+
 // -- Queue -------------------------------------------------------------------
 
 typedef struct queue_item_t {

--- a/src/frame.h
+++ b/src/frame.h
@@ -87,7 +87,7 @@ frame__destroy(frame_t* self) {
 #include "mojo.h"
 #include "py_proc.h"
 
-#define py_frame_key(code, lasti) (((key_dt)(((key_dt)code) & MOJO_INT32) << 16) | lasti)
+#define py_frame_key(code, lasti) (((key_dt)(ptr_key(code) & MOJO_INT32) << 16) | (lasti))
 
 // ----------------------------------------------------------------------------
 static inline int

--- a/src/mojo.h
+++ b/src/mojo.h
@@ -134,8 +134,8 @@ mojo_integer(mojo_int_t integer, int sign) {
     _mojo_write(buffer, ptr - buffer);
 }
 
-// We expect the least significant bits to be varied enough to provide a valid
-// key. This way we can keep the size of references to a maximum of 4 bytes.
+// We expect the retained bits to be varied enough to provide a valid key. This
+// way we can keep the size of references to a maximum of 4 bytes.
 #define mojo_ref(intorptr) (mojo_integer(MOJO_INT32 & ((mojo_int_t)(uintptr_t)intorptr), 0))
 
 // Mojo events

--- a/src/py_string.h
+++ b/src/py_string.h
@@ -266,4 +266,4 @@ _bytes_remote(proc_ref_t pref, raddr_t raddr, ssize_t* size, python_v* py_v) {
     return array;
 }
 
-#define py_string_key(code, field) ((key_dt) * ((raddr_t*)((raddr_t) & code + py_v->py_code.field)))
+#define py_string_key(code, field) ptr_key(*((raddr_t*)((raddr_t) & code + py_v->py_code.field)))


### PR DESCRIPTION
We make sure that MOJO references use the most valuable bits to identify event data. For pointers in particular, we make sure to truncate the first 3 bits which are always guaranteed to be zero.